### PR TITLE
Fix constructors and conversion between categorical arrays 

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -275,7 +275,7 @@ for (A, V, M) in ((:CategoricalArray, :CategoricalVector, :CategoricalMatrix),
 
             refs = convert(Array{R, N}, A.refs)
             pool = convert(CategoricalPool{T, R}, A.pool)
-            ordered!($A(refs, pool), isordered(A))
+            $A(refs, pool)
         end
         convert{S, T, N, R}(::Type{$A{T, N}}, A::CatArray{S, N, R}) =
             convert($A{T, N, R}, A)

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -72,7 +72,7 @@ function Base.convert{S, R}(::Type{CategoricalPool{S, R}}, pool::CategoricalPool
     indexS = convert(Vector{S}, pool.index)
     invindexS = convert(Dict{S, R}, pool.invindex)
     order = convert(Vector{R}, pool.order)
-    return CategoricalPool(indexS, invindexS, order)
+    return CategoricalPool(indexS, invindexS, order, pool.ordered)
 end
 
 function Base.show{T, R}(io::IO, pool::CategoricalPool{T, R})

--- a/test/05_convert.jl
+++ b/test/05_convert.jl
@@ -29,4 +29,8 @@ module TestConvert
     @test promote(1, v1) === (1, 1)
     @test promote(1.0, v1) === (1.0, 1.0)
     @test promote(0x1, v1) === (1, 1)
+
+    # Test that ordered property is preserved
+    pool = CategoricalPool([1, 2, 3], true)
+    @test convert(CategoricalPool{Float64, UInt8}, pool).ordered === true
 end

--- a/test/11_array.jl
+++ b/test/11_array.jl
@@ -30,28 +30,6 @@ for ordered in (false, true)
         @test convert(CategoricalVector{String, DefaultRefType}, x) == x
         @test convert(CategoricalVector{String, UInt8}, x) == x
 
-        for y in (CategoricalArray(x, ordered=ordered),
-                  CategoricalArray{String}(x, ordered=ordered),
-                  CategoricalArray{String, 1}(x, ordered=ordered),
-                  CategoricalArray{String, 1, R}(x, ordered=ordered),
-                  CategoricalArray{String, 1, DefaultRefType}(x, ordered=ordered),
-                  CategoricalArray{String, 1, UInt8}(x, ordered=ordered),
-                  CategoricalVector(x, ordered=ordered),
-                  CategoricalVector{String}(x, ordered=ordered),
-                  CategoricalVector{String, R}(x, ordered=ordered),
-                  CategoricalVector{String, DefaultRefType}(x, ordered=ordered),
-                  CategoricalVector{String, UInt8}(x, ordered=ordered),
-                  categorical(x, ordered=ordered),
-                  categorical(x, false, ordered=ordered),
-                  categorical(x, true, ordered=ordered))
-            @test isa(y, CategoricalVector{String})
-            @test isordered(y) === ordered
-            @test y == x
-            @test y !== x
-            @test y.refs !== x.refs
-            @test y.pool !== x.pool
-        end
-
         @test convert(CategoricalArray, a) == x
         @test convert(CategoricalArray{String}, a) == x
         @test convert(CategoricalArray{String, 1}, a) == x
@@ -254,28 +232,6 @@ for ordered in (false, true)
         @test convert(CategoricalVector{Float64, DefaultRefType}, x) == x
         @test convert(CategoricalVector{Float64, UInt8}, x) == x
 
-        for y in (CategoricalArray(x, ordered=ordered),
-                  CategoricalArray{Float64}(x, ordered=ordered),
-                  CategoricalArray{Float64, 1}(x, ordered=ordered),
-                  CategoricalArray{Float64, 1, R}(x, ordered=ordered),
-                  CategoricalArray{Float64, 1, DefaultRefType}(x, ordered=ordered),
-                  CategoricalArray{Float64, 1, UInt8}(x, ordered=ordered),
-                  CategoricalVector(x, ordered=ordered),
-                  CategoricalVector{Float64}(x, ordered=ordered),
-                  CategoricalVector{Float64, R}(x, ordered=ordered),
-                  CategoricalVector{Float64, DefaultRefType}(x, ordered=ordered),
-                  CategoricalVector{Float64, UInt8}(x, ordered=ordered),
-                  categorical(x, ordered=ordered),
-                  categorical(x, false, ordered=ordered),
-                  categorical(x, true, ordered=ordered))
-            @test isa(y, CategoricalVector{Float64})
-            @test isordered(y) === ordered
-            @test y == x
-            @test y !== x
-            @test y.refs !== x.refs
-            @test y.pool !== x.pool
-        end
-
         @test convert(CategoricalArray, a) == x
         @test convert(CategoricalArray{Float64}, a) == x
         @test convert(CategoricalArray{Float32}, a) == x
@@ -437,28 +393,6 @@ for ordered in (false, true)
         @test convert(CategoricalMatrix{String, R}, x) === x
         @test convert(CategoricalMatrix{String, DefaultRefType}, x) == x
         @test convert(CategoricalMatrix{String, UInt8}, x) == x
-
-        for y in (CategoricalArray(x, ordered=ordered),
-                  CategoricalArray{String}(x, ordered=ordered),
-                  CategoricalArray{String, 2}(x, ordered=ordered),
-                  CategoricalArray{String, 2, R}(x, ordered=ordered),
-                  CategoricalArray{String, 2, DefaultRefType}(x, ordered=ordered),
-                  CategoricalArray{String, 2, UInt8}(x, ordered=ordered),
-                  CategoricalMatrix(x, ordered=ordered),
-                  CategoricalMatrix{String}(x, ordered=ordered),
-                  CategoricalMatrix{String, R}(x, ordered=ordered),
-                  CategoricalMatrix{String, DefaultRefType}(x, ordered=ordered),
-                  CategoricalMatrix{String, UInt8}(x, ordered=ordered),
-                  categorical(x, ordered=ordered),
-                  categorical(x, false, ordered=ordered),
-                  categorical(x, true, ordered=ordered))
-            @test isa(y, CategoricalMatrix{String})
-            @test isordered(y) === ordered
-            @test y == x
-            @test y !== x
-            @test y.refs !== x.refs
-            @test y.pool !== x.pool
-        end
 
         @test convert(CategoricalArray, a) == x
         @test convert(CategoricalArray{String}, a) == x

--- a/test/12_nullablearray.jl
+++ b/test/12_nullablearray.jl
@@ -37,28 +37,6 @@ for ordered in (false, true)
             @test convert(NullableCategoricalVector{String, DefaultRefType}, x) == x
             @test convert(NullableCategoricalVector{String, UInt8}, x) == x
 
-            for y in (NullableCategoricalArray(x, ordered=ordered),
-                      NullableCategoricalArray{String}(x, ordered=ordered),
-                      NullableCategoricalArray{String, 1}(x, ordered=ordered),
-                      NullableCategoricalArray{String, 1, R}(x, ordered=ordered),
-                      NullableCategoricalArray{String, 1, DefaultRefType}(x, ordered=ordered),
-                      NullableCategoricalArray{String, 1, UInt8}(x, ordered=ordered),
-                      NullableCategoricalVector(x, ordered=ordered),
-                      NullableCategoricalVector{String}(x, ordered=ordered),
-                      NullableCategoricalVector{String, R}(x, ordered=ordered),
-                      NullableCategoricalVector{String, DefaultRefType}(x, ordered=ordered),
-                      NullableCategoricalVector{String, UInt8}(x, ordered=ordered),
-                      categorical(x, ordered=ordered),
-                      categorical(x, false, ordered=ordered),
-                      categorical(x, true, ordered=ordered))
-                @test isa(y, NullableCategoricalVector{String})
-                @test isordered(y) === ordered
-                @test y == x
-                @test y !== x
-                @test y.refs !== x.refs
-                @test y.pool !== x.pool
-            end
-
             @test convert(NullableCategoricalArray, a) == x
             @test convert(NullableCategoricalArray{String}, a) == x
             @test convert(NullableCategoricalArray{String, 1}, a) == x
@@ -286,28 +264,6 @@ for ordered in (false, true)
             @test convert(NullableCategoricalVector{String, DefaultRefType}, x) == x
             @test convert(NullableCategoricalVector{String, UInt8}, x) == x
 
-            for y in (NullableCategoricalArray(x, ordered=ordered),
-                      NullableCategoricalArray{String}(x, ordered=ordered),
-                      NullableCategoricalArray{String, 1}(x, ordered=ordered),
-                      NullableCategoricalArray{String, 1, R}(x, ordered=ordered),
-                      NullableCategoricalArray{String, 1, DefaultRefType}(x, ordered=ordered),
-                      NullableCategoricalArray{String, 1, UInt8}(x, ordered=ordered),
-                      NullableCategoricalVector(x, ordered=ordered),
-                      NullableCategoricalVector{String}(x, ordered=ordered),
-                      NullableCategoricalVector{String, R}(x, ordered=ordered),
-                      NullableCategoricalVector{String, DefaultRefType}(x, ordered=ordered),
-                      NullableCategoricalVector{String, UInt8}(x, ordered=ordered),
-                      categorical(x, ordered=ordered),
-                      categorical(x, false, ordered=ordered),
-                      categorical(x, true, ordered=ordered))
-                @test isa(y, NullableCategoricalVector{String})
-                @test isordered(y) === ordered
-                @test y == x
-                @test y !== x
-                @test y.refs !== x.refs
-                @test y.pool !== x.pool
-            end
-
             @test convert(NullableCategoricalArray, a) == x
             @test convert(NullableCategoricalArray{String}, a) == x
             @test convert(NullableCategoricalArray{String, 1}, a) == x
@@ -440,28 +396,6 @@ for ordered in (false, true)
         @test convert(NullableCategoricalVector{Float64, R}, x) === x
         @test convert(NullableCategoricalVector{Float64, DefaultRefType}, x) == x
         @test convert(NullableCategoricalVector{Float64, UInt8}, x) == x
-
-        for y in (NullableCategoricalArray(x, ordered=ordered),
-                  NullableCategoricalArray{Float64}(x, ordered=ordered),
-                  NullableCategoricalArray{Float64, 1}(x, ordered=ordered),
-                  NullableCategoricalArray{Float64, 1, R}(x, ordered=ordered),
-                  NullableCategoricalArray{Float64, 1, DefaultRefType}(x, ordered=ordered),
-                  NullableCategoricalArray{Float64, 1, UInt8}(x, ordered=ordered),
-                  NullableCategoricalVector(x, ordered=ordered),
-                  NullableCategoricalVector{Float64}(x, ordered=ordered),
-                  NullableCategoricalVector{Float64, R}(x, ordered=ordered),
-                  NullableCategoricalVector{Float64, DefaultRefType}(x, ordered=ordered),
-                  NullableCategoricalVector{Float64, UInt8}(x, ordered=ordered),
-                  categorical(x, ordered=ordered),
-                  categorical(x, false, ordered=ordered),
-                  categorical(x, true, ordered=ordered))
-            @test isa(y, NullableCategoricalVector{Float64})
-            @test isordered(y) === ordered
-            @test y == x
-            @test y !== x
-            @test y.refs !== x.refs
-            @test y.pool !== x.pool
-        end
 
         @test convert(NullableCategoricalArray, a) == x
         @test convert(NullableCategoricalArray{Float64}, a) == x
@@ -643,28 +577,6 @@ for ordered in (false, true)
             @test convert(NullableCategoricalMatrix{String, DefaultRefType}, x) == x
             @test convert(NullableCategoricalMatrix{String, UInt8}, x) == x
 
-            for y in (NullableCategoricalArray(x, ordered=ordered),
-                      NullableCategoricalArray{String}(x, ordered=ordered),
-                      NullableCategoricalArray{String, 2}(x, ordered=ordered),
-                      NullableCategoricalArray{String, 2, R}(x, ordered=ordered),
-                      NullableCategoricalArray{String, 2, DefaultRefType}(x, ordered=ordered),
-                      NullableCategoricalArray{String, 2, UInt8}(x, ordered=ordered),
-                      NullableCategoricalMatrix(x, ordered=ordered),
-                      NullableCategoricalMatrix{String}(x, ordered=ordered),
-                      NullableCategoricalMatrix{String, R}(x, ordered=ordered),
-                      NullableCategoricalMatrix{String, DefaultRefType}(x, ordered=ordered),
-                      NullableCategoricalMatrix{String, UInt8}(x, ordered=ordered),
-                      categorical(x, ordered=ordered),
-                      categorical(x, false, ordered=ordered),
-                      categorical(x, true, ordered=ordered))
-                @test isa(y, NullableCategoricalMatrix{String})
-                @test isordered(y) === ordered
-                @test y == x
-                @test y !== x
-                @test y.refs !== x.refs
-                @test y.pool !== x.pool
-            end
-
             @test convert(NullableCategoricalArray, a) == x
             @test convert(NullableCategoricalArray{String}, a) == x
             @test convert(NullableCategoricalArray{String, 2, R}, a) == x
@@ -800,28 +712,6 @@ for ordered in (false, true)
             @test convert(NullableCategoricalMatrix{String, R}, x) === x
             @test convert(NullableCategoricalMatrix{String, DefaultRefType}, x) == x
             @test convert(NullableCategoricalMatrix{String, UInt8}, x) == x
-
-            for y in (NullableCategoricalArray(x, ordered=ordered),
-                      NullableCategoricalArray{String}(x, ordered=ordered),
-                      NullableCategoricalArray{String, 2}(x, ordered=ordered),
-                      NullableCategoricalArray{String, 2, R}(x, ordered=ordered),
-                      NullableCategoricalArray{String, 2, DefaultRefType}(x, ordered=ordered),
-                      NullableCategoricalArray{String, 2, UInt8}(x, ordered=ordered),
-                      NullableCategoricalMatrix(x, ordered=ordered),
-                      NullableCategoricalMatrix{String}(x, ordered=ordered),
-                      NullableCategoricalMatrix{String, R}(x, ordered=ordered),
-                      NullableCategoricalMatrix{String, DefaultRefType}(x, ordered=ordered),
-                      NullableCategoricalMatrix{String, UInt8}(x, ordered=ordered),
-                      categorical(x, ordered=ordered),
-                      categorical(x, false, ordered=ordered),
-                      categorical(x, true, ordered=ordered))
-                @test isa(y, NullableCategoricalMatrix{String})
-                @test isordered(y) === ordered
-                @test y == x
-                @test y !== x
-                @test y.refs !== x.refs
-                @test y.pool !== x.pool
-            end
 
             @test convert(NullableCategoricalArray, a) == x
             @test convert(NullableCategoricalArray{String}, a) == x


### PR DESCRIPTION
Previously only the conversions between CategoricalArrays and between
NullableCategoricalArrays were using specific methods. This means conversion
between these two types did not preserve levels, ordering or reference type.
Use broader signatures to cover this, and throw an error if nulls are found
when converting to CategoricalArray. Make tests more systematic to cover
all possible combinations; remove old tests which are now redundant.

Also drop the guaranty that constructors always return a copy. This is
inconsistent with e.g. Array(), would have made the code more complex,
and would trap users who thought the behavior was the same as for convert().
By the way, this an inconsistency in the default value for the 'ordered'
argument to constructors, and fix docstrings: the default is now always
to preserve the corresponding property of the input.

Fixes https://github.com/JuliaData/CategoricalArrays.jl/issues/62.