### PR TITLE
Allow isless() on unordered CategoricalValues

### DIFF
--- a/src/value.jl
+++ b/src/value.jl
@@ -57,13 +57,22 @@ function Base.isless{S, T}(x::CategoricalValue{S}, y::CategoricalValue{T})
     error("CategoricalValue objects with different pools cannot be tested for order")
 end
 
+# Method defined even on unordered values so that sort() works
 function Base.isless{T}(x::CategoricalValue{T}, y::CategoricalValue{T})
     if x.pool !== y.pool
         error("CategoricalValue objects with different pools cannot be tested for order")
-    elseif !isordered(x.pool) # !isordered(y.pool) is implied by x.pool === y.pool
-        error("Unordered CategoricalValue objects cannot be tested for order; use the ordered! function on the parent array to change this")
     else
-        return isless(order(x.pool)[x.level], order(y.pool)[y.level])
+        return order(x.pool)[x.level] < order(y.pool)[y.level]
+    end
+end
+
+function Base.:<{T}(x::CategoricalValue{T}, y::CategoricalValue{T})
+    if x.pool !== y.pool
+        error("CategoricalValue objects with different pools cannot be tested for order")
+    elseif !isordered(x.pool) # !isordered(y.pool) is implied by x.pool === y.pool
+        error("Unordered CategoricalValue objects cannot be tested for order using <. Use isless instead, or call the ordered! function on the parent array to change this")
+    else
+        return order(x.pool)[x.level] < order(y.pool)[y.level]
     end
 end
 

--- a/src/value.jl
+++ b/src/value.jl
@@ -54,13 +54,13 @@ Base.isequal(x::Any, y::CategoricalValue) = isequal(y, x)
 Base.hash(x::CategoricalValue, h::UInt) = hash(index(x.pool)[x.level], h)
 
 function Base.isless{S, T}(x::CategoricalValue{S}, y::CategoricalValue{T})
-    error("CategoricalValue objects with different pools cannot be tested for order")
+    throw(ArgumentError("CategoricalValue objects with different pools cannot be tested for order"))
 end
 
 # Method defined even on unordered values so that sort() works
 function Base.isless{T}(x::CategoricalValue{T}, y::CategoricalValue{T})
     if x.pool !== y.pool
-        error("CategoricalValue objects with different pools cannot be tested for order")
+        throw(ArgumentError("CategoricalValue objects with different pools cannot be tested for order"))
     else
         return order(x.pool)[x.level] < order(y.pool)[y.level]
     end
@@ -68,9 +68,9 @@ end
 
 function Base.:<{T}(x::CategoricalValue{T}, y::CategoricalValue{T})
     if x.pool !== y.pool
-        error("CategoricalValue objects with different pools cannot be tested for order")
+        throw(ArgumentError("CategoricalValue objects with different pools cannot be tested for order"))
     elseif !isordered(x.pool) # !isordered(y.pool) is implied by x.pool === y.pool
-        error("Unordered CategoricalValue objects cannot be tested for order using <. Use isless instead, or call the ordered! function on the parent array to change this")
+        throw(ArgumentError("Unordered CategoricalValue objects cannot be tested for order using <. Use isless instead, or call the ordered! function on the parent array to change this"))
     else
         return order(x.pool)[x.level] < order(y.pool)[y.level]
     end

--- a/test/10_isless.jl
+++ b/test/10_isless.jl
@@ -8,45 +8,45 @@ module TestIsLess
     v2 = CategoricalValue(2, pool)
     v3 = CategoricalValue(3, pool)
 
-    @test_throws Exception v1 < v1
-    @test_throws Exception v1 < v2
-    @test_throws Exception v1 < v3
-    @test_throws Exception v2 < v1
-    @test_throws Exception v2 < v2
-    @test_throws Exception v2 < v3
-    @test_throws Exception v3 < v1
-    @test_throws Exception v3 < v2
-    @test_throws Exception v3 < v3
+    @test_throws ArgumentError v1 < v1
+    @test_throws ArgumentError v1 < v2
+    @test_throws ArgumentError v1 < v3
+    @test_throws ArgumentError v2 < v1
+    @test_throws ArgumentError v2 < v2
+    @test_throws ArgumentError v2 < v3
+    @test_throws ArgumentError v3 < v1
+    @test_throws ArgumentError v3 < v2
+    @test_throws ArgumentError v3 < v3
 
-    @test_throws Exception v1 <= v1
-    @test_throws Exception v1 <= v2
-    @test_throws Exception v1 <= v3
-    @test_throws Exception v2 <= v1
-    @test_throws Exception v2 <= v2
-    @test_throws Exception v2 <= v3
-    @test_throws Exception v3 <= v1
-    @test_throws Exception v3 <= v2
-    @test_throws Exception v3 <= v3
+    @test_throws ArgumentError v1 <= v1
+    @test_throws ArgumentError v1 <= v2
+    @test_throws ArgumentError v1 <= v3
+    @test_throws ArgumentError v2 <= v1
+    @test_throws ArgumentError v2 <= v2
+    @test_throws ArgumentError v2 <= v3
+    @test_throws ArgumentError v3 <= v1
+    @test_throws ArgumentError v3 <= v2
+    @test_throws ArgumentError v3 <= v3
 
-    @test_throws Exception v1 > v1
-    @test_throws Exception v1 > v2
-    @test_throws Exception v1 > v3
-    @test_throws Exception v2 > v1
-    @test_throws Exception v2 > v2
-    @test_throws Exception v2 > v3
-    @test_throws Exception v3 > v1
-    @test_throws Exception v3 > v2
-    @test_throws Exception v3 > v3
+    @test_throws ArgumentError v1 > v1
+    @test_throws ArgumentError v1 > v2
+    @test_throws ArgumentError v1 > v3
+    @test_throws ArgumentError v2 > v1
+    @test_throws ArgumentError v2 > v2
+    @test_throws ArgumentError v2 > v3
+    @test_throws ArgumentError v3 > v1
+    @test_throws ArgumentError v3 > v2
+    @test_throws ArgumentError v3 > v3
 
-    @test_throws Exception v1 >= v1
-    @test_throws Exception v1 >= v2
-    @test_throws Exception v1 >= v3
-    @test_throws Exception v2 >= v1
-    @test_throws Exception v2 >= v2
-    @test_throws Exception v2 >= v3
-    @test_throws Exception v3 >= v1
-    @test_throws Exception v3 >= v2
-    @test_throws Exception v3 >= v3
+    @test_throws ArgumentError v1 >= v1
+    @test_throws ArgumentError v1 >= v2
+    @test_throws ArgumentError v1 >= v3
+    @test_throws ArgumentError v2 >= v1
+    @test_throws ArgumentError v2 >= v2
+    @test_throws ArgumentError v2 >= v3
+    @test_throws ArgumentError v3 >= v1
+    @test_throws ArgumentError v3 >= v2
+    @test_throws ArgumentError v3 >= v3
 
     @test isless(v1, v1) === false
     @test isless(v1, v2) === true
@@ -167,45 +167,45 @@ module TestIsLess
     @test ordered!(pool, false) === pool
     @test isordered(pool) === false
 
-    @test_throws Exception v1 < v1
-    @test_throws Exception v1 < v2
-    @test_throws Exception v1 < v3
-    @test_throws Exception v2 < v1
-    @test_throws Exception v2 < v2
-    @test_throws Exception v2 < v3
-    @test_throws Exception v3 < v1
-    @test_throws Exception v3 < v2
-    @test_throws Exception v3 < v3
+    @test_throws ArgumentError v1 < v1
+    @test_throws ArgumentError v1 < v2
+    @test_throws ArgumentError v1 < v3
+    @test_throws ArgumentError v2 < v1
+    @test_throws ArgumentError v2 < v2
+    @test_throws ArgumentError v2 < v3
+    @test_throws ArgumentError v3 < v1
+    @test_throws ArgumentError v3 < v2
+    @test_throws ArgumentError v3 < v3
 
-    @test_throws Exception v1 <= v1
-    @test_throws Exception v1 <= v2
-    @test_throws Exception v1 <= v3
-    @test_throws Exception v2 <= v1
-    @test_throws Exception v2 <= v2
-    @test_throws Exception v2 <= v3
-    @test_throws Exception v3 <= v1
-    @test_throws Exception v3 <= v2
-    @test_throws Exception v3 <= v3
+    @test_throws ArgumentError v1 <= v1
+    @test_throws ArgumentError v1 <= v2
+    @test_throws ArgumentError v1 <= v3
+    @test_throws ArgumentError v2 <= v1
+    @test_throws ArgumentError v2 <= v2
+    @test_throws ArgumentError v2 <= v3
+    @test_throws ArgumentError v3 <= v1
+    @test_throws ArgumentError v3 <= v2
+    @test_throws ArgumentError v3 <= v3
 
-    @test_throws Exception v1 > v1
-    @test_throws Exception v1 > v2
-    @test_throws Exception v1 > v3
-    @test_throws Exception v2 > v1
-    @test_throws Exception v2 > v2
-    @test_throws Exception v2 > v3
-    @test_throws Exception v3 > v1
-    @test_throws Exception v3 > v2
-    @test_throws Exception v3 > v3
+    @test_throws ArgumentError v1 > v1
+    @test_throws ArgumentError v1 > v2
+    @test_throws ArgumentError v1 > v3
+    @test_throws ArgumentError v2 > v1
+    @test_throws ArgumentError v2 > v2
+    @test_throws ArgumentError v2 > v3
+    @test_throws ArgumentError v3 > v1
+    @test_throws ArgumentError v3 > v2
+    @test_throws ArgumentError v3 > v3
 
-    @test_throws Exception v1 >= v1
-    @test_throws Exception v1 >= v2
-    @test_throws Exception v1 >= v3
-    @test_throws Exception v2 >= v1
-    @test_throws Exception v2 >= v2
-    @test_throws Exception v2 >= v3
-    @test_throws Exception v3 >= v1
-    @test_throws Exception v3 >= v2
-    @test_throws Exception v3 >= v3
+    @test_throws ArgumentError v1 >= v1
+    @test_throws ArgumentError v1 >= v2
+    @test_throws ArgumentError v1 >= v3
+    @test_throws ArgumentError v2 >= v1
+    @test_throws ArgumentError v2 >= v2
+    @test_throws ArgumentError v2 >= v3
+    @test_throws ArgumentError v3 >= v1
+    @test_throws ArgumentError v3 >= v2
+    @test_throws ArgumentError v3 >= v3
 
     @test isless(v1, v1) === false
     @test isless(v1, v2) === false
@@ -216,4 +216,18 @@ module TestIsLess
     @test isless(v3, v1) === true
     @test isless(v3, v2) === false
     @test isless(v3, v3) === false
+
+
+    # Test that ordering comparisons between pools fail
+    ordered!(pool, true)
+    pool2 = CategoricalPool([1, 2, 3])
+    ordered!(pool2, true)
+
+    v = CategoricalValue(1, pool2)
+
+    @test_throws ArgumentError v < v1
+    @test_throws ArgumentError v <= v1
+    @test_throws ArgumentError v > v1
+    @test_throws ArgumentError v >= v1
+    @test_throws ArgumentError isless(v, v1)
 end

--- a/test/10_isless.jl
+++ b/test/10_isless.jl
@@ -48,6 +48,16 @@ module TestIsLess
     @test_throws Exception v3 >= v2
     @test_throws Exception v3 >= v3
 
+    @test isless(v1, v1) === false
+    @test isless(v1, v2) === true
+    @test isless(v1, v3) === true
+    @test isless(v2, v1) === false
+    @test isless(v2, v2) === false
+    @test isless(v2, v3) === true
+    @test isless(v3, v1) === false
+    @test isless(v3, v2) === false
+    @test isless(v3, v3) === false
+
     @test ordered!(pool, true) === pool
     @test isordered(pool) === true
 
@@ -90,6 +100,16 @@ module TestIsLess
     @test (v3 >= v1) === true
     @test (v3 >= v2) === true
     @test (v3 >= v3) === true
+
+    @test isless(v1, v1) === false
+    @test isless(v1, v2) === true
+    @test isless(v1, v3) === true
+    @test isless(v2, v1) === false
+    @test isless(v2, v2) === false
+    @test isless(v2, v3) === true
+    @test isless(v3, v1) === false
+    @test isless(v3, v2) === false
+    @test isless(v3, v3) === false
 
     @test levels!(pool, [2, 3, 1]) === pool
     @test levels(pool) == [2, 3, 1]
@@ -134,6 +154,16 @@ module TestIsLess
     @test (v3 >= v2) === true
     @test (v3 >= v3) === true
 
+    @test isless(v1, v1) === false
+    @test isless(v1, v2) === false
+    @test isless(v1, v3) === false
+    @test isless(v2, v1) === true
+    @test isless(v2, v2) === false
+    @test isless(v2, v3) === true
+    @test isless(v3, v1) === true
+    @test isless(v3, v2) === false
+    @test isless(v3, v3) === false
+
     @test ordered!(pool, false) === pool
     @test isordered(pool) === false
 
@@ -176,4 +206,14 @@ module TestIsLess
     @test_throws Exception v3 >= v1
     @test_throws Exception v3 >= v2
     @test_throws Exception v3 >= v3
+
+    @test isless(v1, v1) === false
+    @test isless(v1, v2) === false
+    @test isless(v1, v3) === false
+    @test isless(v2, v1) === true
+    @test isless(v2, v2) === false
+    @test isless(v2, v3) === true
+    @test isless(v3, v1) === true
+    @test isless(v3, v2) === false
+    @test isless(v3, v3) === false
 end

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -315,6 +315,15 @@ for (CA, A) in ((CategoricalArray, Array), (NullableCategoricalArray, NullableAr
         @test levels(x) == levels(y)
         @test isordered(x)
     end
+
+    # Test sort() on both unordered and ordered arrays
+    x = CA(["Old", "Young", "Middle", "Young"])
+    levels!(x, ["Young", "Middle", "Old"])
+    @test sort(x) == A(["Young", "Young", "Middle", "Old"])
+    ordered!(x, true)
+    @test sort(x) == A(["Young", "Young", "Middle", "Old"])
+    @test sort!(x) === x
+    @test x == A(["Young", "Young", "Middle", "Old"])
 end
 
 end


### PR DESCRIPTION
< still raises an error for unordered values to protect from meaningless
comparisons, but isless() is now allowed to support sort() on unordered arrays,
where this operation is useful. This behavior is consistent with e.g. NaN being
sorted last by isless() despite the comparison having no mathematical signification.

Cc: @cjprybol