### PR TITLE
[RFC/WIP] More NullableArrays compatibility

### DIFF
--- a/src/CategoricalArrays.jl
+++ b/src/CategoricalArrays.jl
@@ -8,7 +8,7 @@ module CategoricalArrays
            NullableCategoricalArray, NullableCategoricalVector, NullableCategoricalMatrix
     export LevelsException
 
-    export categorical, compress, decompress, droplevels!, levels, levels!, isordered, ordered!
+    export categorical, compress, decompress, droplevels!, levels, levels!, isordered, ordered!, reftype
     export cut, recode, recode!
 
     using Compat

--- a/src/CategoricalArrays.jl
+++ b/src/CategoricalArrays.jl
@@ -11,7 +11,12 @@ module CategoricalArrays
     export categorical, compress, decompress, droplevels!, levels, levels!, isordered, ordered!, reftype
     export cut, recode, recode!
 
-    using Compat
+    using Compat, NullableArrays
+
+    import NullableArrays: unsafe_getindex_notnull, unsafe_getvalue_notnull
+
+    using NullableArrays
+    import NullableArrays: unsafe_getindex_notnull, unsafe_getvalue_notnull
 
     include("typedefs.jl")
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -8,12 +8,21 @@ _isordered(x::AbstractCategoricalArray) = isordered(x)
 _isordered(x::AbstractNullableCategoricalArray) = isordered(x)
 _isordered(x::Any) = false
 
-function reftype(sz::Int)
-    if sz <= typemax(UInt8)
+"""
+    reftype(A::AbstractCategoricalArray)
+    reftype(ncat::Integer)
+
+Get an integral type used to store the references to categories in `A`,
+or the default type for referencing `ncat` categories.
+"""
+reftype{T,N,R}(A::AbstractCategoricalArray{T,N,R}) = R
+
+function reftype(ncat::Integer)
+    if ncat <= typemax(UInt8)
         return UInt8
-    elseif sz <= typemax(UInt16)
+    elseif ncat <= typemax(UInt16)
         return UInt16
-    elseif sz <= typemax(UInt32)
+    elseif ncat <= typemax(UInt32)
         return UInt32
     else
         return UInt64

--- a/src/nullablearray.jl
+++ b/src/nullablearray.jl
@@ -132,6 +132,8 @@ end
     end
 end
 
+@inline Base.isnull(A::NullableCategoricalArray, inds...) = getindex(A.refs, inds...) .== zero(reftype(A))
+
 reftype{T,N,R}(x::AbstractNullableCategoricalArray{T,N,R}) = R
 
 levels!(A::NullableCategoricalArray, newlevels::Vector; nullok=false) = _levels!(A, newlevels, nullok=nullok)

--- a/src/nullablearray.jl
+++ b/src/nullablearray.jl
@@ -123,6 +123,20 @@ NullableCategoricalMatrix{T}(A::AbstractMatrix{T},
     end
 end
 
+@inline NullableArrays.unsafe_getvalue_notnull(A::NullableCategoricalArray, I...) =
+    getindex(A.pool, getindex(A.refs, I...))
+
+@inline function NullableArrays.unsafe_getindex_notnull(A::NullableCategoricalArray, I::Real...)
+    @boundscheck checkbounds(A, I...)
+    @inbounds r = A.refs[I...]
+
+    if isa(r, Array)
+        @inbounds return ordered!(arraytype(A)(r, deepcopy(A.pool)), isordered(A))
+    else
+        @inbounds return Nullable{eltype(eltype(A))}(A.pool[r])
+    end
+end
+
 @inline function setindex!(A::NullableCategoricalArray, v::Nullable, I::Real...)
     @boundscheck checkbounds(A, I...)
     if isnull(v)

--- a/src/nullablearray.jl
+++ b/src/nullablearray.jl
@@ -132,6 +132,8 @@ end
     end
 end
 
+reftype{T,N,R}(x::AbstractNullableCategoricalArray{T,N,R}) = R
+
 levels!(A::NullableCategoricalArray, newlevels::Vector; nullok=false) = _levels!(A, newlevels, nullok=nullok)
 
 droplevels!(A::NullableCategoricalArray) = levels!(A, _unique(Array, A.refs, A.pool))


### PR DESCRIPTION
Add NullableArrays.jl requirement and implement a few of its methods (including the novel ones proposed by JuliaStats/NullableArrays.jl#155)
- `unsafe_getindex/value_notnull()`
- `[unsafe_]isnull()`
- `padnull[!]()`
- `reftype(A::[Nullable]CategoricalArray)` to get the type of the references of `A`
