### PR TITLE
Add cut function

### DIFF
--- a/src/CategoricalArrays.jl
+++ b/src/CategoricalArrays.jl
@@ -8,6 +8,7 @@ module CategoricalArrays
     export LevelsException
 
     export categorical, compress, decompress, droplevels!, levels, levels!, isordered, ordered!
+    export cut
 
     using Compat
 
@@ -21,6 +22,8 @@ module CategoricalArrays
     include("array.jl")
     include("nullablearray.jl")
     include("subarray.jl")
+
+    include("extras.jl")
 
     include("deprecated.jl")
 

--- a/src/extras.jl
+++ b/src/extras.jl
@@ -1,0 +1,143 @@
+function fill_refs!(refs::AbstractVector, X::AbstractArray,
+                    breaks::AbstractVector, extend::Bool, nullok::Bool)
+    n = length(breaks)
+    lower = first(breaks)
+    upper = last(breaks)
+
+    @inbounds for i in eachindex(X)
+        x = X[i]
+
+        if extend && x == upper
+            refs[i] = n-1
+        elseif !extend && !(lower <= x < upper)
+            throw(ArgumentError("value $x (at index $i) is outside the breaks: adapt them manually, or pass extend=true"))
+        else
+            refs[i] = searchsortedlast(breaks, x)
+        end
+    end
+end
+
+function fill_refs!{T<:Nullable}(refs::AbstractVector, X::AbstractArray{T},
+                                  breaks::AbstractVector, extend::Bool, nullok::Bool)
+    n = length(breaks)
+    lower = first(breaks)
+    upper = last(breaks)
+
+    @inbounds for i in eachindex(X)
+        isnull(X[i]) && continue
+
+        x = unsafe_get(X[i])
+
+        if extend && x == upper
+            refs[i] = n-1
+        elseif !extend && !(lower <= x < upper)
+            nullok || throw(ArgumentError("value $x (at index $i) is outside the breaks: adapt them manually, or pass extend=true or nullok=true"))
+            refs[i] = 0
+        else
+            refs[i] = searchsortedlast(breaks, x)
+        end
+    end
+end
+
+function fill_refs!{T}(refs::AbstractVector, X::NullableArray{T},
+                       breaks::AbstractVector, extend::Bool, nullok::Bool)
+    n = length(breaks)
+    lower = first(breaks)
+    upper = last(breaks)
+
+    @inbounds for i in eachindex(X)
+        X.isnull[i] && continue
+
+        x = X.values[i]
+
+        if extend && x == upper
+            refs[i] = n-1
+        elseif !extend && !(lower <= x < upper)
+            nullok || throw(ArgumentError("value $x (at index $i) is outside the breaks: adapt them manually, or pass extend=true or nullok=true"))
+            refs[i] = 0
+        else
+            refs[i] = searchsortedlast(breaks, x)
+        end
+    end
+end
+
+
+_extrema(X::Any) = extrema(X)
+# NullableArrays provide a more efficient version with higher precedence
+_extrema{T<:Nullable}(X::AbstractArray{T}) = (minimum(X), maximum(X))
+
+unwrap(x::Any) = x
+unwrap(x::Nullable) = x.value
+
+"""
+    cut(x::AbstractArray, breaks::AbstractVector;
+        extend::Bool=false, labels::AbstractVector)
+
+Cut a numeric array into intervals and return an ordered `CategoricalArray` indicating
+the interval into which each entry falls. Intervals are of the form `[lower, upper)`,
+i.e. the lower bound is included and the upper bound is excluded.
+
+# Arguments
+* `extend::Bool=false`: when `false`, an error is raised if some values in `x` fall
+  outside of the breaks; when `true`, breaks are automatically added to include all
+  values in `x`.
+* `labels::AbstractVector=String[]`: the names to use for the intervals; if empty,
+  default labels are used.
+
+    cut(x::AbstractArray{<:Nullable}, breaks::AbstractVector;
+        extend::Bool=false, nullok::Bool=false)
+
+For nullable arrays, return a `NullableCategoricalArray`. If `nullok=true`, values outside
+of breaks result in null values.
+"""
+function cut{T, N, U}(x::AbstractArray{T, N}, breaks::AbstractVector;
+                      extend::Bool=false, nullok::Bool=false, labels::AbstractVector{U}=String[])
+    if !issorted(breaks)
+        sort!(breaks)
+    end
+
+    if extend
+        min_x, max_x = _extrema(x)
+        if !isnull(min_x) && breaks[1] > unwrap(min_x)
+            unshift!(breaks, unwrap(min_x))
+        end
+        if !isnull(max_x) && breaks[end] < unwrap(max_x)
+            push!(breaks, unwrap(max_x))
+        end
+    end
+
+    refs = Array{DefaultRefType}(size(x))
+    fill_refs!(refs, x, breaks, extend, nullok)
+
+    n = length(breaks)
+    if isempty(labels)
+        from = map(x -> sprint(showcompact, x), breaks[1:n-1])
+        to = map(x -> sprint(showcompact, x), breaks[2:n])
+        levs = Vector{U}(n-1)
+        for i in 1:n-2
+            levs[i] = string("[", from[i], ", ", to[i], ")")
+        end
+        if extend
+            levs[end] = string("[", from[end], ", ", to[end], "]")
+        else
+            levs[end] = string("[", from[end], ", ", to[end], ")")
+        end
+    else
+        length(labels) == n-1 || throw(ArgumentError("labels must be of length $(n-1), but got length $(length(labels))"))
+        levs = copy(labels)
+    end
+
+    pool = CategoricalPool(levs, true)
+    if T <: Nullable
+        NullableCategoricalArray{U, N, DefaultRefType}(refs, pool)
+    else
+        CategoricalArray{U, N, DefaultRefType}(refs, pool)
+    end
+end
+
+"""
+    cut(x::AbstractArray, ngroups::Integer)
+
+Cut a numeric array into `ngroups` quantiles using `quantile`.
+"""
+cut(x::AbstractArray, ngroups::Integer) = cut(x, quantile(x, 1:ngroups-1)/ngroups)

--- a/src/extras.jl
+++ b/src/extras.jl
@@ -1,4 +1,4 @@
-function fill_refs!(refs::AbstractVector, X::AbstractArray,
+function fill_refs!(refs::AbstractArray, X::AbstractArray,
                     breaks::AbstractVector, extend::Bool, nullok::Bool)
     n = length(breaks)
     lower = first(breaks)
@@ -10,14 +10,14 @@ function fill_refs!(refs::AbstractVector, X::AbstractArray,
         if extend && x == upper
             refs[i] = n-1
         elseif !extend && !(lower <= x < upper)
-            throw(ArgumentError("value $x (at index $i) is outside the breaks: adapt them manually, or pass extend=true"))
+            throw(ArgumentError("value $x (at index $i) does not fall inside the breaks: adapt them manually, or pass extend=true"))
         else
             refs[i] = searchsortedlast(breaks, x)
         end
     end
 end
 
-function fill_refs!{T<:Nullable}(refs::AbstractVector, X::AbstractArray{T},
+function fill_refs!{T<:Nullable}(refs::AbstractArray, X::AbstractArray{T},
                                   breaks::AbstractVector, extend::Bool, nullok::Bool)
     n = length(breaks)
     lower = first(breaks)
@@ -31,7 +31,7 @@ function fill_refs!{T<:Nullable}(refs::AbstractVector, X::AbstractArray{T},
         if extend && x == upper
             refs[i] = n-1
         elseif !extend && !(lower <= x < upper)
-            nullok || throw(ArgumentError("value $x (at index $i) is outside the breaks: adapt them manually, or pass extend=true or nullok=true"))
+            nullok || throw(ArgumentError("value $x (at index $i) does not fall inside the breaks: adapt them manually, or pass extend=true or nullok=true"))
             refs[i] = 0
         else
             refs[i] = searchsortedlast(breaks, x)
@@ -39,8 +39,8 @@ function fill_refs!{T<:Nullable}(refs::AbstractVector, X::AbstractArray{T},
     end
 end
 
-function fill_refs!{T}(refs::AbstractVector, X::NullableArray{T},
-                       breaks::AbstractVector, extend::Bool, nullok::Bool)
+function fill_refs!(refs::AbstractArray, X::NullableArray,
+                    breaks::AbstractVector, extend::Bool, nullok::Bool)
     n = length(breaks)
     lower = first(breaks)
     upper = last(breaks)
@@ -53,7 +53,7 @@ function fill_refs!{T}(refs::AbstractVector, X::NullableArray{T},
         if extend && x == upper
             refs[i] = n-1
         elseif !extend && !(lower <= x < upper)
-            nullok || throw(ArgumentError("value $x (at index $i) is outside the breaks: adapt them manually, or pass extend=true or nullok=true"))
+            nullok || throw(ArgumentError("value $x (at index $i) does not fall inside the breaks: adapt them manually, or pass extend=true or nullok=true"))
             refs[i] = 0
         else
             refs[i] = searchsortedlast(breaks, x)
@@ -71,7 +71,7 @@ unwrap(x::Nullable) = x.value
 
 """
     cut(x::AbstractArray, breaks::AbstractVector;
-        extend::Bool=false, labels::AbstractVector)
+        extend::Bool=false, labels::AbstractVector=[])
 
 Cut a numeric array into intervals and return an ordered `CategoricalArray` indicating
 the interval into which each entry falls. Intervals are of the form `[lower, upper)`,
@@ -80,20 +80,22 @@ i.e. the lower bound is included and the upper bound is excluded.
 # Arguments
 * `extend::Bool=false`: when `false`, an error is raised if some values in `x` fall
   outside of the breaks; when `true`, breaks are automatically added to include all
-  values in `x`.
-* `labels::AbstractVector=String[]`: the names to use for the intervals; if empty,
-  default labels are used.
+  values in `x`, and the upper bound is included in the last interval.
+* `labels::AbstractVector=[]`: a vector of strings giving the names to use for the
+  intervals; if empty, default labels are used.
+
 
     cut(x::AbstractArray{<:Nullable}, breaks::AbstractVector;
-        extend::Bool=false, nullok::Bool=false)
+        extend::Bool=false, labels::AbstractVector=[]), nullok::Bool=false)
 
 For nullable arrays, return a `NullableCategoricalArray`. If `nullok=true`, values outside
 of breaks result in null values.
 """
-function cut{T, N, U}(x::AbstractArray{T, N}, breaks::AbstractVector;
-                      extend::Bool=false, nullok::Bool=false, labels::AbstractVector{U}=String[])
+function cut{T, N, U<:AbstractString}(x::AbstractArray{T, N}, breaks::AbstractVector;
+                                      extend::Bool=false, labels::AbstractVector{U}=String[],
+                                      nullok::Bool=false)
     if !issorted(breaks)
-        sort!(breaks)
+        breaks = sort(breaks)
     end
 
     if extend
@@ -106,14 +108,24 @@ function cut{T, N, U}(x::AbstractArray{T, N}, breaks::AbstractVector;
         end
     end
 
-    refs = Array{DefaultRefType}(size(x))
-    fill_refs!(refs, x, breaks, extend, nullok)
+    refs = Array{DefaultRefType, N}(size(x))
+    try
+        fill_refs!(refs, x, breaks, extend, nullok)
+    catch err
+        # So that the error appears to come from cut() itself,
+        # since it refers to its keyword arguments
+        if isa(err, ArgumentError)
+            throw(err)
+        else
+            rethrow(err)
+        end
+    end
 
     n = length(breaks)
     if isempty(labels)
         from = map(x -> sprint(showcompact, x), breaks[1:n-1])
         to = map(x -> sprint(showcompact, x), breaks[2:n])
-        levs = Vector{U}(n-1)
+        levs = Vector{String}(n-1)
         for i in 1:n-2
             levs[i] = string("[", from[i], ", ", to[i], ")")
         end
@@ -129,15 +141,19 @@ function cut{T, N, U}(x::AbstractArray{T, N}, breaks::AbstractVector;
 
     pool = CategoricalPool(levs, true)
     if T <: Nullable
-        NullableCategoricalArray{U, N, DefaultRefType}(refs, pool)
+        NullableCategoricalArray{String, N, DefaultRefType}(refs, pool)
     else
-        CategoricalArray{U, N, DefaultRefType}(refs, pool)
+        CategoricalArray{String, N, DefaultRefType}(refs, pool)
     end
 end
 
 """
-    cut(x::AbstractArray, ngroups::Integer)
+    cut(x::AbstractArray, ngroups::Integer;
+        labels::AbstractVector=String[])
 
-Cut a numeric array into `ngroups` quantiles using `quantile`.
+Cut a numeric array into `ngroups` quantiles, determined using
+[`quantile`](@ref).
 """
-cut(x::AbstractArray, ngroups::Integer) = cut(x, quantile(x, 1:ngroups-1)/ngroups)
+cut{U<:AbstractString}(x::AbstractArray, ngroups::Integer;
+                       labels::AbstractVector{U}=String[]) =
+    cut(x, quantile(x, (1:ngroups-1)/ngroups); extend=true, labels=labels)

--- a/test/15_extras.jl
+++ b/test/15_extras.jl
@@ -1,0 +1,100 @@
+module TestExtras
+
+using Base.Test
+using CategoricalArrays
+using NullableArrays
+using Compat
+
+# == currently throws an error for Nullables
+const ==  = isequal
+
+# Test cut
+
+for (A, CA) in zip((Array, NullableArray, Array{Nullable}),
+                    (CategoricalArray, NullableCategoricalArray, NullableCategoricalArray))
+    x = cut(A([2, 3, 5]), [1, 3, 6])
+    @test x == CA(["[1, 3)", "[3, 6)", "[3, 6)"])
+    @test isa(x, CA)
+    @test isordered(x)
+    @test levels(x) == ["[1, 3)", "[3, 6)"]
+
+    err = @test_throws ArgumentError cut(A([2, 3, 5]), [3, 6])
+    if A === Array
+        @test err.value.msg == "value 2 (at index 1) is outside the breaks: adapt them manually, or pass extend=true"
+    else
+        @test err.value.msg == "value 2 (at index 1) is outside the breaks: adapt them manually, or pass extend=true or nullok=true"
+    end
+
+
+    err = @test_throws ArgumentError cut(A([2, 3, 5]), [2, 5])
+    if A === Array
+        @test err.value.msg == "value 5 (at index 3) is outside the breaks: adapt them manually, or pass extend=true"
+    else
+        @test err.value.msg == "value 5 (at index 3) is outside the breaks: adapt them manually, or pass extend=true or nullok=true"
+    end
+
+    if A === Array
+        err = @test_throws ArgumentError cut(A([2, 3, 5]), [2, 5], nullok=true)
+        @test err.value.msg == "value 5 (at index 3) is outside the breaks: adapt them manually, or pass extend=true"
+    else
+        x = cut(A([2, 3, 5]), [2, 5], nullok=true)
+        @test x == CA(["[2, 5)", "[2, 5)", Nullable()])
+        @test isa(x, CA)
+        @test isordered(x)
+        @test levels(x) == ["[2, 5)"]
+    end
+
+    x = cut(A([2, 3, 5]), [3, 6], extend=true)
+    @test x == CA(["[2, 3)", "[3, 6]", "[3, 6]"])
+    @test isa(x, CA)
+    @test isordered(x)
+    @test levels(x) == ["[2, 3)", "[3, 6]"]
+
+    x = cut(A([2, 3, 5, 6]), [3, 6], extend=true)
+    @test x == CA(["[2, 3)", "[3, 6]", "[3, 6]", "[3, 6]"])
+    @test isordered(x)
+    @test levels(x) == ["[2, 3)", "[3, 6]"]
+
+    x = cut(A([1, 2, 4]), [1, 3, 6])
+    @test x == CA(["[1, 3)", "[1, 3)", "[3, 6)"])
+    @test isa(x, CA)
+    @test isordered(x)
+    @test levels(x) == ["[1, 3)", "[3, 6)"]
+
+    x = cut(A([1, 2, 4]), [3, 6], extend=true)
+    @test x == CA(["[1, 3)", "[1, 3)", "[3, 6]"])
+    @test isa(x, CA)
+    @test isordered(x)
+    @test levels(x) == ["[1, 3)", "[3, 6]"]
+
+    x = cut(A([1, 2, 4]), [3], extend=true)
+    @test x == CA(["[1, 3)", "[1, 3)", "[3, 4]"])
+    @test isa(x, CA)
+    @test isordered(x)
+    @test levels(x) == ["[1, 3)", "[3, 4]"]
+
+    x = cut(A([1, 5, 7]), [3, 6], extend=true)
+    @test x == CA(["[1, 3)", "[3, 6)", "[6, 7]"])
+    @test isa(x, CA)
+    @test isordered(x)
+    @test levels(x) == ["[1, 3)", "[3, 6)", "[6, 7]"]
+
+    ages = [20, 22, 25, 27, 21, 23, 37, 31, 61, 45, 41, 32]
+    breaks = [18, 25, 35, 60, 100]
+    x = cut(A(ages), breaks)
+    @test x == CA(["[18, 25)", "[18, 25)", "[25, 35)", "[25, 35)", "[18, 25)", "[18, 25)",
+                   "[35, 60)", "[25, 35)", "[60, 100)", "[35, 60)", "[35, 60)", "[25, 35)"])
+    @test isa(x, CA)
+    @test isordered(x)
+    @test levels(x) == ["[18, 25)", "[25, 35)", "[35, 60)", "[60, 100)"]
+
+    labels = ["b", "a"]
+    x = cut(A([2, 3, 5]), [1, 3, 6], labels=labels)
+    @test x == CA(["b", "a", "a"])
+    @test isa(x, CA)
+    @test isordered(x)
+    labels[1] = "c" # Check that labels are copied
+    @test levels(x) == ["b", "a"]
+end
+
+end

--- a/test/15_extras.jl
+++ b/test/15_extras.jl
@@ -12,89 +12,104 @@ const ==  = isequal
 
 for (A, CA) in zip((Array, NullableArray, Array{Nullable}),
                     (CategoricalArray, NullableCategoricalArray, NullableCategoricalArray))
-    x = cut(A([2, 3, 5]), [1, 3, 6])
-    @test x == CA(["[1, 3)", "[3, 6)", "[3, 6)"])
-    @test isa(x, CA)
+    x = @inferred cut(A([2, 3, 5]), [1, 3, 6])
+    @test x == A(["[1, 3)", "[3, 6)", "[3, 6)"])
+    @test isa(x, CA{String, 1})
     @test isordered(x)
     @test levels(x) == ["[1, 3)", "[3, 6)"]
 
     err = @test_throws ArgumentError cut(A([2, 3, 5]), [3, 6])
     if A === Array
-        @test err.value.msg == "value 2 (at index 1) is outside the breaks: adapt them manually, or pass extend=true"
+        @test err.value.msg == "value 2 (at index 1) does not fall inside the breaks: adapt them manually, or pass extend=true"
     else
-        @test err.value.msg == "value 2 (at index 1) is outside the breaks: adapt them manually, or pass extend=true or nullok=true"
+        @test err.value.msg == "value 2 (at index 1) does not fall inside the breaks: adapt them manually, or pass extend=true or nullok=true"
     end
 
 
     err = @test_throws ArgumentError cut(A([2, 3, 5]), [2, 5])
     if A === Array
-        @test err.value.msg == "value 5 (at index 3) is outside the breaks: adapt them manually, or pass extend=true"
+        @test err.value.msg == "value 5 (at index 3) does not fall inside the breaks: adapt them manually, or pass extend=true"
     else
-        @test err.value.msg == "value 5 (at index 3) is outside the breaks: adapt them manually, or pass extend=true or nullok=true"
+        @test err.value.msg == "value 5 (at index 3) does not fall inside the breaks: adapt them manually, or pass extend=true or nullok=true"
     end
 
     if A === Array
         err = @test_throws ArgumentError cut(A([2, 3, 5]), [2, 5], nullok=true)
-        @test err.value.msg == "value 5 (at index 3) is outside the breaks: adapt them manually, or pass extend=true"
+        @test err.value.msg == "value 5 (at index 3) does not fall inside the breaks: adapt them manually, or pass extend=true"
     else
-        x = cut(A([2, 3, 5]), [2, 5], nullok=true)
-        @test x == CA(["[2, 5)", "[2, 5)", Nullable()])
-        @test isa(x, CA)
+        x = @inferred cut(A([2, 3, 5]), [2, 5], nullok=true)
+        @test x == A(["[2, 5)", "[2, 5)", Nullable()])
+        @test isa(x, CA{String, 1})
         @test isordered(x)
         @test levels(x) == ["[2, 5)"]
     end
 
-    x = cut(A([2, 3, 5]), [3, 6], extend=true)
-    @test x == CA(["[2, 3)", "[3, 6]", "[3, 6]"])
-    @test isa(x, CA)
+    x = @inferred cut(A([2, 3, 5]), [3, 6], extend=true)
+    @test x == A(["[2, 3)", "[3, 6]", "[3, 6]"])
+    @test isa(x, CA{String, 1})
     @test isordered(x)
     @test levels(x) == ["[2, 3)", "[3, 6]"]
 
-    x = cut(A([2, 3, 5, 6]), [3, 6], extend=true)
-    @test x == CA(["[2, 3)", "[3, 6]", "[3, 6]", "[3, 6]"])
+    x = @inferred cut(A([2, 3, 5, 6]), [3, 6], extend=true)
+    @test x == A(["[2, 3)", "[3, 6]", "[3, 6]", "[3, 6]"])
     @test isordered(x)
     @test levels(x) == ["[2, 3)", "[3, 6]"]
 
-    x = cut(A([1, 2, 4]), [1, 3, 6])
-    @test x == CA(["[1, 3)", "[1, 3)", "[3, 6)"])
-    @test isa(x, CA)
+    x = @inferred cut(A([1, 2, 4]), [1, 3, 6])
+    @test x == A(["[1, 3)", "[1, 3)", "[3, 6)"])
+    @test isa(x, CA{String, 1})
     @test isordered(x)
     @test levels(x) == ["[1, 3)", "[3, 6)"]
 
-    x = cut(A([1, 2, 4]), [3, 6], extend=true)
-    @test x == CA(["[1, 3)", "[1, 3)", "[3, 6]"])
-    @test isa(x, CA)
+    x = @inferred cut(A([1, 2, 4]), [3, 6], extend=true)
+    @test x == A(["[1, 3)", "[1, 3)", "[3, 6]"])
+    @test isa(x, CA{String, 1})
     @test isordered(x)
     @test levels(x) == ["[1, 3)", "[3, 6]"]
 
-    x = cut(A([1, 2, 4]), [3], extend=true)
-    @test x == CA(["[1, 3)", "[1, 3)", "[3, 4]"])
-    @test isa(x, CA)
+    x = @inferred cut(A([1, 2, 4]), [3], extend=true)
+    @test x == A(["[1, 3)", "[1, 3)", "[3, 4]"])
+    @test isa(x, CA{String, 1})
     @test isordered(x)
     @test levels(x) == ["[1, 3)", "[3, 4]"]
 
-    x = cut(A([1, 5, 7]), [3, 6], extend=true)
-    @test x == CA(["[1, 3)", "[3, 6)", "[6, 7]"])
-    @test isa(x, CA)
+    x = @inferred cut(A([1, 5, 7]), [3, 6], extend=true)
+    @test x == A(["[1, 3)", "[3, 6)", "[6, 7]"])
+    @test isa(x, CA{String, 1})
     @test isordered(x)
     @test levels(x) == ["[1, 3)", "[3, 6)", "[6, 7]"]
 
     ages = [20, 22, 25, 27, 21, 23, 37, 31, 61, 45, 41, 32]
     breaks = [18, 25, 35, 60, 100]
-    x = cut(A(ages), breaks)
-    @test x == CA(["[18, 25)", "[18, 25)", "[25, 35)", "[25, 35)", "[18, 25)", "[18, 25)",
-                   "[35, 60)", "[25, 35)", "[60, 100)", "[35, 60)", "[35, 60)", "[25, 35)"])
-    @test isa(x, CA)
+    x = @inferred cut(A(ages), breaks)
+    @test x == A(["[18, 25)", "[18, 25)", "[25, 35)", "[25, 35)", "[18, 25)", "[18, 25)",
+                  "[35, 60)", "[25, 35)", "[60, 100)", "[35, 60)", "[35, 60)", "[25, 35)"])
+    @test isa(x, CA{String, 1})
     @test isordered(x)
     @test levels(x) == ["[18, 25)", "[25, 35)", "[35, 60)", "[60, 100)"]
 
-    labels = ["b", "a"]
-    x = cut(A([2, 3, 5]), [1, 3, 6], labels=labels)
-    @test x == CA(["b", "a", "a"])
-    @test isa(x, CA)
+    breaks = [1, 6, 3] # Unsorted breaks
+    labels = ["b", "a"] # Differs from lexical ordering
+    x = @inferred cut(A([2, 3, 5]), breaks, labels=labels)
+    @test x == A(["b", "a", "a"])
+    @test isa(x, CA{String, 1})
     @test isordered(x)
+    @test breaks == [1, 6, 3] # Check that breaks are copied before sorting
     labels[1] = "c" # Check that labels are copied
     @test levels(x) == ["b", "a"]
+
+    x = @inferred cut(A([-1.1 3.0; 1.456 10.394]), [-2.134, 3.0, 12.5])
+    @test x == A(["[-2.134, 3.0)" "[3.0, 12.5)"; "[-2.134, 3.0)" "[3.0, 12.5)"])
+    @test isa(x, CA{String, 2})
+    @test isordered(x)
+    @test levels(x) == ["[-2.134, 3.0)", "[3.0, 12.5)"]
 end
+
+# TODO: test on nullable arrays once a quantile() method is provided for them
+x = @inferred cut([5, 4, 3, 2], 2)
+@test x == ["[3.5, 5.0]", "[3.5, 5.0]", "[2.0, 3.5)", "[2.0, 3.5)"]
+@test isa(x, CategoricalArray)
+@test isordered(x)
+@test levels(x) == ["[2.0, 3.5)", "[3.5, 5.0]"]
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,7 +25,8 @@ module TestCategoricalArrays
         "11_array.jl",
         "12_nullablearray.jl",
         "13_arraycommon.jl",
-        "14_view.jl"
+        "14_view.jl",
+        "15_extras.jl"
     ]
 
     println("Running tests:")


### PR DESCRIPTION
Freely inspired by the DataArrays implementation. Differences:
- include lower bound instead of upper bound (consistent with R's
Hmisc::cut2 and Numpy's digitize, and more useful for positive variables)
- raise an error by default if some values are out of bounds, which avoids
computing extremas when not needed
- support transforming out of bounds values into nulls
- accept custom labels

Fixes https://github.com/JuliaStats/DataArrays.jl/issues/225.

(Failure on 0.6 is unrelated.)