### PR TITLE
WIP/RFC: basic promote_rule

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -1,7 +1,7 @@
 ## Common code for CategoricalArray and NullableCategoricalArray
 
 import Base: convert, copy, copy!, getindex, setindex!, similar, size,
-             linearindexing, unique, vcat
+             linearindexing, unique, vcat, promote_rule
 
 # Used for keyword argument default value
 _isordered(x::AbstractCategoricalArray) = isordered(x)
@@ -337,6 +337,14 @@ end
 @inline function setindex!{T}(A::CatArray, v::CategoricalValue{T}, I::Real...)
     @boundscheck checkbounds(A, I...)
     @inbounds A.refs[I...] = get!(A.pool, convert(T, v))
+end
+
+@inline function promote_rule{T,N,R,T2}(::Type{CatArray{T,N,R}}, ::Type{Array{T2}})
+    CatArray{promote_type(T, T2), N, R}
+end
+
+@inline function promote_rule{T,N,R,T2<:Nullable}(::Type{CatArray{T,N,R}}, ::Type{Array{T2}})
+    NullableCategoricalArray{promote_type(T, eltype(T2)), N, R}
 end
 
 function mergelevels(ordered, levels...)

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -280,6 +280,9 @@ for (CA, A) in ((CategoricalArray, Array), (NullableCategoricalArray, NullableAr
     @test x == ux
     @test typeof(x) == CA{Int, 1, UInt8}
     @test typeof(ux) == CA{Int, 1, CategoricalArrays.DefaultRefType}
+
+    @test promote_type(typeof(CA([3,2,1])), typeof([1,2])) == CA{Int,1,DefaultRefType}
+    @test promote_type(typeof(CA([3,2,1])), typeof(NullableArray([1,3]))) == NullableCategoricalArray{Int,1,DefaultRefType}
 end
 
 end


### PR DESCRIPTION
@nalimilan is this what you had in mind? To promote arrays with and without `Nullable` to `CategoricalArray` or `NullableCategoricalArray`. Or do you want to capture any and all `AbstractArray`?