### PR TITLE
Fix convert(::Type{Any}, ::CategoricalValue) on Julia 0.7

### DIFF
--- a/src/value.jl
+++ b/src/value.jl
@@ -2,7 +2,7 @@ function CategoricalValue{T, R}(level::Integer, pool::CategoricalPool{T, R})
     return CategoricalValue(convert(R, level), pool)
 end
 
-Base.convert{T, R}(::Type{CategoricalValue{T, R}}, x::CategoricalValue{T, R}) = x
+Base.convert{T, R <: Integer}(::Type{CategoricalValue{T, R}}, x::CategoricalValue{T, R}) = x
 Base.convert{T}(::Type{CategoricalValue{T}}, x::CategoricalValue{T}) = x
 Base.convert(::Type{CategoricalValue}, x::CategoricalValue) = x
 
@@ -18,8 +18,9 @@ Base.convert{T}(::Type{Nullable{CategoricalValue{Nullable{T}}}},
                 x::CategoricalValue{Nullable{T}}) =
     Nullable(x)
 Base.convert{T}(::Type{Ref}, x::CategoricalValue{T}) = RefValue{T}(x)
+Base.convert(::Type{Any}, x::CategoricalArrays.CategoricalValue) = x
 
-Base.convert{S, T, R}(::Type{S}, x::CategoricalValue{T, R}) = convert(S, index(x.pool)[x.level])
+Base.convert{S}(::Type{S}, x::CategoricalValue) = convert(S, index(x.pool)[x.level])
 
 function Base.show{T}(io::IO, x::CategoricalValue{T})
     if @compat(get(io, :compact, false))

--- a/test/05_convert.jl
+++ b/test/05_convert.jl
@@ -14,13 +14,18 @@ module TestConvert
     v2 = CategoricalValue(2, pool)
     v3 = CategoricalValue(3, pool)
 
-    convert(Int32, v1)
-    convert(Int32, v2)
-    convert(Int32, v3)
+    @test convert(Int32, v1) === Int32(1)
+    @test convert(Int32, v2) === Int32(2)
+    @test convert(Int32, v3) === Int32(3)
 
-    convert(UInt8, v1)
-    convert(UInt8, v2)
-    convert(UInt8, v3)
+    @test convert(UInt8, v1) === 0x01
+    @test convert(UInt8, v2) === 0x02
+    @test convert(UInt8, v3) === 0x03
+
+    @test convert(CategoricalValue, v1) === v1
+    @test convert(CategoricalValue{Int}, v1) === v1
+    @test convert(CategoricalValue{Int, CategoricalArrays.DefaultRefType}, v1) === v1
+    @test convert(Any, v1) === v1
 
     @test get(v1) === 1
     @test get(v2) === 2


### PR DESCRIPTION
Method ambiguity triggered a test failure in DataTables when working
with CategoricalArray{Any}.