### PR TITLE
Override summary() for a cleaner printing

### DIFF
--- a/docs/src/using.md
+++ b/docs/src/using.md
@@ -8,7 +8,7 @@ Suppose that you have data about four individuals, with three different age grou
 julia> using CategoricalArrays
 
 julia> x = CategoricalArray(["Old", "Young", "Middle", "Young"], ordered=true)
-4-element CategoricalArrays.CategoricalArray{String,1,UInt32,String,Union{}}:
+4-element CategoricalArrays.CategoricalArray{String,1,UInt32}:
  "Old"   
  "Young" 
  "Middle"
@@ -26,7 +26,7 @@ julia> levels(x)
  "Young" 
 
 julia> levels!(x, ["Young", "Middle", "Old"])
-4-element CategoricalArrays.CategoricalArray{String,1,UInt32,String,Union{}}:
+4-element CategoricalArrays.CategoricalArray{String,1,UInt32}:
  "Old"   
  "Young" 
  "Middle"
@@ -74,7 +74,7 @@ julia> levels(x)
  "Old"   
 
 julia> droplevels!(x)
-4-element CategoricalArrays.CategoricalArray{String,1,UInt32,String,Union{}}:
+4-element CategoricalArrays.CategoricalArray{String,1,UInt32}:
  "Young" 
  "Young" 
  "Middle"
@@ -105,7 +105,7 @@ julia> x[3]
 CategoricalArrays.CategoricalValue{String,UInt32} "middle" (3/3)
 
 julia> droplevels!(x)
-4-element CategoricalArrays.CategoricalArray{String,1,UInt32,String,Union{}}:
+4-element CategoricalArrays.CategoricalArray{String,1,UInt32}:
  "Young" 
  "Young" 
  "middle"
@@ -132,7 +132,7 @@ Let's adapt the example developed above to support missing values. Since there a
 julia> using Nulls
 
 julia> y = CategoricalArray{Union{Null, String}}(["Old", "Young", "Middle", "Young"], ordered=true)
-4-element CategoricalArrays.CategoricalArray{Union{Nulls.Null, String},1,UInt32,String,Nulls.Null}:
+4-element CategoricalArrays.CategoricalArray{Union{Nulls.Null, String},1,UInt32}:
  "Old"   
  "Young" 
  "Middle"
@@ -150,7 +150,7 @@ julia> levels(y)
  "Young" 
 
 julia> levels!(y, ["Young", "Middle", "Old"])
-4-element CategoricalArrays.CategoricalArray{Union{Nulls.Null, String},1,UInt32,String,Nulls.Null}:
+4-element CategoricalArrays.CategoricalArray{Union{Nulls.Null, String},1,UInt32}:
  "Old"   
  "Young" 
  "Middle"
@@ -172,7 +172,7 @@ julia> y[1] = null
 null
 
 julia> y
-4-element CategoricalArrays.CategoricalArray{Union{Nulls.Null, String},1,UInt32,String,Nulls.Null}:
+4-element CategoricalArrays.CategoricalArray{Union{Nulls.Null, String},1,UInt32}:
  null    
  "Young" 
  "Middle"
@@ -190,14 +190,14 @@ julia> y[1] = "Old"
 "Old"
 
 julia> y
-4-element CategoricalArrays.CategoricalArray{Union{Nulls.Null, String},1,UInt32,String,Nulls.Null}:
+4-element CategoricalArrays.CategoricalArray{Union{Nulls.Null, String},1,UInt32}:
  "Old"   
  "Young" 
  "Middle"
  "Young" 
 
 julia> levels!(y, ["Young", "Middle"]; nullok=true)
-4-element CategoricalArrays.CategoricalArray{Union{Nulls.Null, String},1,UInt32,String,Nulls.Null}:
+4-element CategoricalArrays.CategoricalArray{Union{Nulls.Null, String},1,UInt32}:
  null    
  "Young" 
  "Middle"

--- a/src/array.jl
+++ b/src/array.jl
@@ -2,7 +2,7 @@
 
 using Nulls
 import Base: convert, copy, copy!, getindex, setindex!, similar, size,
-             unique, vcat, in
+             unique, vcat, in, summary
 
 # Used for keyword argument default value
 _isordered(x::AbstractCategoricalArray) = isordered(x)
@@ -698,3 +698,7 @@ function in(x::CategoricalValue, y::CategoricalArray{T, N, R}) where {T, N, R}
         return ref != 0 ? ref in y.refs : false
     end
 end
+
+# Override AbstractArray method to avoid printing useless type parameters
+summary(A::CategoricalArray{T, N, R}) where {T, N, R} =
+    string(Base.dims2string(size(A)), " $CategoricalArray{$T,$N,$R}")

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -468,4 +468,12 @@ ca5 = CategoricalArray([1 2; 3 4])
 @test ca1 != ca4
 @test ca1 != ca5
 
+# Test summary()
+@test summary(CategoricalArray([1, 2, 3])) ==
+    "3-element CategoricalArrays.CategoricalArray{$Int,1,UInt32}"
+# Ordering changed in Julia 0.7
+@test summary(CategoricalArray{Union{Int, Null}}([1 2 3])) in
+    ("1×3 CategoricalArrays.CategoricalArray{Union{Nulls.Null, $Int},2,UInt32}",
+     "1×3 CategoricalArrays.CategoricalArray{Union{$Int, Nulls.Null},2,UInt32}")
+
 end


### PR DESCRIPTION
The two last type parameters `V` and `U` are redundant and only exist for
technical reasons. Better not print them to keep the output readable.