### PR TITLE
uncompact

### DIFF
--- a/src/CategoricalArrays.jl
+++ b/src/CategoricalArrays.jl
@@ -7,7 +7,7 @@ module CategoricalArrays
            NullableCategoricalArray, NullableCategoricalVector, NullableCategoricalMatrix
     export LevelsException
 
-    export categorical, compact, droplevels!, levels, levels!, isordered, ordered!
+    export categorical, compact, uncompact, droplevels!, levels, levels!, isordered, ordered!
 
     using Compat
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -467,16 +467,15 @@ end
     uncompact(A::CategoricalArray)
     uncompact(A::NullableCategoricalArray)
 
-Return a copy of categorical array `A` using the default reference type. If `A` is using
-a small reference type (such as UInt8 or UInt16) the uncompact array will have room for
-more levels.
+Return a copy of categorical array `A` using the default reference type ($DefaultRefType).
+If `A` is using a small reference type (such as `UInt8` or `UInt16`) the uncompacted array
+will have room for more levels.
 
-Avoid using compact to avoid having to call uncompact.
+To avoid the need to call uncompact, ensure [`compact`](@ref) is not called when creating
+the categorical array.
 """
 uncompact{T, N}(A::CatArray{T, N}) =
     convert(arraytype(typeof(A)){T, N, DefaultRefType}, A)
-uncompact{T}(P::CategoricalPool{T}) =
-    convert(CategoricalPool{T, DefaultRefType}, P)
 
 arraytype(A::CategoricalArray...) = CategoricalArray
 arraytype(A::CatArray...) = NullableCategoricalArray

--- a/src/array.jl
+++ b/src/array.jl
@@ -463,6 +463,21 @@ function compact{T, N}(A::CatArray{T, N})
     convert(arraytype(typeof(A)){T, N, R}, A)
 end
 
+"""
+    uncompact(A::CategoricalArray)
+    uncompact(A::NullableCategoricalArray)
+
+Return a copy of categorical array `A` using the default reference type. If `A` is using
+a small reference type (such as UInt8 or UInt16) the uncompact array will have room for
+more levels.
+
+Avoid using compact to avoid having to call uncompact.
+"""
+uncompact{T, N}(A::CatArray{T, N}) =
+    convert(arraytype(typeof(A)){T, N, DefaultRefType}, A)
+uncompact{T}(P::CategoricalPool{T}) =
+    convert(CategoricalPool{T, DefaultRefType}, P)
+
 arraytype(A::CategoricalArray...) = CategoricalArray
 arraytype(A::CatArray...) = NullableCategoricalArray
 

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -182,5 +182,5 @@ ordered!(pool::CategoricalPool, ordered) = (pool.ordered = ordered; pool)
 # LevelsException
 function Base.showerror{T, R}(io::IO, err::LevelsException{T, R})
     levs = join(repr.(err.levels), ", ", " and ")
-    print(io, "cannot store level(s) $levs since reference type $R can only hold $(typemax(R)) levels. Convert categorical array to a larger reference type to add more levels.")
+    print(io, "cannot store level(s) $levs since reference type $R can only hold $(typemax(R)) levels. Convert categorical array to a larger reference type to add more levels (see uncompact).")
 end

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -182,5 +182,5 @@ ordered!(pool::CategoricalPool, ordered) = (pool.ordered = ordered; pool)
 # LevelsException
 function Base.showerror{T, R}(io::IO, err::LevelsException{T, R})
     levs = join(repr.(err.levels), ", ", " and ")
-    print(io, "cannot store level(s) $levs since reference type $R can only hold $(typemax(R)) levels. Convert categorical array to a larger reference type to add more levels (see uncompact).")
+    print(io, "cannot store level(s) $levs since reference type $R can only hold $(typemax(R)) levels. Use the uncompact function to make room for more levels.")
 end

--- a/test/07_levels.jl
+++ b/test/07_levels.jl
@@ -207,18 +207,20 @@ module TestLevels
 
     res = @test_throws LevelsException{Int, UInt8} CategoricalPool{Int, UInt8}(collect(256:-1:1))
     @test res.value.levels == [1]
-    @test sprint(showerror, res.value) == "cannot store level(s) 1 since reference type UInt8 can only hold 255 levels. Convert categorical array to a larger reference type to add more levels."
+    @test sprint(showerror, res.value) == "cannot store level(s) 1 since reference type UInt8 can only hold 255 levels. Convert categorical array to a larger reference type to add more levels (see uncompact)."
 
     pool = CategoricalPool(collect(30:288))
     res = @test_throws LevelsException{Int, UInt8} convert(CategoricalPool{Int, UInt8}, pool)
     @test res.value.levels == collect(285:288)
-    @test sprint(showerror, res.value) == "cannot store level(s) 285, 286, 287 and 288 since reference type UInt8 can only hold 255 levels. Convert categorical array to a larger reference type to add more levels."
+    @test sprint(showerror, res.value) == "cannot store level(s) 285, 286, 287 and 288 since reference type UInt8 can only hold 255 levels. Convert categorical array to a larger reference type to add more levels (see uncompact)."
 
     pool = CategoricalPool{String, UInt8}(string.(318:-1:65))
     res = @test_throws LevelsException{String, UInt8} levels!(pool, vcat("az", levels(pool), "bz", "cz"))
     @test res.value.levels == ["bz", "cz"]
-    @test sprint(showerror, res.value) == "cannot store level(s) \"bz\" and \"cz\" since reference type UInt8 can only hold 255 levels. Convert categorical array to a larger reference type to add more levels."
+    @test sprint(showerror, res.value) == "cannot store level(s) \"bz\" and \"cz\" since reference type UInt8 can only hold 255 levels. Convert categorical array to a larger reference type to add more levels (see uncompact)."
     lev = copy(levels(pool))
     levels!(pool, vcat(lev, "az"))
     @test levels(pool) == vcat(lev, "az")
+    pool2 = uncompact(pool)
+    levels!(pool2, vcat(levels(pool2), "bz", "cz"))
 end

--- a/test/07_levels.jl
+++ b/test/07_levels.jl
@@ -207,20 +207,18 @@ module TestLevels
 
     res = @test_throws LevelsException{Int, UInt8} CategoricalPool{Int, UInt8}(collect(256:-1:1))
     @test res.value.levels == [1]
-    @test sprint(showerror, res.value) == "cannot store level(s) 1 since reference type UInt8 can only hold 255 levels. Convert categorical array to a larger reference type to add more levels (see uncompact)."
+    @test sprint(showerror, res.value) == "cannot store level(s) 1 since reference type UInt8 can only hold 255 levels. Use the uncompact function to make room for more levels."
 
     pool = CategoricalPool(collect(30:288))
     res = @test_throws LevelsException{Int, UInt8} convert(CategoricalPool{Int, UInt8}, pool)
     @test res.value.levels == collect(285:288)
-    @test sprint(showerror, res.value) == "cannot store level(s) 285, 286, 287 and 288 since reference type UInt8 can only hold 255 levels. Convert categorical array to a larger reference type to add more levels (see uncompact)."
+    @test sprint(showerror, res.value) == "cannot store level(s) 285, 286, 287 and 288 since reference type UInt8 can only hold 255 levels. Use the uncompact function to make room for more levels."
 
     pool = CategoricalPool{String, UInt8}(string.(318:-1:65))
     res = @test_throws LevelsException{String, UInt8} levels!(pool, vcat("az", levels(pool), "bz", "cz"))
     @test res.value.levels == ["bz", "cz"]
-    @test sprint(showerror, res.value) == "cannot store level(s) \"bz\" and \"cz\" since reference type UInt8 can only hold 255 levels. Convert categorical array to a larger reference type to add more levels (see uncompact)."
+    @test sprint(showerror, res.value) == "cannot store level(s) \"bz\" and \"cz\" since reference type UInt8 can only hold 255 levels. Use the uncompact function to make room for more levels."
     lev = copy(levels(pool))
     levels!(pool, vcat(lev, "az"))
     @test levels(pool) == vcat(lev, "az")
-    pool2 = uncompact(pool)
-    levels!(pool2, vcat(levels(pool2), "bz", "cz"))
 end

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -239,41 +239,43 @@ for (CA, A) in ((CategoricalArray, Array), (NullableCategoricalArray, NullableAr
 
     res = @test_throws LevelsException{Int, UInt8} CA{Int, 1, UInt8}(256:-1:1)
     @test res.value.levels == [1]
-    @test sprint(showerror, res.value) == "cannot store level(s) 1 since reference type UInt8 can only hold 255 levels. Convert categorical array to a larger reference type to add more levels."
+    @test sprint(showerror, res.value) == "cannot store level(s) 1 since reference type UInt8 can only hold 255 levels. Convert categorical array to a larger reference type to add more levels (see uncompact)."
 
     x = CA{Int, 1, UInt8}(254:-1:1)
     x[1] = 1000
     res = @test_throws LevelsException{Int, UInt8} x[1] = 1001
     @test res.value.levels == [1001]
-    @test sprint(showerror, res.value) == "cannot store level(s) 1001 since reference type UInt8 can only hold 255 levels. Convert categorical array to a larger reference type to add more levels."
+    @test sprint(showerror, res.value) == "cannot store level(s) 1001 since reference type UInt8 can only hold 255 levels. Convert categorical array to a larger reference type to add more levels (see uncompact)."
     @test x == A(vcat(1000, 253:-1:1))
     @test levels(x) == vcat(1:254, 1000)
 
     x = CA{Int, 1, UInt8}(1:254)
     res = @test_throws LevelsException{Int, UInt8} x[1:2] = 1000:1001
     @test res.value.levels == [1001]
-    @test sprint(showerror, res.value) == "cannot store level(s) 1001 since reference type UInt8 can only hold 255 levels. Convert categorical array to a larger reference type to add more levels."
+    @test sprint(showerror, res.value) == "cannot store level(s) 1001 since reference type UInt8 can only hold 255 levels. Convert categorical array to a larger reference type to add more levels (see uncompact)."
     @test x == A(vcat(1000, 2:254))
     @test levels(x) == vcat(1:254, 1000)
 
     x = CA{Int, 1, UInt8}([1, 3, 256])
     res = @test_throws LevelsException{Int, UInt8} levels!(x, collect(1:256))
     @test res.value.levels == [255]
-    @test sprint(showerror, res.value) == "cannot store level(s) 255 since reference type UInt8 can only hold 255 levels. Convert categorical array to a larger reference type to add more levels."
+    @test sprint(showerror, res.value) == "cannot store level(s) 255 since reference type UInt8 can only hold 255 levels. Convert categorical array to a larger reference type to add more levels (see uncompact)."
 
     x = CA(30:2:131115)
     res = @test_throws LevelsException{Int, UInt16} CategoricalVector{Int, UInt16}(x)
     @test res.value.levels == collect(131100:2:131114)
-    @test sprint(showerror, res.value) == "cannot store level(s) 131100, 131102, 131104, 131106, 131108, 131110, 131112 and 131114 since reference type UInt16 can only hold 65535 levels. Convert categorical array to a larger reference type to add more levels."
+    @test sprint(showerror, res.value) == "cannot store level(s) 131100, 131102, 131104, 131106, 131108, 131110, 131112 and 131114 since reference type UInt16 can only hold 65535 levels. Convert categorical array to a larger reference type to add more levels (see uncompact)."
 
     x = CA{String, 1, UInt8}(string.(Char.(65:318)))
     res = @test_throws LevelsException{String, UInt8} levels!(x, vcat(levels(x), "az", "bz", "cz"))
     @test res.value.levels == ["bz", "cz"]
-    @test sprint(showerror, res.value) == "cannot store level(s) \"bz\" and \"cz\" since reference type UInt8 can only hold 255 levels. Convert categorical array to a larger reference type to add more levels."
+    @test sprint(showerror, res.value) == "cannot store level(s) \"bz\" and \"cz\" since reference type UInt8 can only hold 255 levels. Convert categorical array to a larger reference type to add more levels (see uncompact)."
     @test x == A(string.(Char.(65:318)))
     lev = copy(levels(x))
     levels!(x, vcat(lev, "az"))
     @test levels(x) == vcat(lev, "az")
+    x2 = uncompact(x)
+    levels!(x2, vcat(levels(x2), "bz", "cz"))
 end
 
 end

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -239,43 +239,47 @@ for (CA, A) in ((CategoricalArray, Array), (NullableCategoricalArray, NullableAr
 
     res = @test_throws LevelsException{Int, UInt8} CA{Int, 1, UInt8}(256:-1:1)
     @test res.value.levels == [1]
-    @test sprint(showerror, res.value) == "cannot store level(s) 1 since reference type UInt8 can only hold 255 levels. Convert categorical array to a larger reference type to add more levels (see uncompact)."
+    @test sprint(showerror, res.value) == "cannot store level(s) 1 since reference type UInt8 can only hold 255 levels. Use the uncompact function to make room for more levels."
 
     x = CA{Int, 1, UInt8}(254:-1:1)
     x[1] = 1000
     res = @test_throws LevelsException{Int, UInt8} x[1] = 1001
     @test res.value.levels == [1001]
-    @test sprint(showerror, res.value) == "cannot store level(s) 1001 since reference type UInt8 can only hold 255 levels. Convert categorical array to a larger reference type to add more levels (see uncompact)."
+    @test sprint(showerror, res.value) == "cannot store level(s) 1001 since reference type UInt8 can only hold 255 levels. Use the uncompact function to make room for more levels."
     @test x == A(vcat(1000, 253:-1:1))
     @test levels(x) == vcat(1:254, 1000)
 
     x = CA{Int, 1, UInt8}(1:254)
     res = @test_throws LevelsException{Int, UInt8} x[1:2] = 1000:1001
     @test res.value.levels == [1001]
-    @test sprint(showerror, res.value) == "cannot store level(s) 1001 since reference type UInt8 can only hold 255 levels. Convert categorical array to a larger reference type to add more levels (see uncompact)."
+    @test sprint(showerror, res.value) == "cannot store level(s) 1001 since reference type UInt8 can only hold 255 levels. Use the uncompact function to make room for more levels."
     @test x == A(vcat(1000, 2:254))
     @test levels(x) == vcat(1:254, 1000)
 
     x = CA{Int, 1, UInt8}([1, 3, 256])
     res = @test_throws LevelsException{Int, UInt8} levels!(x, collect(1:256))
     @test res.value.levels == [255]
-    @test sprint(showerror, res.value) == "cannot store level(s) 255 since reference type UInt8 can only hold 255 levels. Convert categorical array to a larger reference type to add more levels (see uncompact)."
+    @test sprint(showerror, res.value) == "cannot store level(s) 255 since reference type UInt8 can only hold 255 levels. Use the uncompact function to make room for more levels."
 
     x = CA(30:2:131115)
     res = @test_throws LevelsException{Int, UInt16} CategoricalVector{Int, UInt16}(x)
     @test res.value.levels == collect(131100:2:131114)
-    @test sprint(showerror, res.value) == "cannot store level(s) 131100, 131102, 131104, 131106, 131108, 131110, 131112 and 131114 since reference type UInt16 can only hold 65535 levels. Convert categorical array to a larger reference type to add more levels (see uncompact)."
+    @test sprint(showerror, res.value) == "cannot store level(s) 131100, 131102, 131104, 131106, 131108, 131110, 131112 and 131114 since reference type UInt16 can only hold 65535 levels. Use the uncompact function to make room for more levels."
 
     x = CA{String, 1, UInt8}(string.(Char.(65:318)))
     res = @test_throws LevelsException{String, UInt8} levels!(x, vcat(levels(x), "az", "bz", "cz"))
     @test res.value.levels == ["bz", "cz"]
-    @test sprint(showerror, res.value) == "cannot store level(s) \"bz\" and \"cz\" since reference type UInt8 can only hold 255 levels. Convert categorical array to a larger reference type to add more levels (see uncompact)."
+    @test sprint(showerror, res.value) == "cannot store level(s) \"bz\" and \"cz\" since reference type UInt8 can only hold 255 levels. Use the uncompact function to make room for more levels."
     @test x == A(string.(Char.(65:318)))
     lev = copy(levels(x))
     levels!(x, vcat(lev, "az"))
     @test levels(x) == vcat(lev, "az")
-    x2 = uncompact(x)
-    levels!(x2, vcat(levels(x2), "bz", "cz"))
+
+    x = compact(CA([1, 3, 736251]))
+    ux = uncompact(x)
+    @test x == ux
+    @test typeof(x) == CA{Int, 1, UInt8}
+    @test typeof(ux) == CA{Int, 1, CategoricalArrays.DefaultRefType}
 end
 
 end


### PR DESCRIPTION
Return a copy of categorical array `A` using the default reference type. This is needed when adding levels beyond what a compact pool has room for. Added a suggestion to use `uncompact` when hitting a `LevelsException`.

Related: https://github.com/JuliaStats/DataFrames.jl/pull/990

Example:
```
a = categorical([1;1:255], true)
a[1] = 0 # error
a2 = uncompact(a)
a2[1] = 0 # works
```

Using `uncompact` in the first place would probably be an anti-pattern so I'm not even sure if it's a good idea to add this function. None-the-less I did run into this myself when I used `compact` to keep the array as small as possible in the inner loop yet wanted to merge my output with other results later. I also believe it fits well with the description of what to do when you hit a `LevelsException`.