### PR TITLE
Perform explicit conversion in get!() and levels!()

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -321,11 +321,6 @@ size(A::CatArray) = size(A.refs)
     @inbounds A.refs[I...] = get!(A.pool, v)
 end
 
-@inline function setindex!{T}(A::CatArray, v::CategoricalValue{T}, I::Real...)
-    @boundscheck checkbounds(A, I...)
-    @inbounds A.refs[I...] = get!(A.pool, convert(T, v))
-end
-
 function mergelevels(ordered, levels...)
     T = Base.promote_eltype(levels...)
     res = Array{T}(0)


### PR DESCRIPTION
Allows throwing an error before doing any computations, which can fail and
leave the array in a corrupt state. Can also be faster by doing the conversion
only once. Finally, it allows removing a specialized method.