### PR TITLE
Use isequal() to compare arrays containing nulls

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.6
 Compat 0.19.0
-Nulls 0.0.2
+Nulls 0.1.0

--- a/src/recode.jl
+++ b/src/recode.jl
@@ -1,11 +1,14 @@
+const ≅ = isequal
+
 """
     recode!(dest::AbstractArray, src::AbstractArray[, default::Any], pairs::Pair...)
 
 Fill `dest` with elements from `src`, replacing those matching a key of `pairs`
 with the corresponding value.
 
-For each `Pair` in `pairs`, if the element is equal to (according to `==`) or `in` the key
-(first item of the pair), then the corresponding value (second item) is copied to `dest`.
+For each `Pair` in `pairs`, if the element is equal to (according to [`isequal`](@ref))
+or [`in`](@ref) the key (first item of the pair), then the corresponding value
+(second item) is copied to `dest`.
 If the element matches no key and `default` is not provided or `nothing`, it is copied as-is;
 if `default` is specified, it is used in place of the original element.
 `dest` and `src` must be of the same length, but not necessarily of the same type.
@@ -34,7 +37,7 @@ function recode!(dest::AbstractArray{T}, src::AbstractArray, default::Any, pairs
 
         for j in 1:length(pairs)
             p = pairs[j]
-            if (!isa(p.first, Union{AbstractArray, Tuple}) && x == p.first) ||
+            if (!isa(p.first, Union{AbstractArray, Tuple}) && x ≅ p.first) ||
                (isa(p.first, Union{AbstractArray, Tuple}) && x in p.first)
                 dest[i] = p.second
                 @goto nextitem
@@ -84,7 +87,7 @@ function recode!(dest::CategoricalArray{T}, src::AbstractArray, default::Any, pa
 
         for j in 1:length(pairs)
             p = pairs[j]
-            if (!isa(p.first, Union{AbstractArray, Tuple}) && x == p.first) ||
+            if (!isa(p.first, Union{AbstractArray, Tuple}) && x ≅ p.first) ||
                (isa(p.first, Union{AbstractArray, Tuple}) && x in p.first)
                 drefs[i] = dupvals ? pairmap[j] : j
                 @goto nextitem
@@ -138,7 +141,8 @@ function recode!(dest::CategoricalArray{T}, src::CategoricalArray, default::Any,
         sizehint!(keptlevels, length(srclevels))
 
         for l in srclevels
-            if !(l in firsts || any(f -> isa(f, Union{AbstractArray, Tuple}) && l in f, firsts))
+            if !(any(x -> x ≅ l, firsts) ||
+                 any(f -> isa(f, Union{AbstractArray, Tuple}) && l in f, firsts))
                 try
                     push!(keptlevels, l)
                 catch err
@@ -181,7 +185,7 @@ function recode!(dest::CategoricalArray{T}, src::CategoricalArray, default::Any,
     @inbounds for (i, l) in enumerate(srcindex)
         for j in 1:length(pairs)
             p = pairs[j]
-            if (!isa(p.first, Union{AbstractArray, Tuple}) && l == p.first) ||
+            if (!isa(p.first, Union{AbstractArray, Tuple}) && l ≅ p.first) ||
                (isa(p.first, Union{AbstractArray, Tuple}) && l in p.first)
                 indexmap[i+1] = pairmap[j]
                 @goto nextitem
@@ -252,8 +256,9 @@ Return a copy of `a`, replacing elements matching a key of `pairs` with the corr
 The type of the array is chosen so that it can
 hold all recoded elements (but not necessarily original elements from `a`).
 
-For each `Pair` in `pairs`, if the element is equal to (according to `==`) or `in` the key
-(first item of the pair), then the corresponding value (second item) is used.
+For each `Pair` in `pairs`, if the element is equal to (according to [`isequal`](@ref))
+or [`in`](@ref) the key (first item of the pair), then the corresponding value
+(second item) is used.
 If the element matches no key and `default` is not provided or `nothing`, it is copied as-is;
 if `default` is specified, it is used in place of the original element.
 If an element matches more than one key, the first match is used.

--- a/src/value.jl
+++ b/src/value.jl
@@ -21,6 +21,12 @@ Base.promote_rule(::Type{CategoricalValue{S}}, ::Type{T}) where {S, T <: Abstrac
 Base.promote_rule(::Type{CategoricalValue{S, R}}, ::Type{T}) where {S, T <: AbstractString, R <: Integer} =
     promote_type(S, T)
 
+Base.promote_rule(::Type{CategoricalValue}, ::Type{Null}) = Union{CategoricalValue, Null}
+Base.promote_rule(::Type{CategoricalValue{S}}, ::Type{Null}) where {S} =
+    Union{CategoricalValue{S}, Null}
+Base.promote_rule(::Type{CategoricalValue{S, R}}, ::Type{Null}) where {S, R <: Integer} =
+    Union{CategoricalValue{S, R}, Null}
+
 Base.convert(::Type{Nullable{S}}, x::CategoricalValue{Nullable}) where {S} =
     convert(Nullable{S}, index(x.pool)[x.level])
 Base.convert(::Type{Nullable}, x::CategoricalValue{S}) where {S} = convert(Nullable{S}, x)

--- a/src/value.jl
+++ b/src/value.jl
@@ -66,6 +66,9 @@ Base.repr(x::CategoricalValue) = repr(get(x))
     end
 end
 
+Base.:(==)(::CategoricalValue, ::Null) = null
+Base.:(==)(::Null, ::CategoricalValue) = null
+
 # To fix ambiguities with Base
 Base.:(==)(x::CategoricalValue, y::WeakRef) = index(x.pool)[x.level] == y
 Base.:(==)(x::WeakRef, y::CategoricalValue) = y == x
@@ -86,6 +89,9 @@ end
 
 Base.isequal(x::CategoricalValue, y::Any) = isequal(index(x.pool)[x.level], y)
 Base.isequal(x::Any, y::CategoricalValue) = isequal(y, x)
+
+Base.isequal(::CategoricalValue, ::Null) = false
+Base.isequal(::Null, ::CategoricalValue) = false
 
 Base.in(x::CategoricalValue, y::Any) = index(x.pool)[x.level] in y
 Base.in(x::CategoricalValue, y::Range{T}) where {T<:Integer} = index(x.pool)[x.level] in y

--- a/test/05_convert.jl
+++ b/test/05_convert.jl
@@ -1,6 +1,7 @@
 module TestConvert
     using Base.Test
     using CategoricalArrays
+    using Nulls
 
     pool = CategoricalPool([1, 2, 3])
     @test convert(CategoricalPool{Int, CategoricalArrays.DefaultRefType}, pool) === pool
@@ -38,6 +39,11 @@ module TestConvert
     @test promote(1, v1) === (1, 1)
     @test promote(1.0, v1) === (1.0, 1.0)
     @test promote(0x1, v1) === (1, 1)
+
+    @test promote_type(CategoricalValue, Null) === Union{CategoricalValue, Null}
+    @test promote_type(CategoricalValue{Int}, Null) === Union{CategoricalValue{Int}, Null}
+    @test promote_type(CategoricalValue{Int, UInt32}, Null) ===
+        Union{CategoricalValue{Int, UInt32}, Null}
 
     # Test that ordered property is preserved
     pool = CategoricalPool([1, 2, 3], true)

--- a/test/08_equality.jl
+++ b/test/08_equality.jl
@@ -1,6 +1,7 @@
 module TestEquality
     using Base.Test
     using CategoricalArrays
+    using Nulls
 
     pool1 = CategoricalPool([1, 2, 3])
     pool2 = CategoricalPool([2.0, 1.0, 3.0])
@@ -142,6 +143,17 @@ module TestEquality
     @test (ov2b == nv2a) === false
     @test (ov2b == nv1b) === false
     @test (ov2b == nv2b) === true
+
+    # Check non-equality with null
+    @test isnull(nv1a == null)
+    @test isnull(ov1a == null)
+    @test isnull(null == nv1a)
+    @test isnull(null == ov1a)
+
+    @test isequal(nv1a, null) == false
+    @test isequal(ov1a, null) == false
+    @test isequal(null, nv1a) == false
+    @test isequal(null, ov1a) == false
 
     # Check in()
     pool = CategoricalPool([5, 1, 3])

--- a/test/10_isless.jl
+++ b/test/10_isless.jl
@@ -1,6 +1,7 @@
 module TestIsLess
     using Base.Test
     using CategoricalArrays
+    using Nulls
 
     pool = CategoricalPool([1, 2, 3])
 
@@ -58,6 +59,18 @@ module TestIsLess
     @test isless(v3, v2) === false
     @test isless(v3, v3) === false
 
+    # Check comparison with null
+    @test isless(v1, null)
+    @test !isless(null, v1)
+    @test isnull(v1 < null)
+    @test isnull(v1 <= null)
+    @test isnull(v1 > null)
+    @test isnull(v1 >= null)
+    @test isnull(null < v1)
+    @test isnull(null <= v1)
+    @test isnull(null > v1)
+    @test isnull(null >= v1)
+
     @test ordered!(pool, true) === pool
     @test isordered(pool) === true
 
@@ -110,6 +123,18 @@ module TestIsLess
     @test isless(v3, v1) === false
     @test isless(v3, v2) === false
     @test isless(v3, v3) === false
+
+    # Check comparison with null
+    @test isless(v1, null)
+    @test !isless(null, v1)
+    @test isnull(v1 < null)
+    @test isnull(v1 <= null)
+    @test isnull(v1 > null)
+    @test isnull(v1 >= null)
+    @test isnull(null < v1)
+    @test isnull(null <= v1)
+    @test isnull(null > v1)
+    @test isnull(null >= v1)
 
     @test CategoricalArrays.levels!(pool, [2, 3, 1]) === pool
     @test levels(pool) == [2, 3, 1]
@@ -275,7 +300,6 @@ module TestIsLess
     @test isless(v3, v1) === false
     @test isless(v3, v2) === false
     @test isless(v3, v3) === false
-
 
     # Test that ordering comparisons between pools fail
     ordered!(pool, true)

--- a/test/12_nullablearray.jl
+++ b/test/12_nullablearray.jl
@@ -5,6 +5,8 @@ using Nulls
 using CategoricalArrays
 using CategoricalArrays: DefaultRefType
 
+const ≅ = isequal
+
 for ordered in (false, true)
     for R in (CategoricalArrays.DefaultRefType, UInt8, UInt, Int8, Int)
         # Vector with no null values
@@ -195,26 +197,26 @@ for ordered in (false, true)
 
             push!(x, "e")
             @test length(x) == 4
-            @test x == ["c", null, null, "e"]
+            @test x ≅ ["c", null, null, "e"]
             @test levels(x) == ["e", "c"]
 
             push!(x, "zz")
             @test length(x) == 5
-            @test x == ["c", null, null, "e", "zz"]
+            @test x ≅ ["c", null, null, "e", "zz"]
             @test levels(x) == ["e", "c", "zz"]
 
             push!(x, x[1])
             @test length(x) == 6
-            @test x == ["c", null, null, "e", "zz", "c"]
+            @test x ≅ ["c", null, null, "e", "zz", "c"]
             @test levels(x) == ["e", "c", "zz"]
 
             push!(x, null)
             @test length(x) == 7
-            @test x == ["c", null, null, "e", "zz", "c", null]
+            @test x ≅ ["c", null, null, "e", "zz", "c", null]
             @test levels(x) == ["e", "c", "zz"]
 
             append!(x, x)
-            @test x == ["c", null, null, "e", "zz", "c", null, "c", null, null, "e", "zz", "c", null]
+            @test x ≅ ["c", null, null, "e", "zz", "c", null, "c", null, null, "e", "zz", "c", null]
             @test levels(x) == ["e", "c", "zz"]
             @test isordered(x) === false
             @test length(x) == 14
@@ -225,7 +227,7 @@ for ordered in (false, true)
             @test length(x) == 17
             @test isordered(x) === false
             @test levels(x) == ["e", "c", "zz", "x", "y", "z"]
-            @test x == ["c", null, null, "e", "zz", "c", null, "c", null, null, "e", "zz", "c", null, "z", "y", "x"]
+            @test x ≅ ["c", null, null, "e", "zz", "c", null, "c", null, null, "e", "zz", "c", null, "z", "y", "x"]
 
             empty!(x)
             @test isordered(x) === false
@@ -238,7 +240,7 @@ for ordered in (false, true)
         let a = ["a", "b", null],
             x = CategoricalVector{Union{String, Null}, R}(a, ordered=ordered)
 
-            @test x == a
+            @test x ≅ a
             @test levels(x) == filter(x->!isnull(x), unique(a))
             @test size(x) === (3,)
             @test length(x) === 3
@@ -247,46 +249,46 @@ for ordered in (false, true)
             @test convert(CategoricalArray{Union{String, Null}}, x) === x
             @test convert(CategoricalArray{Union{String, Null}, 1}, x) === x
             @test convert(CategoricalArray{Union{String, Null}, 1, R}, x) === x
-            @test convert(CategoricalArray{Union{String, Null}, 1, DefaultRefType}, x) == x
-            @test convert(CategoricalArray{Union{String, Null}, 1, UInt8}, x) == x
+            @test convert(CategoricalArray{Union{String, Null}, 1, DefaultRefType}, x) ≅ x
+            @test convert(CategoricalArray{Union{String, Null}, 1, UInt8}, x) ≅ x
 
             @test convert(CategoricalVector, x) === x
             @test convert(CategoricalVector{Union{String, Null}}, x) === x
             @test convert(CategoricalVector{Union{String, Null}, R}, x) === x
-            @test convert(CategoricalVector{Union{String, Null}, DefaultRefType}, x) == x
-            @test convert(CategoricalVector{Union{String, Null}, UInt8}, x) == x
+            @test convert(CategoricalVector{Union{String, Null}, DefaultRefType}, x) ≅ x
+            @test convert(CategoricalVector{Union{String, Null}, UInt8}, x) ≅ x
 
-            @test convert(CategoricalArray, a) == x
-            @test convert(CategoricalArray{Union{String, Null}}, a) == x
-            @test convert(CategoricalArray{Union{String, Null}, 1}, a) == x
-            @test convert(CategoricalArray{Union{String, Null}, 1, R}, a) == x
-            @test convert(CategoricalArray{Union{String, Null}, 1, DefaultRefType}, a) == x
-            @test convert(CategoricalArray{Union{String, Null}, 1, UInt8}, a) == x
+            @test convert(CategoricalArray, a) ≅ x
+            @test convert(CategoricalArray{Union{String, Null}}, a) ≅ x
+            @test convert(CategoricalArray{Union{String, Null}, 1}, a) ≅ x
+            @test convert(CategoricalArray{Union{String, Null}, 1, R}, a) ≅ x
+            @test convert(CategoricalArray{Union{String, Null}, 1, DefaultRefType}, a) ≅ x
+            @test convert(CategoricalArray{Union{String, Null}, 1, UInt8}, a) ≅ x
 
-            @test convert(CategoricalVector, a) == x
-            @test convert(CategoricalVector{Union{String, Null}}, a) == x
-            @test convert(CategoricalVector{Union{String, Null}, R}, a) == x
-            @test convert(CategoricalVector{Union{String, Null}, DefaultRefType}, a) == x
-            @test convert(CategoricalVector{Union{String, Null}, UInt8}, a) == x
+            @test convert(CategoricalVector, a) ≅ x
+            @test convert(CategoricalVector{Union{String, Null}}, a) ≅ x
+            @test convert(CategoricalVector{Union{String, Null}, R}, a) ≅ x
+            @test convert(CategoricalVector{Union{String, Null}, DefaultRefType}, a) ≅ x
+            @test convert(CategoricalVector{Union{String, Null}, UInt8}, a) ≅ x
 
-            @test CategoricalArray{Union{String, Null}}(a, ordered=ordered) == x
-            @test CategoricalArray{Union{String, Null}, 1}(a, ordered=ordered) == x
-            @test CategoricalArray{Union{String, Null}, 1, R}(a, ordered=ordered) == x
-            @test CategoricalArray{Union{String, Null}, 1, DefaultRefType}(a, ordered=ordered) == x
-            @test CategoricalArray{Union{String, Null}, 1, UInt8}(a, ordered=ordered) == x
+            @test CategoricalArray{Union{String, Null}}(a, ordered=ordered) ≅ x
+            @test CategoricalArray{Union{String, Null}, 1}(a, ordered=ordered) ≅ x
+            @test CategoricalArray{Union{String, Null}, 1, R}(a, ordered=ordered) ≅ x
+            @test CategoricalArray{Union{String, Null}, 1, DefaultRefType}(a, ordered=ordered) ≅ x
+            @test CategoricalArray{Union{String, Null}, 1, UInt8}(a, ordered=ordered) ≅ x
 
-            @test CategoricalVector(a, ordered=ordered) == x
-            @test CategoricalVector{Union{String, Null}}(a, ordered=ordered) == x
-            @test CategoricalVector{Union{String, Null}, R}(a, ordered=ordered) == x
-            @test CategoricalVector{Union{String, Null}, DefaultRefType}(a, ordered=ordered) == x
-            @test CategoricalVector{Union{String, Null}, UInt8}(a, ordered=ordered) == x
+            @test CategoricalVector(a, ordered=ordered) ≅ x
+            @test CategoricalVector{Union{String, Null}}(a, ordered=ordered) ≅ x
+            @test CategoricalVector{Union{String, Null}, R}(a, ordered=ordered) ≅ x
+            @test CategoricalVector{Union{String, Null}, DefaultRefType}(a, ordered=ordered) ≅ x
+            @test CategoricalVector{Union{String, Null}, UInt8}(a, ordered=ordered) ≅ x
 
             for (y, R1, R2, comp) in ((a, DefaultRefType, UInt8, true),
                                       (a, DefaultRefType, DefaultRefType, false),
                                       (x, R, UInt8, true),
                                       (x, R, R, false))
                 x2 = categorical(y, ordered=ordered)
-                @test x2 == y
+                @test x2 ≅ y
                 if eltype(y) >: Null
                     @test isa(x2, CategoricalVector{Union{String, Null}, R1})
                 else
@@ -295,7 +297,7 @@ for ordered in (false, true)
                 @test isordered(x2) === ordered
 
                 x2 = categorical(y, comp, ordered=ordered)
-                @test x2 == y
+                @test x2 ≅ y
                 if eltype(y) >: Null
                     @test isa(x2, CategoricalVector{Union{String, Null}, R2})
                 else
@@ -305,12 +307,12 @@ for ordered in (false, true)
             end
 
             x2 = compress(x)
-            @test x2 == x
+            @test x2 ≅ x
             @test isa(x2, CategoricalVector{Union{String, Null}, UInt8})
             @test levels(x2) == levels(x)
 
             x2 = copy(x)
-            @test x2 == x
+            @test x2 ≅ x
             @test typeof(x2) === typeof(x)
             @test levels(x2) == levels(x)
 
@@ -321,7 +323,7 @@ for ordered in (false, true)
 
             x2 = x[:]
             @test typeof(x2) === typeof(x)
-            @test x2 == x
+            @test x2 ≅ x
             @test x2 !== x
             @test levels(x2) == levels(x)
             @test levels(x2) !== levels(x)
@@ -329,7 +331,7 @@ for ordered in (false, true)
 
             x2 = x[2:3]
             @test typeof(x2) === typeof(x)
-            @test x2 == ["b", null]
+            @test x2 ≅ ["b", null]
             @test levels(x2) == levels(x)
             @test levels(x2) !== levels(x)
             @test isordered(x2) == isordered(x)
@@ -690,7 +692,7 @@ for ordered in (false, true)
         let a = ["a" null "c"; "b" "a" null]
             x = CategoricalMatrix{Union{String, Null}, R}(a, ordered=ordered)
 
-            @test x == a
+            @test x ≅ a
             @test isordered(x) === ordered
             @test levels(x) == filter(x->!isnull(x), unique(a))
             @test size(x) === (2, 3)
@@ -700,63 +702,63 @@ for ordered in (false, true)
             @test convert(CategoricalArray{Union{String, Null}}, x) === x
             @test convert(CategoricalArray{Union{String, Null}, 2}, x) === x
             @test convert(CategoricalArray{Union{String, Null}, 2, R}, x) === x
-            @test convert(CategoricalArray{Union{String, Null}, 2, DefaultRefType}, x) == x
-            @test convert(CategoricalArray{Union{String, Null}, 2, UInt8}, x) == x
+            @test convert(CategoricalArray{Union{String, Null}, 2, DefaultRefType}, x) ≅ x
+            @test convert(CategoricalArray{Union{String, Null}, 2, UInt8}, x) ≅ x
 
             @test convert(CategoricalMatrix, x) === x
             @test convert(CategoricalMatrix{Union{String, Null}}, x) === x
             @test convert(CategoricalMatrix{Union{String, Null}, R}, x) === x
-            @test convert(CategoricalMatrix{Union{String, Null}, DefaultRefType}, x) == x
-            @test convert(CategoricalMatrix{Union{String, Null}, UInt8}, x) == x
+            @test convert(CategoricalMatrix{Union{String, Null}, DefaultRefType}, x) ≅ x
+            @test convert(CategoricalMatrix{Union{String, Null}, UInt8}, x) ≅ x
 
-            @test convert(CategoricalArray, a) == x
-            @test convert(CategoricalArray{Union{String, Null}}, a) == x
-            @test convert(CategoricalArray{Union{String, Null}, 2, R}, a) == x
-            @test convert(CategoricalArray{Union{String, Null}, 2, DefaultRefType}, a) == x
-            @test convert(CategoricalArray{Union{String, Null}, 2, UInt8}, a) == x
+            @test convert(CategoricalArray, a) ≅ x
+            @test convert(CategoricalArray{Union{String, Null}}, a) ≅ x
+            @test convert(CategoricalArray{Union{String, Null}, 2, R}, a) ≅ x
+            @test convert(CategoricalArray{Union{String, Null}, 2, DefaultRefType}, a) ≅ x
+            @test convert(CategoricalArray{Union{String, Null}, 2, UInt8}, a) ≅ x
 
-            @test convert(CategoricalMatrix, a) == x
-            @test convert(CategoricalMatrix{Union{String, Null}}, a) == x
-            @test convert(CategoricalMatrix{Union{String, Null}, R}, a) == x
-            @test convert(CategoricalMatrix{Union{String, Null}, DefaultRefType}, a) == x
-            @test convert(CategoricalMatrix{Union{String, Null}, UInt8}, a) == x
+            @test convert(CategoricalMatrix, a) ≅ x
+            @test convert(CategoricalMatrix{Union{String, Null}}, a) ≅ x
+            @test convert(CategoricalMatrix{Union{String, Null}, R}, a) ≅ x
+            @test convert(CategoricalMatrix{Union{String, Null}, DefaultRefType}, a) ≅ x
+            @test convert(CategoricalMatrix{Union{String, Null}, UInt8}, a) ≅ x
 
-            @test CategoricalArray{Union{String, Null}}(a, ordered=ordered) == x
-            @test CategoricalArray{Union{String, Null}, 2}(a, ordered=ordered) == x
-            @test CategoricalArray{Union{String, Null}, 2}(a, ordered=ordered) == x
-            @test CategoricalArray{Union{String, Null}, 2, R}(a, ordered=ordered) == x
-            @test CategoricalArray{Union{String, Null}, 2, DefaultRefType}(a, ordered=ordered) == x
-            @test CategoricalArray{Union{String, Null}, 2, UInt8}(a, ordered=ordered) == x
+            @test CategoricalArray{Union{String, Null}}(a, ordered=ordered) ≅ x
+            @test CategoricalArray{Union{String, Null}, 2}(a, ordered=ordered) ≅ x
+            @test CategoricalArray{Union{String, Null}, 2}(a, ordered=ordered) ≅ x
+            @test CategoricalArray{Union{String, Null}, 2, R}(a, ordered=ordered) ≅ x
+            @test CategoricalArray{Union{String, Null}, 2, DefaultRefType}(a, ordered=ordered) ≅ x
+            @test CategoricalArray{Union{String, Null}, 2, UInt8}(a, ordered=ordered) ≅ x
 
-            @test CategoricalMatrix(a, ordered=ordered) == x
-            @test CategoricalMatrix{Union{String, Null}}(a, ordered=ordered) == x
-            @test CategoricalMatrix{Union{String, Null}, R}(a, ordered=ordered) == x
-            @test CategoricalMatrix{Union{String, Null}, DefaultRefType}(a, ordered=ordered) == x
-            @test CategoricalMatrix{Union{String, Null}, UInt8}(a, ordered=ordered) == x
+            @test CategoricalMatrix(a, ordered=ordered) ≅ x
+            @test CategoricalMatrix{Union{String, Null}}(a, ordered=ordered) ≅ x
+            @test CategoricalMatrix{Union{String, Null}, R}(a, ordered=ordered) ≅ x
+            @test CategoricalMatrix{Union{String, Null}, DefaultRefType}(a, ordered=ordered) ≅ x
+            @test CategoricalMatrix{Union{String, Null}, UInt8}(a, ordered=ordered) ≅ x
 
             for (y, R1, R2, comp) in ((a, DefaultRefType, UInt8, true),
                                       (a, DefaultRefType, DefaultRefType, false),
                                       (x, R, UInt8, true),
                                       (x, R, R, false))
                 x2 = categorical(y, ordered=ordered)
-                @test x2 == y
+                @test x2 ≅ y
                 @test isa(x2, CategoricalMatrix{Union{String, Null}, R1})
                 @test isordered(x2) === ordered
 
                 x2 = categorical(y, comp, ordered=ordered)
-                @test x2 == y
+                @test x2 ≅ y
                 @test isa(x2, CategoricalMatrix{Union{String, Null}, R2})
                 @test isordered(x2) === ordered
             end
 
             x2 = compress(x)
-            @test x2 == x
+            @test x2 ≅ x
             @test isa(x2, CategoricalMatrix{Union{String, Null}, UInt8})
             @test isordered(x2) === isordered(x)
             @test levels(x2) == levels(x)
 
             x2 = copy(x)
-            @test x2 == x
+            @test x2 ≅ x
             @test typeof(x2) === typeof(x)
             @test isordered(x2) === isordered(x)
             @test levels(x2) == levels(x)
@@ -781,21 +783,21 @@ for ordered in (false, true)
 
             x2 = x[1:2,:]
             @test typeof(x2) === typeof(x)
-            @test x2 == x
+            @test x2 ≅ x
             @test levels(x2) == levels(x)
             @test levels(x2) !== levels(x)
             @test isordered(x2) == isordered(x)
 
             x2 = x[:,[1, 3]]
             @test typeof(x2) === typeof(x)
-            @test x2 == ["a" "c"; "b" null]
+            @test x2 ≅ ["a" "c"; "b" null]
             @test levels(x2) == levels(x)
             @test levels(x2) !== levels(x)
             @test isordered(x2) == isordered(x)
 
             x2 = x[1:1,2]
             @test isa(x2, CategoricalVector{Union{String, Null}, R})
-            @test x2 == [null]
+            @test x2 ≅ [null]
             @test levels(x2) == levels(x)
             @test levels(x2) !== levels(x)
             @test isordered(x2) == isordered(x)
@@ -904,13 +906,13 @@ for ordered in (false, true)
             @test levels(x) == []
 
             x2 = compress(x)
-            @test x2 == x
+            @test x2 ≅ x
             @test isa(x2, CategoricalArray{Union{String, Null}, ndims(x), UInt8})
             @test isordered(x2) === isordered(x)
             @test levels(x2) == []
 
             x2 = copy(x)
-            @test x2 == x
+            @test x2 ≅ x
             @test typeof(x2) === typeof(x)
             @test isordered(x2) === isordered(x)
             @test levels(x2) == []
@@ -942,7 +944,7 @@ end
 ca1 = CategoricalArray(["a", null])
 ca2 = CategoricalArray([null, "a"])
 r = vcat(ca1, ca2)
-@test r == CategoricalArray(["a", null, null, "a"])
+@test r ≅ CategoricalArray(["a", null, null, "a"])
 @test levels(r) == ["a"]
 @test !isordered(r)
 ordered!(ca1,true)
@@ -956,7 +958,7 @@ ordered!(ca1,false)
 ca1 = CategoricalArray(["a", null])
 ca2 = CategoricalArray([null, null])
 r = vcat(ca1, ca2)
-@test r == ["a", null, null, null]
+@test r ≅ ["a", null, null, null]
 @test levels(r) == ["a"]
 @test !isordered(r)
 
@@ -972,7 +974,7 @@ r = vcat(ca1, ca2)
 ca1 = CategoricalArray(0)
 ca2 = CategoricalArray([null, "b"])
 r = vcat(ca1, ca2)
-@test r == [null, "b"]
+@test r ≅ [null, "b"]
 @test levels(r) == ["b"]
 @test !isordered(r)
 
@@ -980,7 +982,7 @@ r = vcat(ca1, ca2)
 ca1 = CategoricalArray(0)
 ca2 = CategoricalArray([null, null])
 r = vcat(ca1, ca2)
-@test r == [null, null]
+@test r ≅ [null, null]
 @test levels(r) == String[]
 @test !isordered(r)
 
@@ -994,7 +996,7 @@ ca2 = CategoricalArray{Union{String, Null}}(2)
 ordered!(ca1, true)
 @test isempty(levels(ca2))
 r = vcat(ca1, ca2)
-@test r == ["a", null, null, null]
+@test r ≅ ["a", null, null, null]
 @test isordered(r)
 
 
@@ -1002,23 +1004,23 @@ r = vcat(ca1, ca2)
 
 x = CategoricalArray(["Old", "Young", "Middle", null, "Young"])
 @test levels(x) == ["Middle", "Old", "Young"]
-@test unique(x) == ["Middle", "Old", "Young", null]
+@test unique(x) ≅ ["Middle", "Old", "Young", null]
 @test levels!(x, ["Young", "Middle", "Old"]) === x
 @test levels(x) == ["Young", "Middle", "Old"]
-@test unique(x) == ["Young", "Middle", "Old", null]
+@test unique(x) ≅ ["Young", "Middle", "Old", null]
 @test levels!(x, ["Young", "Middle", "Old", "Unused"]) === x
 @test levels(x) == ["Young", "Middle", "Old", "Unused"]
-@test unique(x) == ["Young", "Middle", "Old", null]
+@test unique(x) ≅ ["Young", "Middle", "Old", null]
 @test levels!(x, ["Unused1", "Young", "Middle", "Old", "Unused2"]) === x
 @test levels(x) == ["Unused1", "Young", "Middle", "Old", "Unused2"]
-@test unique(x) == ["Young", "Middle", "Old", null]
+@test unique(x) ≅["Young", "Middle", "Old", null]
 
 x = CategoricalArray((Union{String, Null})[null])
 @test isa(levels(x), Vector{String}) && isempty(levels(x))
-@test unique(x) == [null]
+@test unique(x) ≅ [null]
 @test levels!(x, ["Young", "Middle", "Old"]) === x
 @test levels(x) == ["Young", "Middle", "Old"]
-@test unique(x) == [null]
+@test unique(x) ≅ [null]
 
 # To test short-circuit after 1000 elements
 x = CategoricalArray{Union{Int, Null}}(repeat(1:1500, inner=10))
@@ -1027,7 +1029,7 @@ x = CategoricalArray{Union{Int, Null}}(repeat(1:1500, inner=10))
 @test levels!(x, [1600:-1:1; 2000]) === x
 x[3] = null
 @test levels(x) == [1600:-1:1; 2000]
-@test unique(x) == [1500:-1:3; 2; 1; null]
+@test unique(x) ≅ [1500:-1:3; 2; 1; null]
 
 # in
 x = CategoricalArray{Int}(repeat(1:1500, inner=10))

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -455,21 +455,55 @@ for T in (Int, Union{Int, Null})
 end
 
 # Test ==
-ca1 = CategoricalArray([1, 2, 3])
-ca2 = CategoricalArray{Union{Int, Null}}([1, 2, 3])
-ca3 = CategoricalArray([1, 2, null])
-ca4 = CategoricalArray([4, 3, 2])
-ca5 = CategoricalArray([1 2; 3 4])
+a1 = [1, 2, 3]
+a2 = Union{Int, Null}[1, 2, 3]
+a3 = [1, 2, null]
+a4 = [4, 3, 2]
+a5 = [1 2; 3 4]
+ca1 = CategoricalArray(a1)
+ca2 = CategoricalArray{Union{Int, Null}}(a2)
+ca2b = CategoricalArray{Union{Int, Null}, 1, UInt32}(ca2.refs, ca2.pool)
+ca3 = CategoricalArray(a3)
+ca3b = CategoricalArray{Union{Int, Null}, 1, UInt32}(ca3.refs, ca2.pool)
+ca4 = CategoricalArray(a4)
+ca5 = CategoricalArray(a5)
 
-@test ca1 == copy(ca1)
-@test ca2 == copy(ca2)
-@test ca3 ≅ copy(ca3)
-@test ca4 == copy(ca4)
-@test ca5 == copy(ca5)
-@test ca1 == ca2
-@test ca1 ≇ ca3
+@test ca1 == copy(ca1) == a1
+@test ca2 == copy(ca2) == a2
+@test isnull(ca3 == copy(ca3)) && isnull(ca3 == ca3b) && isnull(ca3 == a3)
+@test ca4 == copy(ca4) == a4
+@test ca5 == copy(ca5) == a5
+@test ca1 == ca2 == a2
+@test isnull(ca1 != ca3) && isnull(ca1 != a3)
 @test ca1 != ca4
+@test ca1 != a4
+@test a1 != ca4
 @test ca1 != ca5
+@test ca1 != a5
+@test a1 != ca5
+@test ca3 != ca4
+@test ca3 != a4
+@test a3 != ca4
+@test isnull(ca2b != ca3b)
+
+# Test isequal
+@test ca1 ≅ copy(ca1) ≅ a1
+@test ca2 ≅ copy(ca2) ≅ a2
+@test ca3 ≅ copy(ca3) ≅ ca3b ≅ a3
+@test ca4 ≅ copy(ca4) ≅ a4
+@test ca5 ≅ copy(ca5) ≅ a5
+@test ca1 ≅ ca2 ≅ a2
+@test ca1 ≇ ca3 && ca1 ≇ a3
+@test ca1 ≇ ca4
+@test ca1 ≇ a4
+@test a1 ≇ ca4
+@test ca1 ≇ ca5
+@test ca1 ≇ a5
+@test a1 ≇ ca5
+@test ca3 ≇ ca4
+@test ca3 ≇ a4
+@test a3 ≇ ca4
+@test ca2b ≇ ca3b
 
 # Test summary()
 @test summary(CategoricalArray([1, 2, 3])) ==

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -5,6 +5,9 @@ using CategoricalArrays
 using Nulls
 using CategoricalArrays: DefaultRefType, index
 
+const ≅ = isequal
+const ≇ = !isequal
+
 # Test that mergelevels handles mutually compatible orderings
 @test CategoricalArrays.mergelevels(true, [6, 2, 4, 8], [2, 3, 5, 4], [2, 4, 8]) ==
     ([6, 2, 3, 5, 4, 8], true)
@@ -164,25 +167,25 @@ for T in (Union{}, Null)
         y[3] = a[2] = null
     end
     @test copy!(x, 1, y, 2) === x
-    @test x == a
+    @test x ≅ a
     @test levels(x) == ["Young", "Middle", "Old", "X", "Y", "Z"]
     @test !isordered(x)
 
     # Test that no corruption happens in case of bounds error
     @test_throws BoundsError copy!(x, 10, y, 2)
-    @test x == a
+    @test x ≅ a
     @test_throws BoundsError copy!(x, 1, y, 10)
-    @test x == a
+    @test x ≅ a
     @test_throws BoundsError copy!(x, 10, y, 20)
-    @test x == a
+    @test x ≅ a
     @test_throws BoundsError copy!(x, 10, y, 2)
-    @test x == a
+    @test x ≅ a
     @test_throws BoundsError copy!(x, 1, y, 2, 10)
-    @test x == a
+    @test x ≅ a
     @test_throws BoundsError copy!(x, 4, y, 1, 2)
-    @test x == a
+    @test x ≅ a
     @test_throws BoundsError copy!(x, 1, y, 4, 2)
-    @test x == a
+    @test x ≅ a
 
     # Test resize!()
     x = CategoricalArray{Union{T, String}}(["Old", "Young", "Middle", "Young"])
@@ -190,7 +193,7 @@ for T in (Union{}, Null)
     @test x == ["Old", "Young", "Middle"]
     @test resize!(x, 4) === x
     if T === Null
-        @test x == ["Old", "Young", "Middle", null]
+        @test x ≅ ["Old", "Young", "Middle", null]
     else
         @test x[1:3] == ["Old", "Young", "Middle"]
         @test !isassigned(x, 4)
@@ -318,7 +321,7 @@ for T in (Union{}, Null)
         x[3] = null
         y = reshape(x, 1, 4)
         @test isa(y, CategoricalArray{Union{T, String}, 2, CategoricalArrays.DefaultRefType})
-        @test y == ["Old" "Young" null "Young"]
+        @test y ≅ ["Old" "Young" null "Young"]
         @test levels(x) == levels(y)
         @test isordered(x)
     end
@@ -460,11 +463,11 @@ ca5 = CategoricalArray([1 2; 3 4])
 
 @test ca1 == copy(ca1)
 @test ca2 == copy(ca2)
-@test ca3 == copy(ca3)
+@test ca3 ≅ copy(ca3)
 @test ca4 == copy(ca4)
 @test ca5 == copy(ca5)
 @test ca1 == ca2
-@test ca1 != ca3
+@test ca1 ≇ ca3
 @test ca1 != ca4
 @test ca1 != ca5
 

--- a/test/15_extras.jl
+++ b/test/15_extras.jl
@@ -4,6 +4,8 @@ using Base.Test
 using CategoricalArrays
 using Nulls
 
+const ≅ = isequal
+
 # Test cut
 
 for T in (Union{}, Null)
@@ -30,7 +32,7 @@ for T in (Union{}, Null)
 
     if T === Null
         x = @inferred cut(Vector{Union{T, Int}}([2, 3, 5]), [2, 5], nullok=true)
-        @test x == ["[2, 5)", "[2, 5)", null]
+        @test x ≅ ["[2, 5)", "[2, 5)", null]
         @test isa(x, CategoricalVector{Union{String, T}})
         @test isordered(x)
         @test levels(x) == ["[2, 5)"]

--- a/test/16_recode.jl
+++ b/test/16_recode.jl
@@ -4,6 +4,7 @@ module TestRecode
     using CategoricalArrays: DefaultRefType
     using Nulls
 
+    const ≅ = isequal
 
     ## Test recode!, used by recode
 
@@ -128,7 +129,7 @@ module TestRecode
               CategoricalArray{Union{String, Null}}(size(x)), x)
         z = @inferred recode!(y, x, "a", "c"=>"b")
         @test y === z
-        @test y == ["a", null, "b", "a"]
+        @test y ≅ ["a", null, "b", "a"]
         if isa(y, CategoricalArray)
             @test levels(y) == ["b", "a"]
             @test !isordered(y)
@@ -141,7 +142,7 @@ module TestRecode
               CategoricalArray{Union{String, Null}}(size(x)), x)
         z = @inferred recode!(y, x, "c"=>"b")
         @test y === z
-        @test y == ["a", null, "b", "d"]
+        @test y ≅ ["a", null, "b", "d"]
         if isa(y, CategoricalArray)
             @test levels(y) == ["a", "d", "b"]
             @test !isordered(y)
@@ -300,7 +301,7 @@ module TestRecode
 
         # Recoding from Int to Union{Int, Null} with null default
         y = @inferred recode(x, null, 1=>100, 2:4=>0, [5; 9:10]=>-1)
-        @test y == [100, 0, 0, 0, -1, null, null, null, -1, -1]
+        @test y ≅ [100, 0, 0, 0, -1, null, null, null, -1, -1]
         if isa(x, CategoricalArray)
             @test isa(y, CategoricalVector{Union{Int, Null}, DefaultRefType})
             @test levels(y) == [100, 0, -1]
@@ -311,7 +312,7 @@ module TestRecode
 
         # Recoding from Int to Union{Int, Null} with null RHS
         y = @inferred recode(x, 1=>null, 2:4=>0, [5; 9:10]=>-1)
-        @test y == [null, 0, 0, 0, -1, 6, 7, 8, -1, -1]
+        @test y ≅ [null, 0, 0, 0, -1, 6, 7, 8, -1, -1]
         if isa(x, CategoricalArray)
             @test isa(y, CategoricalVector{Union{Int, Null}, DefaultRefType})
             @test levels(y) == [6, 7, 8, 0, -1]
@@ -437,7 +438,7 @@ module TestRecode
     x = CategoricalArray{Union{String, Null}}(["a", "b", "c", "d"])
     x[2] = null
     y = @inferred recode(x, "c"=>"b")
-    @test y == ["a", null, "b", "d"]
+    @test y ≅ ["a", null, "b", "d"]
     @test isa(y, CategoricalVector{Union{String, Null}, DefaultRefType})
     @test levels(y) == ["a", "b", "d"]
     @test !isordered(y)
@@ -446,7 +447,7 @@ module TestRecode
     x = CategoricalArray{Union{String, Null}}(["a", "b", "c", "d"])
     x[2] = null
     y = @inferred recode(x, "a", "c"=>"b")
-    @test y == ["a", null, "b", "a"]
+    @test y ≅ ["a", null, "b", "a"]
     @test isa(y, CategoricalVector{Union{String, Null}, DefaultRefType})
     @test levels(y) == ["b", "a"]
     @test !isordered(y)


### PR DESCRIPTION
This is needed to work with the next Nulls release, where `==` will return null in this case.

This is only the first part of the changes, the next one will have to introduce `==` methods for `CategoricalArray` to handle three-valued logic, similar to https://github.com/JuliaData/Nulls.jl/pull/37. EDIT: added a second commit.

The PR should probably add a requirement on the next Nulls release since the `==` methods it introduces wouldn't be consistent with those used by `null` in the current version of Nulls. EDIT: done.