### PR TITLE
Rename compact() to compress() and uncompact() to decompress()

### DIFF
--- a/src/CategoricalArrays.jl
+++ b/src/CategoricalArrays.jl
@@ -7,7 +7,7 @@ module CategoricalArrays
            NullableCategoricalArray, NullableCategoricalVector, NullableCategoricalMatrix
     export LevelsException
 
-    export categorical, compact, uncompact, droplevels!, levels, levels!, isordered, ordered!
+    export categorical, compress, decompress, droplevels!, levels, levels!, isordered, ordered!
 
     using Compat
 

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,1 +1,4 @@
 @deprecate ordered isordered
+
+@deprecate compact compress
+@deprecate uncompact decompress

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -182,5 +182,5 @@ ordered!(pool::CategoricalPool, ordered) = (pool.ordered = ordered; pool)
 # LevelsException
 function Base.showerror{T, R}(io::IO, err::LevelsException{T, R})
     levs = join(repr.(err.levels), ", ", " and ")
-    print(io, "cannot store level(s) $levs since reference type $R can only hold $(typemax(R)) levels. Use the uncompact function to make room for more levels.")
+    print(io, "cannot store level(s) $levs since reference type $R can only hold $(typemax(R)) levels. Use the decompress function to make room for more levels.")
 end

--- a/test/07_levels.jl
+++ b/test/07_levels.jl
@@ -207,17 +207,17 @@ module TestLevels
 
     res = @test_throws LevelsException{Int, UInt8} CategoricalPool{Int, UInt8}(collect(256:-1:1))
     @test res.value.levels == [1]
-    @test sprint(showerror, res.value) == "cannot store level(s) 1 since reference type UInt8 can only hold 255 levels. Use the uncompact function to make room for more levels."
+    @test sprint(showerror, res.value) == "cannot store level(s) 1 since reference type UInt8 can only hold 255 levels. Use the decompress function to make room for more levels."
 
     pool = CategoricalPool(collect(30:288))
     res = @test_throws LevelsException{Int, UInt8} convert(CategoricalPool{Int, UInt8}, pool)
     @test res.value.levels == collect(285:288)
-    @test sprint(showerror, res.value) == "cannot store level(s) 285, 286, 287 and 288 since reference type UInt8 can only hold 255 levels. Use the uncompact function to make room for more levels."
+    @test sprint(showerror, res.value) == "cannot store level(s) 285, 286, 287 and 288 since reference type UInt8 can only hold 255 levels. Use the decompress function to make room for more levels."
 
     pool = CategoricalPool{String, UInt8}(string.(318:-1:65))
     res = @test_throws LevelsException{String, UInt8} levels!(pool, vcat("az", levels(pool), "bz", "cz"))
     @test res.value.levels == ["bz", "cz"]
-    @test sprint(showerror, res.value) == "cannot store level(s) \"bz\" and \"cz\" since reference type UInt8 can only hold 255 levels. Use the uncompact function to make room for more levels."
+    @test sprint(showerror, res.value) == "cannot store level(s) \"bz\" and \"cz\" since reference type UInt8 can only hold 255 levels. Use the decompress function to make room for more levels."
     lev = copy(levels(pool))
     levels!(pool, vcat(lev, "az"))
     @test levels(pool) == vcat(lev, "az")

--- a/test/11_array.jl
+++ b/test/11_array.jl
@@ -94,7 +94,7 @@ for ordered in (false, true)
             @test isordered(x2) === ordered
         end
 
-        x2 = compact(x)
+        x2 = compress(x)
         @test x2 == x
         @test isa(x2, CategoricalVector{String, UInt8})
         @test isordered(x2) === isordered(x)
@@ -502,7 +502,7 @@ for ordered in (false, true)
             @test isordered(x2) === ordered
         end
 
-        x2 = compact(x)
+        x2 = compress(x)
         @test x2 == x
         @test isa(x2, CategoricalMatrix{String, UInt8})
         @test isordered(x2) === isordered(x)
@@ -633,7 +633,7 @@ for ordered in (false, true)
             @test isordered(x) === ordered
             @test levels(x) == []
 
-            x2 = compact(x)
+            x2 = compress(x)
             if VERSION >= v"0.5.0-dev"
                 @test isa(x2, CategoricalArray{String, ndims(x), UInt8})
             else

--- a/test/12_nullablearray.jl
+++ b/test/12_nullablearray.jl
@@ -109,7 +109,7 @@ for ordered in (false, true)
                 @test isordered(x2) === ordered
             end
 
-            x2 = compact(x)
+            x2 = compress(x)
             @test x2 == x
             @test isa(x2, NullableCategoricalVector{String, UInt8})
             @test isordered(x2) === isordered(x)
@@ -350,7 +350,7 @@ for ordered in (false, true)
                 @test isordered(x2) === ordered
             end
 
-            x2 = compact(x)
+            x2 = compress(x)
             @test x2 == x
             @test isa(x2, NullableCategoricalVector{String, UInt8})
             @test levels(x2) == levels(x)
@@ -527,7 +527,7 @@ for ordered in (false, true)
             @test isordered(x2) === ordered
         end
 
-        x2 = compact(x)
+        x2 = compress(x)
         @test x2 == x
         @test isordered(x2) === isordered(x)
         @test isa(x2, NullableCategoricalVector{Float64, UInt8})
@@ -715,7 +715,7 @@ for ordered in (false, true)
             @test isordered(x2) === ordered
             end
 
-            x2 = compact(x)
+            x2 = compress(x)
             @test x2 == x
             @test isa(x2, NullableCategoricalMatrix{String, UInt8})
             @test isordered(x2) === isordered(x)
@@ -865,7 +865,7 @@ for ordered in (false, true)
                 @test isordered(x2) === ordered
             end
 
-            x2 = compact(x)
+            x2 = compress(x)
             @test x2 == x
             @test isa(x2, NullableCategoricalMatrix{String, UInt8})
             @test isordered(x2) === isordered(x)
@@ -1050,7 +1050,7 @@ for ordered in (false, true)
             @test isnull(x[2])
             @test levels(x) == []
 
-            x2 = compact(x)
+            x2 = compress(x)
             @test x2 == x
             if VERSION >= v"0.5.0-dev"
                 @test isa(x2, NullableCategoricalArray{String, ndims(x), UInt8})

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -70,13 +70,13 @@ typealias String Compat.ASCIIString
 for (CA, A) in ((CategoricalArray, Array), (NullableCategoricalArray, NullableArray))
     # Test vcat()
 
-    # Test that vcat of compact arrays uses a reftype that doesn't overflow
+    # Test that vcat of compress arrays uses a reftype that doesn't overflow
     a1 = 3:200
     a2 = 300:-1:100
     ca1 = CA(a1)
     ca2 = CA(a2)
-    cca1 = compact(ca1)
-    cca2 = compact(ca2)
+    cca1 = compress(ca1)
+    cca2 = compress(ca2)
     r = vcat(cca1, cca2)
     @test r == A(vcat(a1, a2))
     @test isa(cca1, CA{Int, 1, UInt8})
@@ -93,8 +93,8 @@ for (CA, A) in ((CategoricalArray, Array), (NullableCategoricalArray, NullableAr
     a2[1:end] = (1:length(a2)) + 10
     ca1 = CA(a1)
     ca2 = CA(a2)
-    cca1 = compact(ca1)
-    cca2 = compact(ca2)
+    cca1 = compress(ca1)
+    cca2 = compress(ca2)
     r = vcat(cca1, cca2)
     @test r == A(vcat(a1, a2))
     @test isa(r, CA{Int, 4, CategoricalArrays.DefaultRefType})
@@ -249,44 +249,44 @@ for (CA, A) in ((CategoricalArray, Array), (NullableCategoricalArray, NullableAr
 
     res = @test_throws LevelsException{Int, UInt8} CA{Int, 1, UInt8}(256:-1:1)
     @test res.value.levels == [1]
-    @test sprint(showerror, res.value) == "cannot store level(s) 1 since reference type UInt8 can only hold 255 levels. Use the uncompact function to make room for more levels."
+    @test sprint(showerror, res.value) == "cannot store level(s) 1 since reference type UInt8 can only hold 255 levels. Use the decompress function to make room for more levels."
 
     x = CA{Int, 1, UInt8}(254:-1:1)
     x[1] = 1000
     res = @test_throws LevelsException{Int, UInt8} x[1] = 1001
     @test res.value.levels == [1001]
-    @test sprint(showerror, res.value) == "cannot store level(s) 1001 since reference type UInt8 can only hold 255 levels. Use the uncompact function to make room for more levels."
+    @test sprint(showerror, res.value) == "cannot store level(s) 1001 since reference type UInt8 can only hold 255 levels. Use the decompress function to make room for more levels."
     @test x == A(vcat(1000, 253:-1:1))
     @test levels(x) == vcat(1:254, 1000)
 
     x = CA{Int, 1, UInt8}(1:254)
     res = @test_throws LevelsException{Int, UInt8} x[1:2] = 1000:1001
     @test res.value.levels == [1001]
-    @test sprint(showerror, res.value) == "cannot store level(s) 1001 since reference type UInt8 can only hold 255 levels. Use the uncompact function to make room for more levels."
+    @test sprint(showerror, res.value) == "cannot store level(s) 1001 since reference type UInt8 can only hold 255 levels. Use the decompress function to make room for more levels."
     @test x == A(vcat(1000, 2:254))
     @test levels(x) == vcat(1:254, 1000)
 
     x = CA{Int, 1, UInt8}([1, 3, 256])
     res = @test_throws LevelsException{Int, UInt8} levels!(x, collect(1:256))
     @test res.value.levels == [255]
-    @test sprint(showerror, res.value) == "cannot store level(s) 255 since reference type UInt8 can only hold 255 levels. Use the uncompact function to make room for more levels."
+    @test sprint(showerror, res.value) == "cannot store level(s) 255 since reference type UInt8 can only hold 255 levels. Use the decompress function to make room for more levels."
 
     x = CA(30:2:131115)
     res = @test_throws LevelsException{Int, UInt16} CategoricalVector{Int, UInt16}(x)
     @test res.value.levels == collect(131100:2:131114)
-    @test sprint(showerror, res.value) == "cannot store level(s) 131100, 131102, 131104, 131106, 131108, 131110, 131112 and 131114 since reference type UInt16 can only hold 65535 levels. Use the uncompact function to make room for more levels."
+    @test sprint(showerror, res.value) == "cannot store level(s) 131100, 131102, 131104, 131106, 131108, 131110, 131112 and 131114 since reference type UInt16 can only hold 65535 levels. Use the decompress function to make room for more levels."
 
     x = CA{String, 1, UInt8}(string.(Char.(65:318)))
     res = @test_throws LevelsException{String, UInt8} levels!(x, vcat(levels(x), "az", "bz", "cz"))
     @test res.value.levels == ["bz", "cz"]
-    @test sprint(showerror, res.value) == "cannot store level(s) \"bz\" and \"cz\" since reference type UInt8 can only hold 255 levels. Use the uncompact function to make room for more levels."
+    @test sprint(showerror, res.value) == "cannot store level(s) \"bz\" and \"cz\" since reference type UInt8 can only hold 255 levels. Use the decompress function to make room for more levels."
     @test x == A(string.(Char.(65:318)))
     lev = copy(levels(x))
     levels!(x, vcat(lev, "az"))
     @test levels(x) == vcat(lev, "az")
 
-    x = compact(CA([1, 3, 736251]))
-    ux = uncompact(x)
+    x = compress(CA([1, 3, 736251]))
+    ux = decompress(x)
     @test x == ux
     @test typeof(x) == CA{Int, 1, UInt8}
     @test typeof(ux) == CA{Int, 1, CategoricalArrays.DefaultRefType}


### PR DESCRIPTION
As discussed some time ago. That way both terms exist and are easy to
understand.

Cc: @gustafsson 