### PR TITLE
Add parentheses to correct operator precedence in `copy!`

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -404,7 +404,7 @@ function copy!{T, N}(dest::CatArray{T, N}, dstart::Integer,
     # Orderedness cannot be preserved if the source was unordered and new levels
     # need to be added: new comparisons would only be based on the source's order
     # (this is consistent with what happens when adding a new level via setindex!)
-    ordered &= isordered(src) | length(newlevels) == length(levels(dest))
+    ordered &= isordered(src) | (length(newlevels) == length(levels(dest)))
     ordered!(dest, ordered)
 
     # Simple case: replace all values

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -223,6 +223,16 @@ for (CA, A) in ((CategoricalArray, Array), (NullableCategoricalArray, NullableAr
         @test levels(x) == ["Young", "Middle", "Old"]
         @test !isordered(x)
 
+        # Origin ordered, destination ordered with no levels: check that result is ordered
+        y = CA(["Middle", "Middle", "Old", "Young"])
+        ordered!(y, true)
+        levels!(y, ["Young", "Middle", "Old"])
+        x = similar(x)
+        ordered!(x, true)
+        @test copy!(x, y) === x
+        @test levels(x) == ["Young", "Middle", "Old"]
+        @test isordered(x)
+
         # Destination ordered, but not origin, and new levels: check that result is unordered
         x = CA(["Old", "Young", "Middle", "Young"])
         levels!(x, ["Young", "Middle", "Old"])


### PR DESCRIPTION
`X | Y == Z` is being evaluated as `(X | Y) == Z` instead of the desired
`X | (Y == Z)` which causes `copy!`ing an ordered source array into an
ordered destination array with no existing levels to end up with the
destination unordered

This incidentally prevents in-line sorting of ordered categorical arrays
from working, e.g. `sort(x)` since this ultimately calls `copy!`,
causing `isless` to fail.