### PR TITLE
Override Nulls.levels and reexport Nulls

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.6
 Compat 0.19.0
-Nulls 0.1.0
+Nulls 0.1.2

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.6
 Compat 0.19.0
 Nulls 0.1.2
+Reexport

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,6 +1,5 @@
 using PkgBenchmark
 using CategoricalArrays
-using Nulls
 
 @benchgroup "isequal(A, v::String)" begin
     function sumequals(A::AbstractArray, v::Any)

--- a/docs/src/using.md
+++ b/docs/src/using.md
@@ -129,8 +129,6 @@ The examples above assumed that the data contained no missing values. This is ge
 Let's adapt the example developed above to support missing values. Since there are no missing values in the input vector, we need to specify that the array should be able to hold either a `String` or `null`:
 
 ```jldoctest using
-julia> using Nulls
-
 julia> y = CategoricalArray{Union{Null, String}}(["Old", "Young", "Middle", "Young"], ordered=true)
 4-element CategoricalArrays.CategoricalArray{Union{Nulls.Null, String},1,UInt32}:
  "Old"   

--- a/src/CategoricalArrays.jl
+++ b/src/CategoricalArrays.jl
@@ -12,6 +12,8 @@ module CategoricalArrays
     export cut, recode, recode!
 
     using Compat
+    using Reexport
+    @reexport using Nulls
 
     include("typedefs.jl")
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -530,7 +530,7 @@ in the data (see [`droplevels!`](@ref)).
 As a special case, `null` is never included in the levels, even if
 the array contains missing values.
 """
-levels(A::CategoricalArray) = levels(A.pool)
+Nulls.levels(A::CategoricalArray) = levels(A.pool)
 
 """
     levels!(A::CategoricalArray, newlevels::Vector; nullok::Bool=false)

--- a/src/array.jl
+++ b/src/array.jl
@@ -1,6 +1,5 @@
 ## Code for CategoricalArray
 
-using Nulls
 import Base: convert, copy, copy!, getindex, setindex!, similar, size,
              unique, vcat, in, summary
 
@@ -526,9 +525,6 @@ end
 
 Return the levels of categorical array `A`. This may include levels which do not actually appear
 in the data (see [`droplevels!`](@ref)).
-
-As a special case, `null` is never included in the levels, even if
-the array contains missing values.
 """
 Nulls.levels(A::CategoricalArray) = levels(A.pool)
 

--- a/src/nullablearray.jl
+++ b/src/nullablearray.jl
@@ -1,5 +1,4 @@
 import Base: convert, getindex, setindex!, similar, in
-using Nulls
 
 ## Constructors and converters
 ## (special methods for AbstractArray{Union{T, Null}}, to avoid wrapping nulls inside CategoricalValues)

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -173,7 +173,7 @@ function levels!(pool::CategoricalPool{S, R, V}, newlevels::Vector) where {S, R,
 end
 
 index(pool::CategoricalPool) = pool.index
-levels(pool::CategoricalPool) = pool.levels
+Nulls.levels(pool::CategoricalPool) = pool.levels
 order(pool::CategoricalPool) = pool.order
 
 isordered(pool::CategoricalPool) = pool.ordered

--- a/src/subarray.jl
+++ b/src/subarray.jl
@@ -1,10 +1,7 @@
 # delegate methods for SubArrays to support view
 
-for f in [:levels, :isordered]
-    @eval begin
-        $f(sa::SubArray{T,N,P}) where {T,N,P<:CategoricalArray} = $f(parent(sa))
-    end
-end
+Nulls.levels(sa::SubArray{T,N,P}) where {T,N,P<:CategoricalArray} = levels(parent(sa))
+isordered(sa::SubArray{T,N,P}) where {T,N,P<:CategoricalArray} = isordered(parent(sa))
 
 function unique(sa::SubArray{T,N,P}) where {T,N,P<:CategoricalArray}
     A = parent(sa)

--- a/src/typedefs.jl
+++ b/src/typedefs.jl
@@ -1,5 +1,3 @@
-using Nulls
-
 const DefaultRefType = UInt32
 
 ## Pools

--- a/test/05_convert.jl
+++ b/test/05_convert.jl
@@ -1,7 +1,6 @@
 module TestConvert
     using Base.Test
     using CategoricalArrays
-    using Nulls
 
     pool = CategoricalPool([1, 2, 3])
     @test convert(CategoricalPool{Int, CategoricalArrays.DefaultRefType}, pool) === pool

--- a/test/08_equality.jl
+++ b/test/08_equality.jl
@@ -1,7 +1,6 @@
 module TestEquality
     using Base.Test
     using CategoricalArrays
-    using Nulls
 
     pool1 = CategoricalPool([1, 2, 3])
     pool2 = CategoricalPool([2.0, 1.0, 3.0])

--- a/test/10_isless.jl
+++ b/test/10_isless.jl
@@ -1,7 +1,6 @@
 module TestIsLess
     using Base.Test
     using CategoricalArrays
-    using Nulls
 
     pool = CategoricalPool([1, 2, 3])
 

--- a/test/12_nullablearray.jl
+++ b/test/12_nullablearray.jl
@@ -1,7 +1,6 @@
 module TestNullableArray
 
 using Base.Test
-using Nulls
 using CategoricalArrays
 using CategoricalArrays: DefaultRefType
 

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -2,7 +2,6 @@ module TestArrayCommon
 
 using Base.Test
 using CategoricalArrays
-using Nulls
 using CategoricalArrays: DefaultRefType, index
 
 const ≅ = isequal

--- a/test/14_view.jl
+++ b/test/14_view.jl
@@ -2,7 +2,6 @@ module TestView
 
 using Base.Test
 using CategoricalArrays
-using Nulls
 
 for T in (Union{}, Null)
     for order in (true, false)

--- a/test/15_extras.jl
+++ b/test/15_extras.jl
@@ -2,7 +2,6 @@ module TestExtras
 
 using Base.Test
 using CategoricalArrays
-using Nulls
 
 const ≅ = isequal
 

--- a/test/16_recode.jl
+++ b/test/16_recode.jl
@@ -2,7 +2,6 @@ module TestRecode
     using Base.Test
     using CategoricalArrays
     using CategoricalArrays: DefaultRefType
-    using Nulls
 
     const ≅ = isequal
 


### PR DESCRIPTION
The first commit is needed to avoid conflicts with the newly-defined `Nulls.levels`. The second is more convenient for users.