### PR TITLE
WIP: Adjustments for common Table interface

### DIFF
--- a/src/nullablearray.jl
+++ b/src/nullablearray.jl
@@ -136,4 +136,4 @@ levels!(A::NullableCategoricalArray, newlevels::Vector; nullok=false) = _levels!
 
 droplevels!(A::NullableCategoricalArray) = levels!(A, _unique(Array, A.refs, A.pool))
 
-unique{T}(A::NullableCategoricalArray{T}) = _unique(NullableArray{T}, A.refs, A.pool)
+unique{T}(A::NullableCategoricalArray{T}) = _unique(Array{Nullable{T}}, A.refs, A.pool)


### PR DESCRIPTION
This is a tiny one but there might be more changes that I'd like to propose in order to get a common interface for tables that `StatsModels` can use. The change here is consistent with the behavior in `NullableArrays` and it might help in the construction of contrasts. I don't think there should be any NullableArrays specific code in StatsModels and the price would then have to be that the `ContrastsMatrix` has `Nullable`s in it but I guess that is in line with the idea of propagating nullables.

- Return Array{Nullable{T}} instead of NullableArray{T} in unique