### PR TITLE
Allow arbitrary "categorical value" types

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
 julia 0.6
-Compat 0.19.0
 Nulls 0.1.2
 Reexport

--- a/src/CategoricalArrays.jl
+++ b/src/CategoricalArrays.jl
@@ -8,7 +8,6 @@ module CategoricalArrays
            NullableCategoricalArray, NullableCategoricalVector, NullableCategoricalMatrix
     export LevelsException
 
-    export catvalue#, iscatvalue
     export categorical, compress, decompress, droplevels!, levels, levels!, isordered, ordered!
     export cut, recode, recode!
 

--- a/src/CategoricalArrays.jl
+++ b/src/CategoricalArrays.jl
@@ -1,6 +1,6 @@
 __precompile__()
 module CategoricalArrays
-    export CategoricalPool, CategoricalValue
+    export CategoricalPool, CategoricalValue, CategoricalString
     export AbstractCategoricalArray, AbstractCategoricalVector, AbstractCategoricalMatrix,
            CategoricalArray, CategoricalVector, CategoricalMatrix
     export AbstractNullableCategoricalArray, AbstractNullableCategoricalVector,
@@ -8,7 +8,7 @@ module CategoricalArrays
            NullableCategoricalArray, NullableCategoricalVector, NullableCategoricalMatrix
     export LevelsException
 
-    export categorical, compress, decompress, droplevels!, levels, levels!, isordered, ordered!
+    export categorical, compress, decompress, droplevels!, levels, levels!, isordered, ordered!, iscatvalue
     export cut, recode, recode!
 
     using Compat

--- a/src/CategoricalArrays.jl
+++ b/src/CategoricalArrays.jl
@@ -8,7 +8,8 @@ module CategoricalArrays
            NullableCategoricalArray, NullableCategoricalVector, NullableCategoricalMatrix
     export LevelsException
 
-    export categorical, compress, decompress, droplevels!, levels, levels!, isordered, ordered!, iscatvalue
+    export catvalue#, iscatvalue
+    export categorical, compress, decompress, droplevels!, levels, levels!, isordered, ordered!
     export cut, recode, recode!
 
     using Compat

--- a/src/array.jl
+++ b/src/array.jl
@@ -504,7 +504,6 @@ catvaluetype(::Type{T}) where {T <: CategoricalArray} = Nulls.T(eltype(T))
 catvaluetype(A::CategoricalArray) = catvaluetype(typeof(A))
 
 leveltype(::Type{T}) where {T <: CategoricalArray} = leveltype(catvaluetype(T))
-leveltype(A::CategoricalArray) = leveltype(typeof(A))
 
 """
     levels(A::CategoricalArray)

--- a/src/array.jl
+++ b/src/array.jl
@@ -143,11 +143,6 @@ CategoricalArray{T}(m::Int, n::Int; ordered=false) where {T} =
 CategoricalArray{T}(m::Int, n::Int, o::Int; ordered=false) where {T} =
     CategoricalArray{T}((m, n, o), ordered=ordered)
 
-#(::Type{CategoricalArray{CategoricalValue, N}}){N}(dims::NTuple{N,Int}; ordered=false) =
-#   CategoricalArray{String, N}(dims, ordered=ordered)
-#(::Type{CategoricalArray{CategoricalValue}}){N}(dims::NTuple{N,Int}; ordered=false) =
-#   CategoricalArray{String, N}(dims, ordered=ordered)
-
 CategoricalVector(m::Integer; ordered=false) = CategoricalArray(m, ordered=ordered)
 CategoricalVector{T}(m::Int; ordered=false) where {T} =
     CategoricalArray{T}((m,), ordered=ordered)
@@ -228,12 +223,6 @@ convert(::Type{CategoricalArray{T, N}}, A::AbstractArray{S, N}) where {S, T, N} 
 convert(::Type{CategoricalArray{T}}, A::AbstractArray{S, N}) where {S, T, N} =
     convert(CategoricalArray{T, N}, A)
 convert(::Type{CategoricalArray}, A::AbstractArray{T, N}) where {T, N} =
-    convert(CategoricalArray{T, N}, A)
-
-# FIXME T=String would use wrong categorical value, also it's not extensible, where it's used?
-convert(::Type{CategoricalArray{CategoricalValue{T, R}, N}}, A::AbstractArray{T, N}) where {T, N, R} =
-    convert(CategoricalArray{T, N, R}, A)
-convert(::Type{CategoricalArray{CategoricalValue{T}, N}}, A::AbstractArray{T, N}) where {T, N} =
     convert(CategoricalArray{T, N}, A)
 
 convert(::Type{CategoricalVector{T}}, A::AbstractVector) where {T} =

--- a/src/array.jl
+++ b/src/array.jl
@@ -19,10 +19,6 @@ function reftype(sz::Int)
     end
 end
 
-unwrap_catvalue_type(::Type{<: CategoricalValue{T}}) where {T} = T
-unwrap_catvalue_type(::Type{Union{V, Null}}) where {T, V <: CategoricalValue{T}} = Union{T, Null}
-unwrap_catvalue_type(::Type{T}) where {T} = T
-
 """
     CategoricalArray{T}(dims::Dims; ordered::Bool=false)
     CategoricalArray{T}(dims::Int...; ordered::Bool=false)

--- a/src/array.jl
+++ b/src/array.jl
@@ -120,7 +120,7 @@ CategoricalArray(dims::Int...; ordered=false) =
     CategoricalArray{String}(dims, ordered=ordered)
 
 CategoricalArray{T, N, R}(dims::NTuple{N,Int}; ordered=false) where {T, N, R<:Integer} =
-    CategoricalArray{T, N, R}(zeros(R, dims), CategoricalPool{T, R}(ordered))
+    CategoricalArray{T, N}(zeros(R, dims), CategoricalPool{T, R}(ordered))
 CategoricalArray{T, N}(dims::NTuple{N,Int}; ordered=false) where {T, N} =
     CategoricalArray{T, N, reftype(T)}(dims, ordered=ordered)
 CategoricalArray{T}(dims::NTuple{N,Int}; ordered=false) where {T, N} =
@@ -146,7 +146,7 @@ CategoricalArray{T}(m::Int, n::Int, o::Int; ordered=false) where {T} =
 function CategoricalArray{T, N, R}(dims::NTuple{N,Int};
                                    ordered=false) where {T<:CatValue, N, R<:Integer}
     V = unwrap_catvalue_type(T)
-    CategoricalArray{V, N, R}(zeros(R, dims), CategoricalPool{V, R, T}(ordered))
+    CategoricalArray{V, N}(zeros(R, dims), CategoricalPool{V, R, T}(ordered))
 end
 
 CategoricalArray{T, N}(dims::NTuple{N,Int}; ordered=false) where {T<:CatValue, N} =
@@ -175,7 +175,7 @@ function CategoricalArray{T, N, R}(A::CategoricalArray{S, N, Q};
     V = unwrap_catvalue_type(T)
     res = convert(CategoricalArray{V, N, R}, A)
     if res.pool === A.pool # convert() only makes a copy when necessary
-        res = CategoricalArray{V, N, R}(res.refs, deepcopy(res.pool))
+        res = CategoricalArray{V, N}(res.refs, deepcopy(res.pool))
     end
     ordered!(res, ordered)
 end
@@ -284,7 +284,7 @@ function convert(::Type{CategoricalArray{T, N, R}}, A::CategoricalArray{S, N}) w
 
     pool = convert(CategoricalPool{unwrap_catvalue_type(U), R}, A.pool)
     refs = convert(Array{R, N}, A.refs)
-    CategoricalArray{unwrap_catvalue_type(T), N, R}(refs, pool)
+    CategoricalArray{unwrap_catvalue_type(T), N}(refs, pool)
 end
 convert(::Type{CategoricalArray{T, N}}, A::CategoricalArray{S, N, R}) where {S, T, N, R} =
     convert(CategoricalArray{T, N, R}, A)
@@ -500,7 +500,7 @@ function vcat(A::CategoricalArray...)
     R = reftype(T)
     refs = R[refsvec...;]
     pool = CategoricalPool(newlevels, ordered)
-    CategoricalArray{T, ndims(refs), R}(refs, pool)
+    CategoricalArray{T, ndims(refs)}(refs, pool)
 end
 
 @inline function getindex(A::CategoricalArray{T}, I...) where {T}
@@ -509,7 +509,7 @@ end
     @inbounds r = A.refs[I...]
 
     if isa(r, Array)
-        res = CategoricalArray{T, ndims(r), eltype(r)}(r, deepcopy(A.pool))
+        res = CategoricalArray{T, ndims(r)}(r, deepcopy(A.pool))
         return ordered!(res, isordered(A))
     else
         r > 0 || throw(UndefRefError())
@@ -663,9 +663,9 @@ end
 
 Base.empty!(A::CategoricalArray) = (empty!(A.refs); return A)
 
-function Base.reshape(A::CategoricalArray{T, N, R}, dims::Dims) where {T, N, R}
+function Base.reshape(A::CategoricalArray{T, N}, dims::Dims) where {T, N}
     x = reshape(A.refs, dims)
-    res = CategoricalArray{T, ndims(x), R}(x, A.pool)
+    res = CategoricalArray{T, ndims(x)}(x, A.pool)
     ordered!(res, isordered(res))
 end
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -115,7 +115,7 @@ CategoricalArray(dims::Int...; ordered=false) =
 
 function CategoricalArray{T, N, R}(dims::NTuple{N,Int};
                                    ordered=false) where {T, N, R}
-    C = catvalue_type(unwrap_catvalue_type(T), R)
+    C = catvalue_type(T, R)
     V = valtype(C)
     S = T >: Null ? Union{V, Null} : V
     CategoricalArray{S, N}(zeros(R, dims), CategoricalPool{V, R, C}(ordered))

--- a/src/array.jl
+++ b/src/array.jl
@@ -115,7 +115,7 @@ CategoricalArray(dims::Int...; ordered=false) =
 
 function CategoricalArray{T, N, R}(dims::NTuple{N,Int};
                                    ordered=false) where {T, N, R}
-    C = catvalue_type(T, R)
+    C = catvaluetype(T, R)
     V = valtype(C)
     S = T >: Null ? Union{V, Null} : V
     CategoricalArray{S, N}(zeros(R, dims), CategoricalPool{V, R, C}(ordered))
@@ -158,7 +158,7 @@ CategoricalMatrix{T}(m::Int, n::Int; ordered=false) where {T} =
 # so that ordered!() does not affect the original array
 function CategoricalArray{T, N, R}(A::CategoricalArray{S, N, Q};
                                    ordered=_isordered(A)) where {S, T, N, Q, R}
-    V = unwrap_catvalue_type(T)
+    V = unwrap_catvaluetype(T)
     res = convert(CategoricalArray{V, N, R}, A)
     if res.pool === A.pool # convert() only makes a copy when necessary
         res = CategoricalArray{V, N}(res.refs, deepcopy(res.pool))
@@ -167,7 +167,7 @@ function CategoricalArray{T, N, R}(A::CategoricalArray{S, N, Q};
 end
 
 function CategoricalArray{T, N, R}(A::AbstractArray; ordered=_isordered(A)) where {T, N, R}
-    V = unwrap_catvalue_type(T)
+    V = unwrap_catvaluetype(T)
     ordered!(convert(CategoricalArray{V, N, R}, A), ordered)
 end
 
@@ -263,9 +263,9 @@ function convert(::Type{CategoricalArray{T, N, R}}, A::CategoricalArray{S, N}) w
         S >: Null && any(iszero, A.refs) && throw(NullException())
     end
 
-    pool = convert(CategoricalPool{unwrap_catvalue_type(U), R}, A.pool)
+    pool = convert(CategoricalPool{unwrap_catvaluetype(U), R}, A.pool)
     refs = convert(Array{R, N}, A.refs)
-    CategoricalArray{unwrap_catvalue_type(T), N}(refs, pool)
+    CategoricalArray{unwrap_catvaluetype(T), N}(refs, pool)
 end
 convert(::Type{CategoricalArray{T, N}}, A::CategoricalArray{S, N, R}) where {S, T, N, R} =
     convert(CategoricalArray{T, N, R}, A)

--- a/src/array.jl
+++ b/src/array.jl
@@ -19,6 +19,9 @@ function reftype(sz::Int)
     end
 end
 
+reftype(::Type{<:CategoricalArray{T, N, R}}) where {T, N, R} = R
+reftype(A::T) where {T <: CategoricalArray} = reftype(T)
+
 """
     CategoricalArray{T}(dims::Dims; ordered::Bool=false)
     CategoricalArray{T}(dims::Int...; ordered::Bool=false)

--- a/src/array.jl
+++ b/src/array.jl
@@ -116,7 +116,7 @@ CategoricalArray(dims::Int...; ordered=false) =
 function CategoricalArray{T, N, R}(dims::NTuple{N,Int};
                                    ordered=false) where {T, N, R}
     C = catvaluetype(T, R)
-    V = valtype(C)
+    V = leveltype(C)
     S = T >: Null ? Union{V, Null} : V
     CategoricalArray{S, N}(zeros(R, dims), CategoricalPool{V, R, C}(ordered))
 end

--- a/src/array.jl
+++ b/src/array.jl
@@ -498,6 +498,12 @@ end
     end
 end
 
+catvaluetype(::Type{T}) where {T <: CategoricalArray} = Nulls.T(eltype(T))
+catvaluetype(A::CategoricalArray) = catvaluetype(typeof(A))
+
+leveltype(::Type{T}) where {T <: CategoricalArray} = leveltype(catvaluetype(T))
+leveltype(A::CategoricalArray) = leveltype(typeof(A))
+
 """
     levels(A::CategoricalArray)
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -132,7 +132,7 @@ CategoricalArray{T, 2}(m::Int, n::Int; ordered=false) where {T} =
 CategoricalArray{T, 1, R}(m::Int; ordered=false) where {T, R} =
     CategoricalArray{T, 1, R}((m,), ordered=ordered)
 # R <: Integer is required to prevent default constructor from being called instead
-CategoricalArray{T, 2, R}(m::Int, n::Int; ordered=false) where {T, R<:Integer} =
+CategoricalArray{T, 2, R}(m::Int, n::Int; ordered=false) where {T, R <: Integer} =
     CategoricalArray{T, 2, R}((m, n), ordered=ordered)
 CategoricalArray{T, 3, R}(m::Int, n::Int, o::Int; ordered=false) where {T, R} =
     CategoricalArray{T, 3, R}((m, n, o), ordered=ordered)

--- a/src/array.jl
+++ b/src/array.jl
@@ -243,7 +243,9 @@ function convert(::Type{CategoricalArray{T, N, R}}, A::AbstractArray{S, N}) wher
     res = CategoricalArray{T, N, R}(size(A))
     copy!(res, A)
 
-    if method_exists(isless, Tuple{T, T})
+    # if order is defined for level type, automatically apply it
+    L = leveltype(res)
+    if method_exists(isless, Tuple{L, L})
         levels!(res, sort(levels(res)))
     end
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -22,6 +22,9 @@ end
 reftype(::Type{<:CategoricalArray{T, N, R}}) where {T, N, R} = R
 reftype(A::T) where {T <: CategoricalArray} = reftype(T)
 
+catvalue_type(::Type{<:CategoricalArray{T,N,R,V}}) where {T,N,R,V} = CategoricalValue{V, R}
+catvalue_type(A::T) where {T <: CategoricalArray} = catvalue_type(T)
+
 """
     CategoricalArray{T}(dims::Dims; ordered::Bool=false)
     CategoricalArray{T}(dims::Int...; ordered::Bool=false)

--- a/src/array.jl
+++ b/src/array.jl
@@ -122,7 +122,7 @@ function CategoricalArray{T, N, R}(dims::NTuple{N,Int};
 end
 
 CategoricalArray{T, N}(dims::NTuple{N,Int}; ordered=false) where {T, N} =
-    CategoricalArray{T, N, reftype(T)}(dims, ordered=ordered)
+    CategoricalArray{T, N, DefaultRefType}(dims, ordered=ordered)
 CategoricalArray{T}(dims::NTuple{N,Int}; ordered=false) where {T, N} =
     CategoricalArray{T, N}(dims, ordered=ordered)
 CategoricalArray{T, 1}(m::Int; ordered=false) where {T} =
@@ -173,7 +173,7 @@ end
 
 # From AbstractArray
 CategoricalArray{T, N}(A::AbstractArray{S, N}; ordered=_isordered(A)) where {S, T, N} =
-    CategoricalArray{T, N, reftype(T)}(A, ordered=ordered)
+    CategoricalArray{T, N, DefaultRefType}(A, ordered=ordered)
 CategoricalArray{T}(A::AbstractArray{S, N}; ordered=_isordered(A)) where {S, T, N} =
     CategoricalArray{T, N}(A, ordered=ordered)
 CategoricalArray(A::AbstractArray{T, N}; ordered=_isordered(A)) where {T, N} =
@@ -219,21 +219,21 @@ CategoricalMatrix(A::CategoricalArray{T, 2, R};
 
 # From AbstractArray
 convert(::Type{CategoricalArray{T, N}}, A::AbstractArray{S, N}) where {S, T, N} =
-    convert(CategoricalArray{T, N, reftype(T)}, A)
+    convert(CategoricalArray{T, N, DefaultRefType}, A)
 convert(::Type{CategoricalArray{T}}, A::AbstractArray{S, N}) where {S, T, N} =
     convert(CategoricalArray{T, N}, A)
 convert(::Type{CategoricalArray}, A::AbstractArray{T, N}) where {T, N} =
     convert(CategoricalArray{T, N}, A)
 
 convert(::Type{CategoricalVector{T}}, A::AbstractVector) where {T} =
-    convert(CategoricalVector{T, reftype(T)}, A)
+    convert(CategoricalVector{T, DefaultRefType}, A)
 convert(::Type{CategoricalVector}, A::AbstractVector{T}) where {T} =
     convert(CategoricalVector{T}, A)
 convert(::Type{CategoricalVector{T}}, A::CategoricalVector{T}) where {T} = A
 convert(::Type{CategoricalVector}, A::CategoricalVector) = A
 
 convert(::Type{CategoricalMatrix{T}}, A::AbstractMatrix) where {T} =
-    convert(CategoricalMatrix{T, reftype(T)}, A)
+    convert(CategoricalMatrix{T, DefaultRefType}, A)
 convert(::Type{CategoricalMatrix}, A::AbstractMatrix{T}) where {T} =
     convert(CategoricalMatrix{T}, A)
 convert(::Type{CategoricalMatrix{T}}, A::CategoricalMatrix{T}) where {T} = A
@@ -465,7 +465,7 @@ To avoid the need to call decompress, ensure [`compress`](@ref) is not called wh
 the categorical array.
 """
 decompress(A::CategoricalArray{T, N}) where {T, N} =
-    convert(CategoricalArray{T, N, reftype(T)}, A)
+    convert(CategoricalArray{T, N, DefaultRefType}, A)
 
 function vcat(A::CategoricalArray...)
     ordered = any(isordered, A) && all(a->isordered(a) || isempty(levels(a)), A)
@@ -478,8 +478,7 @@ function vcat(A::CategoricalArray...)
 
     T = Base.promote_eltype(A...) >: Null ?
         Union{eltype(newlevels), Null} : eltype(newlevels)
-    R = reftype(T)
-    refs = R[refsvec...;]
+    refs = DefaultRefType[refsvec...;]
     pool = CategoricalPool(newlevels, ordered)
     CategoricalArray{T, ndims(refs)}(refs, pool)
 end
@@ -678,7 +677,7 @@ categorical(A::AbstractArray; ordered=_isordered(A)) = CategoricalArray(A, order
 
 # Type-unstable methods
 function categorical(A::AbstractArray{T, N}, compress; ordered=_isordered(A)) where {T, N}
-    RefType = compress ? reftype(length(unique(A))) : reftype(T)
+    RefType = compress ? reftype(length(unique(A))) : DefaultRefType
     CategoricalArray{T, N, RefType}(A, ordered=ordered)
 end
 function categorical(A::CategoricalArray{T, N, R}, compress; ordered=_isordered(A)) where {T, N, R}

--- a/src/array.jl
+++ b/src/array.jl
@@ -19,12 +19,6 @@ function reftype(sz::Int)
     end
 end
 
-reftype(::Type{<:CategoricalArray{T, N, R}}) where {T, N, R} = R
-reftype(A::T) where {T <: CategoricalArray} = reftype(T)
-
-catvalue_type(::Type{<:CategoricalArray{T,N,R,V,C}}) where {T,N,R,V,C} = C
-catvalue_type(A::T) where {T <: CategoricalArray} = catvalue_type(T)
-
 """
     CategoricalArray{T}(dims::Dims; ordered::Bool=false)
     CategoricalArray{T}(dims::Int...; ordered::Bool=false)

--- a/src/buildfields.jl
+++ b/src/buildfields.jl
@@ -18,11 +18,11 @@ function buildinvindex(index::Vector{T}, ::Type{R}=DefaultRefType) where {T, R}
     return invindex
 end
 
-function buildvalues!(pool::CategoricalPool{T, R, V}) where {T, R, V}
-    n = length(levels(pool))
-    resize!(pool.valindex, n)
-    for i in 1:n
-        pool.valindex[i] = V(i, pool)
+function buildvalues!(pool::CategoricalPool)
+    resize!(pool.valindex, length(levels(pool)))
+    for i in eachindex(pool.valindex)
+        v = CategoricalValue(i, pool)
+        @inbounds pool.valindex[i] = v
     end
     return pool.valindex
 end

--- a/src/buildfields.jl
+++ b/src/buildfields.jl
@@ -21,7 +21,7 @@ end
 function buildvalues!(pool::CategoricalPool)
     resize!(pool.valindex, length(levels(pool)))
     for i in eachindex(pool.valindex)
-        v = CategoricalValue(i, pool)
+        v = catvalue(i, pool)
         @inbounds pool.valindex[i] = v
     end
     return pool.valindex

--- a/src/extras.jl
+++ b/src/extras.jl
@@ -109,7 +109,7 @@ function cut(x::AbstractArray{T, N}, breaks::AbstractVector;
 
     pool = CategoricalPool(levs, true)
     S = T >: Null ? Union{String, Null} : String
-    CategoricalArray{S, N, DefaultRefType}(refs, pool)
+    CategoricalArray{S, N}(refs, pool)
 end
 
 """

--- a/src/nullablearray.jl
+++ b/src/nullablearray.jl
@@ -1,18 +1,4 @@
-import Base: convert, getindex, setindex!, similar, in
-
-## Constructors and converters
-## (special methods for AbstractArray{Union{T, Null}}, to avoid wrapping nulls inside CategoricalValues)
-
-function convert(::Type{CategoricalArray{T, N, R}}, A::AbstractArray{S, N}) where {S, T>:Null, N, R}
-    res = CategoricalArray{T, N, R}(size(A))
-    copy!(res, A)
-
-    if method_exists(isless, Tuple{Nulls.T(T), Nulls.T(T)})
-        levels!(res, sort(levels(res)))
-    end
-
-    res
-end
+import Base: getindex, setindex!, similar, in
 
 @inline function getindex(A::CategoricalArray{T}, I...) where {T>:Null}
     @boundscheck checkbounds(A, I...)

--- a/src/nullablearray.jl
+++ b/src/nullablearray.jl
@@ -9,7 +9,7 @@ import Base: convert, getindex, setindex!, similar, in
 
 #function CategoricalArray{Union{T, Null}, N, R}(dims::NTuple{N,Int};
 #                                                ordered=false) where {T<:CatValue, N, R<:Integer}
-#    V = unwrap_catvalue_type(T)
+#    V = unwrap_catvaluetype(T)
 #    CategoricalArray{Union{V, Null}, N}(zeros(R, dims), CategoricalPool{V, R, T}(ordered))
 #end
 

--- a/src/nullablearray.jl
+++ b/src/nullablearray.jl
@@ -3,41 +3,6 @@ import Base: convert, getindex, setindex!, similar, in
 ## Constructors and converters
 ## (special methods for AbstractArray{Union{T, Null}}, to avoid wrapping nulls inside CategoricalValues)
 
-# FIXME remove these ctors? (handled by generic CategoricalArray ctors) 
-#CategoricalArray{Union{T, Null}, N, R}(dims::NTuple{N,Int}; ordered=false) where {T, N, R<:Integer} =
-#    CategoricalArray{Union{T, Null}, N}(zeros(R, dims), CategoricalPool{T, R}(ordered))
-
-#function CategoricalArray{Union{T, Null}, N, R}(dims::NTuple{N,Int};
-#                                                ordered=false) where {T<:CatValue, N, R<:Integer}
-#    V = unwrap_catvaluetype(T)
-#    CategoricalArray{Union{V, Null}, N}(zeros(R, dims), CategoricalPool{V, R, T}(ordered))
-#end
-
-#CategoricalArray{Union{T, Null}, N}(dims::NTuple{N,Int}; ordered=false) where {T<:CatValue, N} =
-#    CategoricalArray{Union{T, Null}, N, reftype(T)}(dims, ordered=ordered)
-
-#CategoricalArray{Union{T, Null}}(dims::NTuple{N,Int}; ordered=false) where {T<:CatValue, N} =
-#    CategoricalArray{Union{T, Null}, N}(dims, ordered=ordered)
-
-# CategoricalArray{Union{CategoricalValue, Null}, N}}){N}(dims::NTuple{N,Int};
-#                                                                 ordered=false) =
-#     CategoricalArray{Union{String, Null}, N}(dims; ordered=ordered)
-# CategoricalArray{Union{CategoricalValue, Null}}}){N}(dims::NTuple{N,Int};
-#                                                              ordered=false) =
-#     CategoricalArray{Union{String, Null}, N}(dims; ordered=ordered)
-
-#CategoricalVector{T}(m::Int; ordered=false) where {T>:Null} =
-#    CategoricalArray{T}((m,); ordered=ordered)
-#CategoricalMatrix{T}(m::Int, n::Int; ordered=false) where {T>:Null} =
-#    CategoricalArray{T}((m, n); ordered=ordered)
-
-#CategoricalArray(A::AbstractArray{T}; ordered=_isordered(A)) where {T>:Null} =
-#    CategoricalArray{T}(A, ordered=ordered)
-#CategoricalVector(A::AbstractVector{T}; ordered=_isordered(A)) where {T>:Null} =
-#    CategoricalVector{T}(A, ordered=ordered)
-#CategoricalMatrix(A::AbstractMatrix{T}; ordered=_isordered(A)) where {T>:Null} =
-#    CategoricalMatrix{T}(A, ordered=ordered)
-
 function convert(::Type{CategoricalArray{T, N, R}}, A::AbstractArray{S, N}) where {S, T>:Null, N, R}
     res = CategoricalArray{T, N, R}(size(A))
     copy!(res, A)

--- a/src/nullablearray.jl
+++ b/src/nullablearray.jl
@@ -3,20 +3,21 @@ import Base: convert, getindex, setindex!, similar, in
 ## Constructors and converters
 ## (special methods for AbstractArray{Union{T, Null}}, to avoid wrapping nulls inside CategoricalValues)
 
-CategoricalArray{Union{T, Null}, N, R}(dims::NTuple{N,Int}; ordered=false) where {T, N, R<:Integer} =
-    CategoricalArray{Union{T, Null}, N}(zeros(R, dims), CategoricalPool{T, R}(ordered))
+# FIXME remove these ctors? (handled by generic CategoricalArray ctors) 
+#CategoricalArray{Union{T, Null}, N, R}(dims::NTuple{N,Int}; ordered=false) where {T, N, R<:Integer} =
+#    CategoricalArray{Union{T, Null}, N}(zeros(R, dims), CategoricalPool{T, R}(ordered))
 
-function CategoricalArray{Union{T, Null}, N, R}(dims::NTuple{N,Int};
-                                                ordered=false) where {T<:CatValue, N, R<:Integer}
-    V = unwrap_catvalue_type(T)
-    CategoricalArray{Union{V, Null}, N}(zeros(R, dims), CategoricalPool{V, R, T}(ordered))
-end
+#function CategoricalArray{Union{T, Null}, N, R}(dims::NTuple{N,Int};
+#                                                ordered=false) where {T<:CatValue, N, R<:Integer}
+#    V = unwrap_catvalue_type(T)
+#    CategoricalArray{Union{V, Null}, N}(zeros(R, dims), CategoricalPool{V, R, T}(ordered))
+#end
 
-CategoricalArray{Union{T, Null}, N}(dims::NTuple{N,Int}; ordered=false) where {T<:CatValue, N} =
-    CategoricalArray{Union{T, Null}, N, reftype(T)}(dims, ordered=ordered)
+#CategoricalArray{Union{T, Null}, N}(dims::NTuple{N,Int}; ordered=false) where {T<:CatValue, N} =
+#    CategoricalArray{Union{T, Null}, N, reftype(T)}(dims, ordered=ordered)
 
-CategoricalArray{Union{T, Null}}(dims::NTuple{N,Int}; ordered=false) where {T<:CatValue, N} =
-    CategoricalArray{Union{T, Null}, N}(dims, ordered=ordered)
+#CategoricalArray{Union{T, Null}}(dims::NTuple{N,Int}; ordered=false) where {T<:CatValue, N} =
+#    CategoricalArray{Union{T, Null}, N}(dims, ordered=ordered)
 
 # CategoricalArray{Union{CategoricalValue, Null}, N}}){N}(dims::NTuple{N,Int};
 #                                                                 ordered=false) =
@@ -25,17 +26,17 @@ CategoricalArray{Union{T, Null}}(dims::NTuple{N,Int}; ordered=false) where {T<:C
 #                                                              ordered=false) =
 #     CategoricalArray{Union{String, Null}, N}(dims; ordered=ordered)
 
-CategoricalVector{T}(m::Int; ordered=false) where {T>:Null} =
-    CategoricalArray{T}((m,); ordered=ordered)
-CategoricalMatrix{T}(m::Int, n::Int; ordered=false) where {T>:Null} =
-    CategoricalArray{T}((m, n); ordered=ordered)
+#CategoricalVector{T}(m::Int; ordered=false) where {T>:Null} =
+#    CategoricalArray{T}((m,); ordered=ordered)
+#CategoricalMatrix{T}(m::Int, n::Int; ordered=false) where {T>:Null} =
+#    CategoricalArray{T}((m, n); ordered=ordered)
 
-CategoricalArray(A::AbstractArray{T}; ordered=_isordered(A)) where {T>:Null} =
-    CategoricalArray{T}(A, ordered=ordered)
-CategoricalVector(A::AbstractVector{T}; ordered=_isordered(A)) where {T>:Null} =
-    CategoricalVector{T}(A, ordered=ordered)
-CategoricalMatrix(A::AbstractMatrix{T}; ordered=_isordered(A)) where {T>:Null} =
-    CategoricalMatrix{T}(A, ordered=ordered)
+#CategoricalArray(A::AbstractArray{T}; ordered=_isordered(A)) where {T>:Null} =
+#    CategoricalArray{T}(A, ordered=ordered)
+#CategoricalVector(A::AbstractVector{T}; ordered=_isordered(A)) where {T>:Null} =
+#    CategoricalVector{T}(A, ordered=ordered)
+#CategoricalMatrix(A::AbstractMatrix{T}; ordered=_isordered(A)) where {T>:Null} =
+#    CategoricalMatrix{T}(A, ordered=ordered)
 
 function convert(::Type{CategoricalArray{T, N, R}}, A::AbstractArray{S, N}) where {S, T>:Null, N, R}
     res = CategoricalArray{T, N, R}(size(A))

--- a/src/nullablearray.jl
+++ b/src/nullablearray.jl
@@ -4,12 +4,12 @@ import Base: convert, getindex, setindex!, similar, in
 ## (special methods for AbstractArray{Union{T, Null}}, to avoid wrapping nulls inside CategoricalValues)
 
 CategoricalArray{Union{T, Null}, N, R}(dims::NTuple{N,Int}; ordered=false) where {T, N, R<:Integer} =
-    CategoricalArray{Union{T, Null}, N, R}(zeros(R, dims), CategoricalPool{T, R}(ordered))
+    CategoricalArray{Union{T, Null}, N}(zeros(R, dims), CategoricalPool{T, R}(ordered))
 
 function CategoricalArray{Union{T, Null}, N, R}(dims::NTuple{N,Int};
                                                 ordered=false) where {T<:CatValue, N, R<:Integer}
     V = unwrap_catvalue_type(T)
-    CategoricalArray{Union{V, Null}, N, R}(zeros(R, dims), CategoricalPool{V, R, T}(ordered))
+    CategoricalArray{Union{V, Null}, N}(zeros(R, dims), CategoricalPool{V, R, T}(ordered))
 end
 
 CategoricalArray{Union{T, Null}, N}(dims::NTuple{N,Int}; ordered=false) where {T<:CatValue, N} =
@@ -54,7 +54,7 @@ end
     @inbounds r = A.refs[I...]
 
     if isa(r, Array)
-        ret = CategoricalArray{T, ndims(r), eltype(r)}(r, deepcopy(A.pool))
+        ret = CategoricalArray{T, ndims(r)}(r, deepcopy(A.pool))
         return ordered!(ret, isordered(A))
     else
         if r > 0

--- a/src/nullablearray.jl
+++ b/src/nullablearray.jl
@@ -3,21 +3,21 @@ import Base: convert, getindex, setindex!, similar, in
 ## Constructors and converters
 ## (special methods for AbstractArray{Union{T, Null}}, to avoid wrapping nulls inside CategoricalValues)
 
-CategoricalArray{Union{T, Null}, N, R}(dims::NTuple{N,Int}; ordered=false) where {T, N, R} =
+CategoricalArray{Union{T, Null}, N, R}(dims::NTuple{N,Int}; ordered=false) where {T, N, R<:Integer} =
     CategoricalArray{Union{T, Null}, N, R}(zeros(R, dims), CategoricalPool{T, R}(ordered))
 
-CategoricalArray{Union{CategoricalValue{T, R}, Null}, N, R}(dims::NTuple{N,Int};
-                                                                      ordered=false) where {T, N, R} =
-    CategoricalArray{Union{T, Null}, N, R}(dims; ordered=ordered)
-CategoricalArray{Union{CategoricalValue{T}, Null}, N, R}(dims::NTuple{N,Int};
-                                                                   ordered=false) where {T, N, R} =
-    CategoricalArray{Union{T, Null}, N, R}(dims; ordered=ordered)
-CategoricalArray{Union{CategoricalValue{T, R}, Null}, N}(dims::NTuple{N,Int};
-                                                                   ordered=false) where {T, N, R} =
-    CategoricalArray{Union{T, Null}, N, R}(dims; ordered=ordered)
-CategoricalArray{Union{CategoricalValue{T}, Null}, N}(dims::NTuple{N,Int};
-                                                                ordered=false) where {T, N} =
-    CategoricalArray{Union{T, Null}, N}(dims; ordered=ordered)
+function CategoricalArray{Union{T, Null}, N, R}(dims::NTuple{N,Int};
+                                                ordered=false) where {T<:CatValue, N, R<:Integer}
+    V = unwrap_catvalue_type(T)
+    CategoricalArray{Union{V, Null}, N, R}(zeros(R, dims), CategoricalPool{V, R, T}(ordered))
+end
+
+CategoricalArray{Union{T, Null}, N}(dims::NTuple{N,Int}; ordered=false) where {T<:CatValue, N} =
+    CategoricalArray{Union{T, Null}, N, reftype(T)}(dims, ordered=ordered)
+
+CategoricalArray{Union{T, Null}}(dims::NTuple{N,Int}; ordered=false) where {T<:CatValue, N} =
+    CategoricalArray{Union{T, Null}, N}(dims, ordered=ordered)
+
 # CategoricalArray{Union{CategoricalValue, Null}, N}}){N}(dims::NTuple{N,Int};
 #                                                                 ordered=false) =
 #     CategoricalArray{Union{String, Null}, N}(dims; ordered=ordered)

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -4,7 +4,7 @@ function CategoricalPool(index::Vector{S},
                          ordered::Bool=false) where {S, T <: Integer, R <: Integer}
     invindex = convert(Dict{S, R}, invindex)
     C = catvaluetype(S, R)
-    V = valtype(C) # might be different from S (e.g. S == SubString, V == String)
+    V = leveltype(C) # might be different from S (e.g. S == SubString, V == String)
     CategoricalPool{V, R, C}(index, invindex, order, ordered)
 end
 

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -3,7 +3,7 @@ function CategoricalPool(index::Vector{S},
                          order::Vector{R},
                          ordered::Bool=false) where {S, T <: Integer, R <: Integer}
     invindex = convert(Dict{S, R}, invindex)
-    C = catvalue_type(S, R)
+    C = catvaluetype(S, R)
     V = valtype(C) # might be different from S (e.g. S == SubString, V == String)
     CategoricalPool{V, R, C}(index, invindex, order, ordered)
 end

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -62,9 +62,7 @@ function CategoricalPool(invindex::Dict{S, R},
     return CategoricalPool(index, invindex, order, ordered)
 end
 
-Base.convert(::Type{CategoricalPool}, pool::CategoricalPool) = pool
-Base.convert(::Type{CategoricalPool{T}}, pool::CategoricalPool{T}) where {T} = pool
-Base.convert(::Type{CategoricalPool{T, R}}, pool::CategoricalPool{T, R}) where {T, R <: Integer} = pool
+Base.convert(::Type{T}, pool::T) where {T <: CategoricalPool} = pool
 
 Base.convert(::Type{CategoricalPool{S}}, pool::CategoricalPool{T, R}) where {S, T, R <: Integer} =
     convert(CategoricalPool{S, R}, pool)

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -13,27 +13,25 @@ CategoricalPool{T, R, C}(ordered::Bool=false) where {T, R, C} =
 CategoricalPool{T, R}(ordered::Bool=false) where {T, R} =
     CategoricalPool(T[], Dict{T, R}(), R[], ordered)
 CategoricalPool{T}(ordered::Bool=false) where {T} =
-    CategoricalPool{T, reftype(T)}(ordered)
+    CategoricalPool{T, DefaultRefType}(ordered)
 
-function CategoricalPool{T, R}(index::Vector{T},
+function CategoricalPool{T, R}(index::Vector,
                                ordered::Bool=false) where {T, R}
     invindex = buildinvindex(index, R)
     order = Vector{R}(1:length(index))
     CategoricalPool(index, invindex, order, ordered)
 end
 
-function CategoricalPool(index::Vector{T}, ordered::Bool=false) where {T}
+function CategoricalPool(index::Vector, ordered::Bool=false)
     invindex = buildinvindex(index)
-    R = reftype(T)
-    order = Vector{R}(1:length(index))
+    order = Vector{DefaultRefType}(1:length(index))
     return CategoricalPool(index, invindex, order, ordered)
 end
 
 function CategoricalPool(invindex::Dict{S, R},
                          ordered::Bool=false) where {S, R <: Integer}
     index = buildindex(invindex)
-    Q = reftype(S)
-    order = Vector{Q}(1:length(index))
+    order = Vector{DefaultRefType}(1:length(index))
     return CategoricalPool(index, invindex, order, ordered)
 end
 
@@ -41,8 +39,7 @@ end
 function CategoricalPool(index::Vector{S},
                          invindex::Dict{S, R},
                          ordered::Bool=false) where {S, R <: Integer}
-    Q = reftype(S)
-    order = Vector{Q}(1:length(index))
+    order = Vector{DefaultRefType}(1:length(index))
     return CategoricalPool(index, invindex, order, ordered)
 end
 

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -91,7 +91,7 @@ Base.getindex(pool::CategoricalPool, i::Integer) = pool.valindex[i]
 Base.get(pool::CategoricalPool, level::Any) = pool.invindex[level]
 Base.get(pool::CategoricalPool, level::Any, default::Any) = get(pool.invindex, level, default)
 
-function Base.get!(pool::CategoricalPool{T, R, V}, level) where {T, R, V}
+function Base.get!(pool::CategoricalPool{T, R}, level::Any) where {T, R}
     get!(pool.invindex, level) do
         x = convert(T, level)
         n = length(pool)
@@ -103,7 +103,7 @@ function Base.get!(pool::CategoricalPool{T, R, V}, level) where {T, R, V}
         push!(pool.index, x)
         push!(pool.order, i)
         push!(pool.levels, x)
-        push!(pool.valindex, V(i, pool))
+        push!(pool.valindex, catvalue(i, pool))
         i
     end
 end
@@ -118,7 +118,7 @@ function Base.append!(pool::CategoricalPool, levels)
     return pool
 end
 
-function Base.delete!(pool::CategoricalPool{S, R, V}, levels...) where {S, R, V}
+function Base.delete!(pool::CategoricalPool{S}, levels...) where S
     for level in levels
         levelS = convert(S, level)
         if haskey(pool.invindex, levelS)
@@ -130,7 +130,7 @@ function Base.delete!(pool::CategoricalPool{S, R, V}, levels...) where {S, R, V}
             splice!(pool.valindex, ind)
             for i in ind:length(pool)
                 pool.invindex[pool.index[i]] -= 1
-                pool.valindex[i] = V(i, pool)
+                pool.valindex[i] = catvalue(i, pool)
             end
             for i in 1:length(pool)
                 pool.order[i] > ord && (pool.order[i] -= 1)
@@ -140,7 +140,7 @@ function Base.delete!(pool::CategoricalPool{S, R, V}, levels...) where {S, R, V}
     return pool
 end
 
-function levels!(pool::CategoricalPool{S, R, V}, newlevels::Vector) where {S, R, V}
+function levels!(pool::CategoricalPool{S, R}, newlevels::Vector) where {S, R}
     levs = convert(Vector{S}, newlevels)
     if !allunique(levs)
         throw(ArgumentError(string("duplicated levels found in levs: ",
@@ -166,7 +166,7 @@ function levels!(pool::CategoricalPool{S, R, V}, newlevels::Vector) where {S, R,
             v = levs[i]
             pool.index[i] = v
             pool.invindex[v] = i
-            pool.valindex[i] = V(i, pool)
+            pool.valindex[i] = catvalue(i, pool)
         end
     end
 

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -3,9 +3,11 @@ function CategoricalPool(index::Vector{S},
                          order::Vector{R},
                          ordered::Bool=false) where {S, T <: Integer, R <: Integer}
     invindex = convert(Dict{S, R}, invindex)
-    CategoricalPool{S, R, CategoricalValue{S, R}}(index, invindex, order, ordered)
+    CategoricalPool{S, R, catvalue_type(S, R)}(index, invindex, order, ordered)
 end
 
+CategoricalPool{T, R, C}(ordered::Bool=false) where {T, R, C} =
+    CategoricalPool{T, R, C}(T[], Dict{T, R}(), R[], ordered)
 CategoricalPool{T, R}(ordered::Bool=false) where {T, R} =
     CategoricalPool(T[], Dict{T, R}(), R[], ordered)
 CategoricalPool{T}(ordered::Bool=false) where {T} =

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -11,25 +11,27 @@ CategoricalPool{T, R, C}(ordered::Bool=false) where {T, R, C} =
 CategoricalPool{T, R}(ordered::Bool=false) where {T, R} =
     CategoricalPool(T[], Dict{T, R}(), R[], ordered)
 CategoricalPool{T}(ordered::Bool=false) where {T} =
-    CategoricalPool(T[], Dict{T, DefaultRefType}(), DefaultRefType[], ordered)
+    CategoricalPool{T, reftype(T)}(ordered)
 
-function CategoricalPool{T, R}(index::Vector,
+function CategoricalPool{T, R}(index::Vector{T},
                                ordered::Bool=false) where {T, R}
     invindex = buildinvindex(index, R)
     order = Vector{R}(1:length(index))
     CategoricalPool(index, invindex, order, ordered)
 end
 
-function CategoricalPool(index::Vector, ordered::Bool=false)
+function CategoricalPool(index::Vector{T}, ordered::Bool=false) where {T}
     invindex = buildinvindex(index)
-    order = Vector{DefaultRefType}(1:length(index))
+    R = reftype(T)
+    order = Vector{R}(1:length(index))
     return CategoricalPool(index, invindex, order, ordered)
 end
 
 function CategoricalPool(invindex::Dict{S, R},
                          ordered::Bool=false) where {S, R <: Integer}
     index = buildindex(invindex)
-    order = Vector{DefaultRefType}(1:length(index))
+    Q = reftype(S)
+    order = Vector{Q}(1:length(index))
     return CategoricalPool(index, invindex, order, ordered)
 end
 
@@ -37,7 +39,8 @@ end
 function CategoricalPool(index::Vector{S},
                          invindex::Dict{S, R},
                          ordered::Bool=false) where {S, R <: Integer}
-    order = Vector{DefaultRefType}(1:length(index))
+    Q = reftype(S)
+    order = Vector{Q}(1:length(index))
     return CategoricalPool(index, invindex, order, ordered)
 end
 

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -87,9 +87,6 @@ function Base.show(io::IO, pool::CategoricalPool{T, R}) where {T, R}
     pool.ordered && print(io, " with ordered levels")
 end
 
-reftype(::Type{CategoricalPool{T,R}}) where {T,R} = R
-reftype(pool::CategoricalPool) = reftype(typeof(pool))
-
 Base.length(pool::CategoricalPool) = length(pool.index)
 
 Base.getindex(pool::CategoricalPool, i::Integer) = pool.valindex[i]

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -80,6 +80,9 @@ function Base.show(io::IO, pool::CategoricalPool{T, R}) where {T, R}
     pool.ordered && print(io, " with ordered levels")
 end
 
+reftype(::Type{CategoricalPool{T,R}}) where {T,R} = R
+reftype(pool::CategoricalPool) = reftype(typeof(pool))
+
 Base.length(pool::CategoricalPool) = length(pool.index)
 
 Base.getindex(pool::CategoricalPool, i::Integer) = pool.valindex[i]

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -3,7 +3,9 @@ function CategoricalPool(index::Vector{S},
                          order::Vector{R},
                          ordered::Bool=false) where {S, T <: Integer, R <: Integer}
     invindex = convert(Dict{S, R}, invindex)
-    CategoricalPool{S, R, catvalue_type(S, R)}(index, invindex, order, ordered)
+    C = catvalue_type(S, R)
+    V = valtype(C) # might be diffrent from S (e.g. S==SubString, V==String)
+    CategoricalPool{V, R, C}(index, invindex, order, ordered)
 end
 
 CategoricalPool{T, R, C}(ordered::Bool=false) where {T, R, C} =

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -4,7 +4,7 @@ function CategoricalPool(index::Vector{S},
                          ordered::Bool=false) where {S, T <: Integer, R <: Integer}
     invindex = convert(Dict{S, R}, invindex)
     C = catvalue_type(S, R)
-    V = valtype(C) # might be diffrent from S (e.g. S==SubString, V==String)
+    V = valtype(C) # might be different from S (e.g. S == SubString, V == String)
     CategoricalPool{V, R, C}(index, invindex, order, ordered)
 end
 

--- a/src/typedefs.jl
+++ b/src/typedefs.jl
@@ -50,9 +50,6 @@ struct CategoricalString{R <: Integer} <: AbstractString
     pool::CategoricalPool{String, R, CategoricalString{R}}
 end
 
-# alias for all implementations of categorical value concept
-const CatValue = Union{CategoricalValue, CategoricalString}
-
 ## Arrays
 
 # Type params:

--- a/src/typedefs.jl
+++ b/src/typedefs.jl
@@ -63,8 +63,8 @@ end
 # * `C` categorical value type that implements "categorical value" trait
 # * `U` type of null value, `Union{}` if the data is non-nullable
 abstract type AbstractCategoricalArray{T, N, R, V, C, U} <: AbstractArray{Union{C, U}, N} end
-AbstractCategoricalVector{T, R, V, C, U} = AbstractCategoricalArray{T, 1, R, V, C, U}
-AbstractCategoricalMatrix{T, R, V, C, U} = AbstractCategoricalArray{T, 2, R, V, C, U}
+const AbstractCategoricalVector{T, R, V, C, U} = AbstractCategoricalArray{T, 1, R, V, C, U}
+const AbstractCategoricalMatrix{T, R, V, C, U} = AbstractCategoricalArray{T, 2, R, V, C, U}
 
 struct CategoricalArray{T, N, R <: Integer, V, C, U} <: AbstractCategoricalArray{T, N, R, V, C, U}
     refs::Array{R, N}

--- a/src/typedefs.jl
+++ b/src/typedefs.jl
@@ -2,9 +2,12 @@ const DefaultRefType = UInt32
 
 ## Pools
 
-# V is always set to CategoricalValue{T}
-# This workaround is needed since this type not defined yet
-# See JuliaLang/julia#269
+# Type params:
+# * `T` type of categorized values
+# * `R` integral type for referncing category levels
+# * `V` categorical value type, always set to CategoricalValue{T}
+#   This workaround is needed since this type not defined yet
+#   See JuliaLang/julia#269
 mutable struct CategoricalPool{T, R <: Integer, V}
     index::Vector{T}        # category levels ordered by their reference codes
     invindex::Dict{T, R}    # map from category levels to their reference codes
@@ -38,6 +41,12 @@ end
 
 ## Arrays
 
+# Type params:
+# * `T` original type of elements before categorization, could be nullable
+# * `N` array dimension
+# * `R` integral type for referncing category levels
+# * `V` orignial type of non-nullable elements before categorization
+# * `U` type of null value, `Union{}` if the data is non-nullable
 abstract type AbstractCategoricalArray{T, N, R, V, U} <: AbstractArray{Union{CategoricalValue{V, R}, U}, N} end
 AbstractCategoricalVector{T, R, V, U} = AbstractCategoricalArray{T, 1, R, V, U}
 AbstractCategoricalMatrix{T, R, V, U} = AbstractCategoricalArray{T, 2, R, V, U}

--- a/src/typedefs.jl
+++ b/src/typedefs.jl
@@ -70,8 +70,8 @@ struct CategoricalArray{T, N, R <: Integer, V, C, U} <: AbstractCategoricalArray
     refs::Array{R, N}
     pool::CategoricalPool{V, R, C}
 
-    function CategoricalArray{T, N, R}(refs::Array{R, N},
-                                       pool::CategoricalPool{V, R, C}) where
+    function CategoricalArray{T, N}(refs::Array{R, N},
+                                    pool::CategoricalPool{V, R, C}) where
                                                  {T, N, R <: Integer, V, C}
         T === V || T == Union{V, Null} || throw(ArgumentError("T ($T) must be equal to $V or Union{$V, Null}"))
         U = T >: Null ? Null : Union{}

--- a/src/typedefs.jl
+++ b/src/typedefs.jl
@@ -18,10 +18,10 @@ mutable struct CategoricalPool{T, R <: Integer, V}
                                       invindex::Dict{T, R},
                                       order::Vector{R},
                                       ordered::Bool) where {T, R, V}
-        if iscatvalue(T) === IsCatValue
+        if iscatvalue(T)
             throw(ArgumentError("Level type $T cannot be a type with \"categorical value\" trait"))
         end
-        if iscatvalue(V) !== IsCatValue
+        if !iscatvalue(V)
             throw(ArgumentError("Type $V does not have \"categorical value\" trait"))
         end
         if valtype(V) !== T

--- a/src/typedefs.jl
+++ b/src/typedefs.jl
@@ -24,8 +24,8 @@ mutable struct CategoricalPool{T, R <: Integer, V}
         if !iscatvalue(V)
             throw(ArgumentError("Type $V does not have \"categorical value\" trait"))
         end
-        if valtype(V) !== T
-            throw(ArgumentError("Value types of the categorical value ($(valtype(V))) and of the pool ($T) do not match"))
+        if leveltype(V) !== T
+            throw(ArgumentError("Value types of the categorical value ($(leveltype(V))) and of the pool ($T) do not match"))
         end
         if reftype(V) !== R
             throw(ArgumentError("Reference types of the categorical value ($(reftype(V))) and of the pool ($R) do not match"))

--- a/src/typedefs.jl
+++ b/src/typedefs.jl
@@ -18,8 +18,17 @@ mutable struct CategoricalPool{T, R <: Integer, V}
                                       invindex::Dict{T, R},
                                       order::Vector{R},
                                       ordered::Bool) where {T, R, V}
+        if iscatvalue(T) === IsCatValue
+            throw(ArgumentError("Level type $T cannot be a type with \"categorical value\" trait"))
+        end
         if iscatvalue(V) !== IsCatValue
             throw(ArgumentError("Type $V does not have \"categorical value\" trait"))
+        end
+        if valtype(V) !== T
+            throw(ArgumentError("Value types of the categorical value ($(valtype(V))) and of the pool ($T) do not match"))
+        end
+        if reftype(V) !== R
+            throw(ArgumentError("Reference types of the categorical value ($(reftype(V))) and of the pool ($R) do not match"))
         end
         levels = similar(index)
         levels[order] = index

--- a/src/typedefs.jl
+++ b/src/typedefs.jl
@@ -18,6 +18,9 @@ mutable struct CategoricalPool{T, R <: Integer, V}
                                       invindex::Dict{T, R},
                                       order::Vector{R},
                                       ordered::Bool) where {T, R, V}
+        if iscatvalue(V) !== IsCatValue
+            throw(ArgumentError("Type $V does not have \"categorical value\" trait"))
+        end
         levels = similar(index)
         levels[order] = index
         pool = new(index, invindex, order, levels, V[], ordered)

--- a/src/typedefs.jl
+++ b/src/typedefs.jl
@@ -78,5 +78,5 @@ struct CategoricalArray{T, N, R <: Integer, V, C, U} <: AbstractCategoricalArray
         new{T, N, R, V, C, U}(refs, pool)
     end
 end
-CategoricalVector{T, R, V, C, U} = CategoricalArray{T, 1, V, C, U}
-CategoricalMatrix{T, R, V, C, U} = CategoricalArray{T, 2, V, C, U}
+const CategoricalVector{T, R, V, C, U} = CategoricalArray{T, 1, V, C, U}
+const CategoricalMatrix{T, R, V, C, U} = CategoricalArray{T, 2, V, C, U}

--- a/src/typedefs.jl
+++ b/src/typedefs.jl
@@ -5,7 +5,7 @@ const DefaultRefType = UInt32
 # Type params:
 # * `T` type of categorized values
 # * `R` integer type for referencing category levels
-# * `V` categorical value type that implements "categorical value" trait
+# * `V` categorical value type
 mutable struct CategoricalPool{T, R <: Integer, V}
     index::Vector{T}        # category levels ordered by their reference codes
     invindex::Dict{T, R}    # map from category levels to their reference codes
@@ -19,16 +19,16 @@ mutable struct CategoricalPool{T, R <: Integer, V}
                                       order::Vector{R},
                                       ordered::Bool) where {T, R, V}
         if iscatvalue(T)
-            throw(ArgumentError("Level type $T cannot be a type with \"categorical value\" trait"))
+            throw(ArgumentError("Level type $T cannot be a categorical value type"))
         end
         if !iscatvalue(V)
-            throw(ArgumentError("Type $V does not have \"categorical value\" trait"))
+            throw(ArgumentError("Type $V is not a categorical value type"))
         end
         if leveltype(V) !== T
-            throw(ArgumentError("Value types of the categorical value ($(leveltype(V))) and of the pool ($T) do not match"))
+            throw(ArgumentError("Level type of the categorical value ($(leveltype(V))) and of the pool ($T) do not match"))
         end
         if reftype(V) !== R
-            throw(ArgumentError("Reference types of the categorical value ($(reftype(V))) and of the pool ($R) do not match"))
+            throw(ArgumentError("Reference type of the categorical value ($(reftype(V))) and of the pool ($R) do not match"))
         end
         levels = similar(index)
         levels[order] = index
@@ -45,7 +45,7 @@ end
 ## Values
 
 """
-Default "categorical value" type for
+Default categorical value type for
 referencing values of type `T`.
 """
 struct CategoricalValue{T, R <: Integer}
@@ -69,7 +69,7 @@ end
 # * `N` array dimension
 # * `R` integer type for referencing category levels
 # * `V` original type of non-nullable elements before categorization
-# * `C` categorical value type that implements "categorical value" trait
+# * `C` categorical value type
 # * `U` type of null value, `Union{}` if the data is non-nullable
 abstract type AbstractCategoricalArray{T, N, R, V, C, U} <: AbstractArray{Union{C, U}, N} end
 const AbstractCategoricalVector{T, R, V, C, U} = AbstractCategoricalArray{T, 1, R, V, C, U}

--- a/src/typedefs.jl
+++ b/src/typedefs.jl
@@ -4,7 +4,7 @@ const DefaultRefType = UInt32
 
 # Type params:
 # * `T` type of categorized values
-# * `R` integral type for referncing category levels
+# * `R` integer type for referencing category levels
 # * `V` categorical value type that implements "categorical value" concept
 mutable struct CategoricalPool{T, R <: Integer, V}
     index::Vector{T}        # category levels ordered by their reference codes
@@ -58,8 +58,8 @@ const CatValue = Union{CategoricalValue, CategoricalString}
 # Type params:
 # * `T` original type of elements before categorization, could be nullable
 # * `N` array dimension
-# * `R` integral type for referncing category levels
-# * `V` orignial type of non-nullable elements before categorization
+# * `R` integer type for referencing category levels
+# * `V` original type of non-nullable elements before categorization
 # * `C` categorical value type that implements "categorical value" concept
 # * `U` type of null value, `Union{}` if the data is non-nullable
 abstract type AbstractCategoricalArray{T, N, R, V, C, U} <: AbstractArray{Union{C, U}, N} end

--- a/src/typedefs.jl
+++ b/src/typedefs.jl
@@ -5,7 +5,7 @@ const DefaultRefType = UInt32
 # Type params:
 # * `T` type of categorized values
 # * `R` integer type for referencing category levels
-# * `V` categorical value type that implements "categorical value" concept
+# * `V` categorical value type that implements "categorical value" trait
 mutable struct CategoricalPool{T, R <: Integer, V}
     index::Vector{T}        # category levels ordered by their reference codes
     invindex::Dict{T, R}    # map from category levels to their reference codes
@@ -36,8 +36,8 @@ end
 ## Values
 
 """
-Default implementation of "categorical value" concept
-that references value of type `T`.
+Default "categorical value" type for
+referencing values of type `T`.
 """
 struct CategoricalValue{T, R <: Integer}
     level::R
@@ -60,7 +60,7 @@ end
 # * `N` array dimension
 # * `R` integer type for referencing category levels
 # * `V` original type of non-nullable elements before categorization
-# * `C` categorical value type that implements "categorical value" concept
+# * `C` categorical value type that implements "categorical value" trait
 # * `U` type of null value, `Union{}` if the data is non-nullable
 abstract type AbstractCategoricalArray{T, N, R, V, C, U} <: AbstractArray{Union{C, U}, N} end
 AbstractCategoricalVector{T, R, V, C, U} = AbstractCategoricalArray{T, 1, R, V, C, U}

--- a/src/value.jl
+++ b/src/value.jl
@@ -4,6 +4,11 @@ level(x::CategoricalValue) = x.level
 Base.get(x::CategoricalValue) = index(pool(x))[level(x)]
 order(x::CategoricalValue) = order(pool(x))[level(x)]
 
+# extract the type of original value from categorical value type
+unwrap_catvalue_type(::Type{<: CategoricalValue{T}}) where {T} = T
+unwrap_catvalue_type(::Type{Union{V, Null}}) where {T, V <: CategoricalValue{T}} = Union{T, Null}
+unwrap_catvalue_type(::Type{T}) where {T} = T
+
 function CategoricalValue(level::Integer, pool::CategoricalPool{T, R}) where {T, R}
     return CategoricalValue(convert(R, level), pool)
 end

--- a/src/value.jl
+++ b/src/value.jl
@@ -1,4 +1,4 @@
-# union of all types categorical value types
+# union of all categorical value types
 const CatValue{R} = Union{CategoricalValue{T, R} where T,
                           CategoricalString{R}}
 

--- a/src/value.jl
+++ b/src/value.jl
@@ -53,9 +53,6 @@ order(x::CatValue) = order(pool(x))[level(x)]
 catvalue(level::Integer, pool::CategoricalPool{T, R, C}) where {T, R, C} =
     C(convert(R, level), pool)
 
-Base.convert(::Type{T}, x::T) where {T <: CatValue} = x
-Base.convert(::Type{Union{T, Null}}, x::T) where {T <: CatValue} = x
-
 # FIXME do we need this rule or promotion is only required for CategoricalString?
 Base.promote_rule(::Type{C}, ::Type{T}) where {C <: CatValue, T} = promote_type(leveltype(C), T)
 
@@ -74,8 +71,9 @@ Base.convert(::Type{Ref}, x::CatValue) = RefValue{leveltype(x)}(x)
 Base.convert(::Type{String}, x::CatValue) = convert(String, get(x))
 Base.convert(::Type{Any}, x::CatValue) = x
 
-# fallback
-Base.convert(::Type{S}, x::CatValue) where {S} = convert(S, get(x))
+Base.convert(::Type{T}, x::T) where {T <: CatValue} = x
+Base.convert(::Type{Union{T, Null}}, x::T) where {T <: CatValue} = x # override the convert() below
+Base.convert(::Type{S}, x::CatValue) where {S} = convert(S, get(x)) # fallback
 
 function Base.show(io::IO, x::CatValue)
     if get(io, :compact, false)

--- a/src/value.jl
+++ b/src/value.jl
@@ -53,7 +53,6 @@ order(x::CatValue) = order(pool(x))[level(x)]
 catvalue(level::Integer, pool::CategoricalPool{T, R, C}) where {T, R, C} =
     C(convert(R, level), pool)
 
-# FIXME do we need this rule or promotion is only required for CategoricalString?
 Base.promote_rule(::Type{C}, ::Type{T}) where {C <: CatValue, T} = promote_type(leveltype(C), T)
 
 # To fix ambiguities with definitions from Base

--- a/src/value.jl
+++ b/src/value.jl
@@ -35,6 +35,9 @@ catvalue_type(::Type{T}, ::Type{R}) where {T, R} =
     CategoricalValue{T, R}
 catvalue_type(::Type{<:AbstractString}, ::Type{R}) where {R} =
     CategoricalString{R}
+# default to CategoricalString in degenerated case (all nulls)
+catvalue_type(::Type{Null}, ::Type{R}) where {R} =
+    CategoricalString{R}
 
 Base.get(x::CatValue) = index(pool(x))[level(x)]
 order(x::CatValue) = order(pool(x))[level(x)]

--- a/src/value.jl
+++ b/src/value.jl
@@ -7,7 +7,8 @@ iscatvalue(::Type{<:CategoricalString}) = true
 iscatvalue(::Type{<:CategoricalValue}) = true
 valtype(::Type{<:CategoricalValue{T}}) where T = T
 valtype(::Type{<:CategoricalString}) = String
-# type of levels
+# integer type of category reference codes for given type
+reftype(::Type) = DefaultRefType
 reftype(::Type{<:CategoricalValue{T, R}}) where {T,R} = R
 reftype(::Type{<:CategoricalString{R}}) where R = R
 

--- a/src/value.jl
+++ b/src/value.jl
@@ -11,9 +11,7 @@ iscatvalue(x::Any) = iscatvalue(typeof(x))
 valtype(::Type{<:CategoricalValue{T}}) where {T} = T
 valtype(::Type{<:CategoricalString}) = String
 
-# integer type of category reference codes for given type
-reftype(::Type) = DefaultRefType
-# TODO reftype(::Type{T}) where {T <: Integer} = T ?
+# integer type of category reference codes used by categorical value
 reftype(::Type{<:CatValue{R}}) where {R} = R
 
 pool(x::CatValue) = x.pool

--- a/src/value.jl
+++ b/src/value.jl
@@ -4,7 +4,7 @@ const CatValue{R} = Union{CategoricalValue{T, R} where T,
 
 # checks whether the type is categorical value
 iscatvalue(::Type) = false
-iscatvalue(::Type{Union{}}) = false # otherwise it dispatches to Type{<:...}
+iscatvalue(::Type{Union{}}) = false # prevent incorrect dispatch to Type{<:CatValue} method
 iscatvalue(::Type{<:CatValue}) = true
 iscatvalue(x::Any) = iscatvalue(typeof(x))
 
@@ -27,8 +27,8 @@ level(x::CatValue) = x.level
 unwrap_catvaluetype(::Type{T}) where {T} = T
 unwrap_catvaluetype(::Type{T}) where {T >: Null} =
     Union{unwrap_catvaluetype(Nulls.T(T)), Null}
-unwrap_catvaluetype(::Type{Union{}}) = Union{} # to prevent incorrect dispatch to T<:CatValue method
-unwrap_catvaluetype(::Type{Any}) = Any # to prevent dispatching to T>:Null method
+unwrap_catvaluetype(::Type{Union{}}) = Union{} # prevent incorrect dispatch to T<:CatValue method
+unwrap_catvaluetype(::Type{Any}) = Any # prevent recursion in T>:Null method
 unwrap_catvaluetype(::Type{T}) where {T <: CatValue} = leveltype(T)
 
 # get the categorical value type given value type `T` and reference type `R`
@@ -37,7 +37,7 @@ catvaluetype(::Type{T}, ::Type{R}) where {T >: Null, R} =
 catvaluetype(::Type{T}, ::Type{R}) where {T <: CatValue, R} =
     catvaluetype(leveltype(T), R)
 catvaluetype(::Type{Any}, ::Type{R}) where {R} =
-    CategoricalValue{Any, R}  # to prevent dispatching to T>:Null method
+    CategoricalValue{Any, R}  # prevent recursion in T>:Null method
 catvaluetype(::Type{T}, ::Type{R}) where {T, R} =
     CategoricalValue{T, R}
 catvaluetype(::Type{<:AbstractString}, ::Type{R}) where {R} =

--- a/src/value.jl
+++ b/src/value.jl
@@ -1,69 +1,104 @@
-pool(x::CategoricalValue) = x.pool
-level(x::CategoricalValue) = x.level
+# categorical value concept
+iscatvalue(::Type) = false
+iscatvalue(x::Any) = iscatvalue(typeof(x))
 
-Base.get(x::CategoricalValue) = index(pool(x))[level(x)]
-order(x::CategoricalValue) = order(pool(x))[level(x)]
-
+# categorical value concept implementation for CategoricalValue and CategoricalString
+iscatvalue(::Type{<:CategoricalString}) = true
+iscatvalue(::Type{<:CategoricalValue}) = true
 valtype(::Type{<:CategoricalValue{T}}) where T = T
-reftype(::Type{CategoricalValue{T, R}}) where {T,R} = R
-reftype(v::CategoricalValue) = reftype(typeof(v))
+valtype(::Type{<:CategoricalString}) = String
+# type of levels
+reftype(::Type{<:CategoricalValue{T, R}}) where {T,R} = R
+reftype(::Type{<:CategoricalString{R}}) where R = R
+
+pool(x::CatValue) = x.pool
+level(x::CatValue) = x.level
 
 # extract the type of original value from categorical value type
-unwrap_catvalue_type(::Type{<: CategoricalValue{T}}) where {T} = T
-unwrap_catvalue_type(::Type{Union{V, Null}}) where {T, V <: CategoricalValue{T}} = Union{T, Null}
+unwrap_catvalue_type(::Type{T}) where {T<:CatValue} = valtype(T)
+unwrap_catvalue_type(::Type{Union{T, Null}}) where {T<:CatValue} = Union{valtype(T), Null}
 unwrap_catvalue_type(::Type{T}) where {T} = T
 
 # default categorical value type for given non-null value type `T` and reference type `R`
-catvalue_type(::Type{T}, refType::Type{R}) where {T<:CategoricalValue, R} =
+catvalue_type(::Type{T}, refType::Type{R}) where {T<:CatValue, R} =
     reftype(T) === R ? T : catvalue_type(valtype(T), refType)
+catvalue_type(::Type{Any}, refType::Type{R}) where {R} = # to avoid recursion within Union{T,Null}
+    CategoricalValue{Any, R}
 catvalue_type(::Type{Union{T, Null}}, refType::Type{R}) where {T, R} =
     catvalue_type(T, R)
 catvalue_type(::Type{T}, refType::Type{R}) where {T, R} =
     CategoricalValue{T, R}
+catvalue_type(::Type{String}, refType::Type{R}) where {R} =
+    CategoricalString{R}
 
-function CategoricalValue(level::Integer, pool::CategoricalPool{T, R}) where {T, R}
-    return CategoricalValue(convert(R, level), pool)
+#= type-unstable by more generic version
+function catvalue_type(::Type{T}, refType::Type) where {T, R} =
+    if iscatvalue(T) # generic categorical value type not included in CatValue
+        if reftype(T) === R
+            return T
+        else
+            return catvalue_type(valtype(T), R)
+        end
+    else
+        return CategoricalValue{T, R}
+    end
+end
+=#
+
+# these functions use the "categorical value" concept,
+# but are defined only for CatValue union
+Base.get(x::CatValue) = index(pool(x))[level(x)]
+order(x::CatValue) = order(pool(x))[level(x)]
+
+# creates categorical value for `level` from the `pool`
+# The result type is of type `C`, which may be different from `CategoricalValue{T,R}`
+function CategoricalValue(level::Integer, pool::CategoricalPool{T, R, C}) where {T, R, C}
+    return C(convert(R, level), pool)
 end
 
 Base.convert(::Type{CategoricalValue{T, R}}, x::CategoricalValue{T, R}) where {T, R <: Integer} = x
 Base.convert(::Type{CategoricalValue{T}}, x::CategoricalValue{T}) where {T} = x
 Base.convert(::Type{CategoricalValue}, x::CategoricalValue) = x
 
+Base.convert(::Type{CategoricalString{R}}, x::CategoricalString{R}) where {R <: Integer} = x
+Base.convert(::Type{CategoricalString}, x::CategoricalString) = x
+
 Base.convert(::Type{Union{CategoricalValue{T, R}, Null}}, x::CategoricalValue{T, R}) where {T, R <: Integer} = x
 Base.convert(::Type{Union{CategoricalValue{T}, Null}}, x::CategoricalValue{T}) where {T} = x
 Base.convert(::Type{Union{CategoricalValue, Null}}, x::CategoricalValue) = x
 
+# To fix ambiguities with definitions from Base
 Base.promote_rule(::Type{CategoricalValue{S, R}}, ::Type{T}) where {S, T, R} = promote_type(S, T)
 Base.promote_rule(::Type{CategoricalValue{S}}, ::Type{T}) where {S, T} = promote_type(S, T)
 Base.promote_rule(::Type{CategoricalValue}, ::Type{T}) where {T} = T
 
-# To fix ambiguities with definitions from Base
-Base.promote_rule(::Type{CategoricalValue}, ::Type{T}) where {T <: AbstractString} = T
-Base.promote_rule(::Type{CategoricalValue{S}}, ::Type{T}) where {S, T <: AbstractString} =
-    promote_type(S, T)
-Base.promote_rule(::Type{CategoricalValue{S, R}}, ::Type{T}) where {S, T <: AbstractString, R <: Integer} =
-    promote_type(S, T)
+# FIXME is that right?
+Base.promote_rule(::Type{<:CategoricalString}, ::Type{T}) where {T <: AbstractString} = T
 
 Base.promote_rule(::Type{CategoricalValue}, ::Type{Null}) = Union{CategoricalValue, Null}
-Base.promote_rule(::Type{CategoricalValue{S}}, ::Type{Null}) where {S} =
-    Union{CategoricalValue{S}, Null}
-Base.promote_rule(::Type{CategoricalValue{S, R}}, ::Type{Null}) where {S, R <: Integer} =
-    Union{CategoricalValue{S, R}, Null}
+Base.promote_rule(::Type{CategoricalValue{T}}, ::Type{Null}) where T = Union{CategoricalValue{T}, Null}
+Base.promote_rule(::Type{CategoricalValue{T,R}}, ::Type{Null}) where {T,R} = Union{CategoricalValue{T,R}, Null}
 
+Base.promote_rule(::Type{CategoricalString}, ::Type{Null}) = Union{CategoricalString, Null}
+Base.promote_rule(::Type{CategoricalString{R}}, ::Type{Null}) where {R} = Union{CategoricalString{R}, Null}
+
+# Nullable support
 Base.convert(::Type{Nullable{S}}, x::CategoricalValue{Nullable}) where {S} =
     convert(Nullable{S}, get(x))
 Base.convert(::Type{Nullable}, x::CategoricalValue{S}) where {S} = convert(Nullable{S}, x)
 Base.convert(::Type{Nullable{CategoricalValue{Nullable{T}}}},
              x::CategoricalValue{Nullable{T}}) where {T} =
     Nullable(x)
-Base.convert(::Type{Ref}, x::CategoricalValue{T}) where {T} = RefValue{T}(x)
-Base.convert(::Type{String}, x::CategoricalValue) = convert(String, get(x))
-Base.convert(::Type{Any}, x::CategoricalValue) = x
+Base.convert(::Type{Ref}, x::CatValue) = RefValue{valtype(x)}(x)
+Base.convert(::Type{String}, x::CatValue) = convert(String, get(x))
+Base.convert(::Type{Any}, x::CatValue) = x
 
-Base.convert(::Type{S}, x::CategoricalValue) where {S} = convert(S, get(x))
-Base.convert(::Type{Union{S, Null}}, x::CategoricalValue) where {S} = convert(S, get(x))
+# fallback
+Base.convert(::Type{S}, x::CatValue) where {S} = convert(S, get(x))
+# Null support
+Base.convert(::Type{Union{S, Null}}, x::CatValue) where {S} = convert(S, get(x))
 
-function Base.show(io::IO, x::CategoricalValue{T}) where {T}
+function Base.show(io::IO, x::CatValue)
     if get(io, :compact, false)
         print(io, repr(x))
     elseif isordered(pool(x))
@@ -75,10 +110,10 @@ function Base.show(io::IO, x::CategoricalValue{T}) where {T}
     end
 end
 
-Base.print(io::IO, x::CategoricalValue) = print(io, get(x))
-Base.repr(x::CategoricalValue) = repr(get(x))
+Base.print(io::IO, x::CatValue) = print(io, get(x))
+Base.repr(x::CatValue) = repr(get(x))
 
-@inline function Base.:(==)(x::CategoricalValue, y::CategoricalValue)
+@inline function Base.:(==)(x::CatValue, y::CatValue)
     if x.pool === y.pool
         return x.level == y.level
     else
@@ -86,44 +121,41 @@ Base.repr(x::CategoricalValue) = repr(get(x))
     end
 end
 
-Base.:(==)(::CategoricalValue, ::Null) = null
-Base.:(==)(::Null, ::CategoricalValue) = null
+Base.:(==)(::CatValue, ::Null) = null
+Base.:(==)(::Null, ::CatValue) = null
 
 # To fix ambiguities with Base
-Base.:(==)(x::CategoricalValue, y::WeakRef) = get(x) == y
-Base.:(==)(x::WeakRef, y::CategoricalValue) = y == x
+Base.:(==)(x::CatValue, y::WeakRef) = get(x) == y
+Base.:(==)(x::WeakRef, y::CatValue) = y == x
 
-Base.:(==)(x::CategoricalValue, y::AbstractString) = get(x) == y
-Base.:(==)(x::AbstractString, y::CategoricalValue) = y == x
+Base.:(==)(x::CatValue, y::AbstractString) = get(x) == y
+Base.:(==)(x::AbstractString, y::CatValue) = y == x
 
-Base.:(==)(x::CategoricalValue, y::Any) = get(x) == y
-Base.:(==)(x::Any, y::CategoricalValue) = y == x
+Base.:(==)(x::CatValue, y::Any) = get(x) == y
+Base.:(==)(x::Any, y::CatValue) = y == x
 
-@inline function Base.isequal(x::CategoricalValue, y::CategoricalValue)
+@inline function Base.isequal(x::CatValue, y::CatValue)
     if pool(x) === pool(y)
         return level(x) == level(y)
     else
         return isequal(get(x), get(y))
     end
-
-Base.isequal(x::CategoricalValue, y::Any) = isequal(get(x), y)
-Base.isequal(x::Any, y::CategoricalValue) = isequal(y, x)
-
-Base.isequal(::CategoricalValue, ::Null) = false
-Base.isequal(::Null, ::CategoricalValue) = false
-
-Base.in(x::CategoricalValue, y::Any) = get(x) in y
-Base.in(x::CategoricalValue, y::Set) = get(x) in y
-Base.in(x::CategoricalValue, y::Range{T}) where {T<:Integer} = get(x) in y
-
-Base.hash(x::CategoricalValue, h::UInt) = hash(get(x), h)
-
-function Base.isless(x::CategoricalValue{S}, y::CategoricalValue{T}) where {S, T}
-    throw(ArgumentError("CategoricalValue objects with different pools cannot be tested for order"))
 end
 
+Base.isequal(x::CatValue, y::Any) = isequal(get(x), y)
+Base.isequal(x::Any, y::CatValue) = isequal(y, x)
+
+Base.isequal(::CatValue, ::Null) = false
+Base.isequal(::Null, ::CatValue) = false
+
+Base.in(x::CatValue, y::Any) = get(x) in y
+Base.in(x::CatValue, y::Set) = get(x) in y
+Base.in(x::CatValue, y::Range{T}) where {T<:Integer} = get(x) in y
+
+Base.hash(x::CatValue, h::UInt) = hash(get(x), h)
+
 # Method defined even on unordered values so that sort() works
-function Base.isless(x::CategoricalValue{T}, y::CategoricalValue{T}) where {T}
+function Base.isless(x::CatValue, y::CatValue)
     if pool(x) !== pool(y)
         throw(ArgumentError("CategoricalValue objects with different pools cannot be tested for order"))
     else
@@ -131,7 +163,7 @@ function Base.isless(x::CategoricalValue{T}, y::CategoricalValue{T}) where {T}
     end
 end
 
-function Base.:<(x::CategoricalValue{T}, y::CategoricalValue{T}) where {T}
+function Base.:<(x::CatValue, y::CatValue)
     if pool(x) !== pool(y)
         throw(ArgumentError("CategoricalValue objects with different pools cannot be tested for order"))
     elseif !isordered(pool(x)) # !isordered(pool(y)) is implied by pool(x) === pool(y)
@@ -142,21 +174,21 @@ function Base.:<(x::CategoricalValue{T}, y::CategoricalValue{T}) where {T}
 end
 
 # AbstractString interface
-Base.string(x::CategoricalValue{<:AbstractString}) = get(x)
-Base.length(x::CategoricalValue{<:AbstractString}) = length(get(x))
-Base.endof(x::CategoricalValue{<:AbstractString}) = endof(get(x))
-Base.sizeof(x::CategoricalValue{<:AbstractString}) = sizeof(get(x))
-Base.nextind(x::CategoricalValue{<:AbstractString}, i::Integer) = nextind(get(x), i)
-Base.prevind(x::CategoricalValue{<:AbstractString}, i::Integer) = prevind(get(x), i)
-Base.next(x::CategoricalValue{<:AbstractString}, i::Int) = next(get(x), i)
-Base.done(x::CategoricalValue{<:AbstractString}, i::Int) = done(get(x), i)
-Base.getindex(x::CategoricalValue{<:AbstractString}, i::Int) = getindex(get(x), i)
-Base.codeunit(x::CategoricalValue{<:AbstractString}, i::Integer) = codeunit(get(x), i)
-Base.ascii(x::CategoricalValue{<:AbstractString}) = ascii(get(x))
-Base.isvalid(x::CategoricalValue{<:AbstractString}) = isvalid(get(x))
-Base.isvalid(x::CategoricalValue{<:AbstractString}, i::Integer) = isvalid(get(x), i)
-Base.match(r::Regex, s::CategoricalValue{<:AbstractString},
+Base.string(x::CategoricalString) = get(x)
+Base.length(x::CategoricalString) = length(get(x))
+Base.endof(x::CategoricalString) = endof(get(x))
+Base.sizeof(x::CategoricalString) = sizeof(get(x))
+Base.nextind(x::CategoricalString, i::Integer) = nextind(get(x), i)
+Base.prevind(x::CategoricalString, i::Integer) = prevind(get(x), i)
+Base.next(x::CategoricalString, i::Int) = next(get(x), i)
+Base.getindex(x::CategoricalString, i::Int) = getindex(get(x), i)
+Base.codeunit(x::CategoricalString, i::Integer) = codeunit(get(x), i)
+Base.ascii(x::CategoricalString) = ascii(get(x))
+Base.isvalid(x::CategoricalString) = isvalid(get(x))
+Base.isvalid(x::CategoricalString, i::Integer) = isvalid(get(x), i)
+Base.match(r::Regex, s::CategoricalString,
            idx::Integer=start(s), add_opts::UInt32=UInt32(0)) =
     match(r, get(s), idx, add_opts)
-Base.matchall(r::Regex, s::CategoricalValue{<:AbstractString}, overlap::Bool=false) =
+Base.matchall(r::Regex, s::CategoricalString, overlap::Bool=false) =
     matchall(r, get(s), overlap)
+Base.collect(x::CategoricalString) = collect(get(x))

--- a/src/value.jl
+++ b/src/value.jl
@@ -4,6 +4,7 @@ level(x::CategoricalValue) = x.level
 Base.get(x::CategoricalValue) = index(pool(x))[level(x)]
 order(x::CategoricalValue) = order(pool(x))[level(x)]
 
+valtype(::Type{<:CategoricalValue{T}}) where T = T
 reftype(::Type{CategoricalValue{T, R}}) where {T,R} = R
 reftype(v::CategoricalValue) = reftype(typeof(v))
 
@@ -11,6 +12,14 @@ reftype(v::CategoricalValue) = reftype(typeof(v))
 unwrap_catvalue_type(::Type{<: CategoricalValue{T}}) where {T} = T
 unwrap_catvalue_type(::Type{Union{V, Null}}) where {T, V <: CategoricalValue{T}} = Union{T, Null}
 unwrap_catvalue_type(::Type{T}) where {T} = T
+
+# default categorical value type for given non-null value type `T` and reference type `R`
+catvalue_type(::Type{T}, refType::Type{R}) where {T<:CategoricalValue, R} =
+    reftype(T) === R ? T : catvalue_type(valtype(T), refType)
+catvalue_type(::Type{Union{T, Null}}, refType::Type{R}) where {T, R} =
+    catvalue_type(T, R)
+catvalue_type(::Type{T}, refType::Type{R}) where {T, R} =
+    CategoricalValue{T, R}
 
 function CategoricalValue(level::Integer, pool::CategoricalPool{T, R}) where {T, R}
     return CategoricalValue(convert(R, level), pool)

--- a/src/value.jl
+++ b/src/value.jl
@@ -53,7 +53,7 @@ order(x::CatValue) = order(pool(x))[level(x)]
 
 # creates categorical value for `level` from the `pool`
 # The result type is of type `C`, which may be different from `CategoricalValue{T,R}`
-function CategoricalValue(level::Integer, pool::CategoricalPool{T, R, C}) where {T, R, C}
+function catvalue(level::Integer, pool::CategoricalPool{T, R, C}) where {T, R, C}
     return C(convert(R, level), pool)
 end
 

--- a/src/value.jl
+++ b/src/value.jl
@@ -21,7 +21,7 @@ level(x::CatValue) = x.level
 unwrap_catvalue_type(::Type{T}) where {T} = T
 unwrap_catvalue_type(::Type{T}) where {T >: Null} =
     Union{unwrap_catvalue_type(Nulls.T(T)), Null}
-unwrap_catvalue_type(::Type{Null}) = Null # to prevent dispatching to T<:CatValue method
+unwrap_catvalue_type(::Type{Null}) = Null # to prevent dispatching to T>:Null method
 unwrap_catvalue_type(::Type{Any}) = Any # to prevent dispatching to T>:Null method
 unwrap_catvalue_type(::Type{T}) where {T <: CatValue} = valtype(T)
 

--- a/src/value.jl
+++ b/src/value.jl
@@ -4,6 +4,9 @@ level(x::CategoricalValue) = x.level
 Base.get(x::CategoricalValue) = index(pool(x))[level(x)]
 order(x::CategoricalValue) = order(pool(x))[level(x)]
 
+reftype(::Type{CategoricalValue{T, R}}) where {T,R} = R
+reftype(v::CategoricalValue) = reftype(typeof(v))
+
 # extract the type of original value from categorical value type
 unwrap_catvalue_type(::Type{<: CategoricalValue{T}}) where {T} = T
 unwrap_catvalue_type(::Type{Union{V, Null}}) where {T, V <: CategoricalValue{T}} = Union{T, Null}

--- a/src/value.jl
+++ b/src/value.jl
@@ -10,6 +10,8 @@ iscatvalue(x::Any) = iscatvalue(typeof(x))
 
 valtype(::Type{<:CategoricalValue{T}}) where {T} = T
 valtype(::Type{<:CategoricalString}) = String
+valtype(::Type) = throw(ArgumentError("Not a \"categorical value\" type"))
+valtype(x::Any) = valtype(typeof(x))
 
 # integer type of category reference codes used by categorical value
 reftype(::Type{<:CatValue{R}}) where {R} = R

--- a/src/value.jl
+++ b/src/value.jl
@@ -27,7 +27,7 @@ level(x::CatValue) = x.level
 unwrap_catvaluetype(::Type{T}) where {T} = T
 unwrap_catvaluetype(::Type{T}) where {T >: Null} =
     Union{unwrap_catvaluetype(Nulls.T(T)), Null}
-unwrap_catvaluetype(::Type{Null}) = Null # to prevent dispatching to T>:Null method
+unwrap_catvaluetype(::Type{Union{}}) = Union{} # to prevent incorrect dispatch to T<:CatValue method
 unwrap_catvaluetype(::Type{Any}) = Any # to prevent dispatching to T>:Null method
 unwrap_catvaluetype(::Type{T}) where {T <: CatValue} = leveltype(T)
 
@@ -42,9 +42,8 @@ catvaluetype(::Type{T}, ::Type{R}) where {T, R} =
     CategoricalValue{T, R}
 catvaluetype(::Type{<:AbstractString}, ::Type{R}) where {R} =
     CategoricalString{R}
-# default to CategoricalString in degenerated case (all nulls)
-catvaluetype(::Type{Null}, ::Type{R}) where {R} =
-    CategoricalString{R}
+# to prevent incorrect dispatch to T<:CatValue method
+catvaluetype(::Type{Union{}}, ::Type{R}) where {R} = CategoricalValue{Union{}, R}
 
 Base.get(x::CatValue) = index(pool(x))[level(x)]
 order(x::CatValue) = order(pool(x))[level(x)]

--- a/src/value.jl
+++ b/src/value.jl
@@ -21,26 +21,26 @@ pool(x::CatValue) = x.pool
 level(x::CatValue) = x.level
 
 # extract the type of the original value from array eltype `T`
-unwrap_catvalue_type(::Type{T}) where {T} = T
-unwrap_catvalue_type(::Type{T}) where {T >: Null} =
-    Union{unwrap_catvalue_type(Nulls.T(T)), Null}
-unwrap_catvalue_type(::Type{Null}) = Null # to prevent dispatching to T>:Null method
-unwrap_catvalue_type(::Type{Any}) = Any # to prevent dispatching to T>:Null method
-unwrap_catvalue_type(::Type{T}) where {T <: CatValue} = valtype(T)
+unwrap_catvaluetype(::Type{T}) where {T} = T
+unwrap_catvaluetype(::Type{T}) where {T >: Null} =
+    Union{unwrap_catvaluetype(Nulls.T(T)), Null}
+unwrap_catvaluetype(::Type{Null}) = Null # to prevent dispatching to T>:Null method
+unwrap_catvaluetype(::Type{Any}) = Any # to prevent dispatching to T>:Null method
+unwrap_catvaluetype(::Type{T}) where {T <: CatValue} = valtype(T)
 
 # get the "categorical value" type given value type `T` and reference type `R`
-catvalue_type(::Type{T}, ::Type{R}) where {T >: Null, R} =
-    catvalue_type(Nulls.T(T), R)
-catvalue_type(::Type{T}, ::Type{R}) where {T <: CatValue, R} =
-    reftype(T) === R ? T : catvalue_type(valtype(T), R)
-catvalue_type(::Type{Any}, ::Type{R}) where {R} =
+catvaluetype(::Type{T}, ::Type{R}) where {T >: Null, R} =
+    catvaluetype(Nulls.T(T), R)
+catvaluetype(::Type{T}, ::Type{R}) where {T <: CatValue, R} =
+    reftype(T) === R ? T : catvaluetype(valtype(T), R)
+catvaluetype(::Type{Any}, ::Type{R}) where {R} =
     CategoricalValue{Any, R}  # to prevent dispatching to T>:Null method
-catvalue_type(::Type{T}, ::Type{R}) where {T, R} =
+catvaluetype(::Type{T}, ::Type{R}) where {T, R} =
     CategoricalValue{T, R}
-catvalue_type(::Type{<:AbstractString}, ::Type{R}) where {R} =
+catvaluetype(::Type{<:AbstractString}, ::Type{R}) where {R} =
     CategoricalString{R}
 # default to CategoricalString in degenerated case (all nulls)
-catvalue_type(::Type{Null}, ::Type{R}) where {R} =
+catvaluetype(::Type{Null}, ::Type{R}) where {R} =
     CategoricalString{R}
 
 Base.get(x::CatValue) = index(pool(x))[level(x)]

--- a/src/value.jl
+++ b/src/value.jl
@@ -15,6 +15,7 @@ valtype(x::Any) = valtype(typeof(x))
 
 # integer type of category reference codes used by categorical value
 reftype(::Type{<:CatValue{R}}) where {R} = R
+reftype(x::Any) = reftype(typeof(x))
 
 pool(x::CatValue) = x.pool
 level(x::CatValue) = x.level

--- a/src/value.jl
+++ b/src/value.jl
@@ -21,6 +21,7 @@ level(x::CatValue) = x.level
 unwrap_catvalue_type(::Type{T}) where {T} = T
 unwrap_catvalue_type(::Type{T}) where {T >: Null} =
     Union{unwrap_catvalue_type(Nulls.T(T)), Null}
+unwrap_catvalue_type(::Type{Null}) = Null # to prevent dispatching to T<:CatValue method
 unwrap_catvalue_type(::Type{Any}) = Any # to prevent dispatching to T>:Null method
 unwrap_catvalue_type(::Type{T}) where {T <: CatValue} = valtype(T)
 

--- a/src/value.jl
+++ b/src/value.jl
@@ -1,8 +1,8 @@
-# union of all types that have "categorical value" trait
+# union of all types categorical value types
 const CatValue{R} = Union{CategoricalValue{T, R} where T,
                           CategoricalString{R}}
 
-# checks whether the type is "categorical value"
+# checks whether the type is categorical value
 iscatvalue(::Type) = false
 iscatvalue(::Type{Union{}}) = false # otherwise it dispatches to Type{<:...}
 iscatvalue(::Type{<:CatValue}) = true
@@ -10,7 +10,7 @@ iscatvalue(x::Any) = iscatvalue(typeof(x))
 
 leveltype(::Type{<:CategoricalValue{T}}) where {T} = T
 leveltype(::Type{<:CategoricalString}) = String
-leveltype(::Type) = throw(ArgumentError("Not a \"categorical value\" type"))
+leveltype(::Type) = throw(ArgumentError("Not a categorical value type"))
 leveltype(x::Any) = leveltype(typeof(x))
 # eltype() is a synonym of leveltype() for categorical values
 Base.eltype(::Type{T}) where {T <: CatValue} = leveltype(T)
@@ -31,7 +31,7 @@ unwrap_catvaluetype(::Type{Null}) = Null # to prevent dispatching to T>:Null met
 unwrap_catvaluetype(::Type{Any}) = Any # to prevent dispatching to T>:Null method
 unwrap_catvaluetype(::Type{T}) where {T <: CatValue} = leveltype(T)
 
-# get the "categorical value" type given value type `T` and reference type `R`
+# get the categorical value type given value type `T` and reference type `R`
 catvaluetype(::Type{T}, ::Type{R}) where {T >: Null, R} =
     catvaluetype(Nulls.T(T), R)
 catvaluetype(::Type{T}, ::Type{R}) where {T <: CatValue, R} =

--- a/src/value.jl
+++ b/src/value.jl
@@ -35,7 +35,7 @@ unwrap_catvaluetype(::Type{T}) where {T <: CatValue} = leveltype(T)
 catvaluetype(::Type{T}, ::Type{R}) where {T >: Null, R} =
     catvaluetype(Nulls.T(T), R)
 catvaluetype(::Type{T}, ::Type{R}) where {T <: CatValue, R} =
-    reftype(T) === R ? T : catvaluetype(leveltype(T), R)
+    catvaluetype(leveltype(T), R)
 catvaluetype(::Type{Any}, ::Type{R}) where {R} =
     CategoricalValue{Any, R}  # to prevent dispatching to T>:Null method
 catvaluetype(::Type{T}, ::Type{R}) where {T, R} =

--- a/src/value.jl
+++ b/src/value.jl
@@ -14,7 +14,6 @@ const CatValue{R} = Union{CategoricalValue{T, R} where T,
 
 # "categorical value" trait implementation for CategoricalValue and CategoricalString
 iscatvalue(::Type{<:CatValue}) = IsCatValue
-valtype(::Type) = Union{} # no value type if not a proper categorical value type
 valtype(::Type{<:CategoricalValue{T}}) where {T} = T
 valtype(::Type{<:CategoricalString}) = String
 

--- a/src/value.jl
+++ b/src/value.jl
@@ -115,8 +115,8 @@ Base.print(io::IO, x::CatValue) = print(io, get(x))
 Base.repr(x::CatValue) = repr(get(x))
 
 @inline function Base.:(==)(x::CatValue, y::CatValue)
-    if x.pool === y.pool
-        return x.level == y.level
+    if pool(x) === pool(y)
+        return level(x) == level(y)
     else
         return get(x) == get(y)
     end

--- a/src/value.jl
+++ b/src/value.jl
@@ -12,6 +12,9 @@ leveltype(::Type{<:CategoricalValue{T}}) where {T} = T
 leveltype(::Type{<:CategoricalString}) = String
 leveltype(::Type) = throw(ArgumentError("Not a \"categorical value\" type"))
 leveltype(x::Any) = leveltype(typeof(x))
+# eltype() is a synonym of leveltype() for categorical values
+Base.eltype(::Type{T}) where {T <: CatValue} = leveltype(T)
+Base.eltype(x::CatValue) = eltype(typeof(x))
 
 # integer type of category reference codes used by categorical value
 reftype(::Type{<:CatValue{R}}) where {R} = R

--- a/src/value.jl
+++ b/src/value.jl
@@ -174,7 +174,7 @@ function Base.:<(x::CatValue, y::CatValue)
     end
 end
 
-# AbstractString interface
+# AbstractString interface for CategoricalString
 Base.string(x::CategoricalString) = get(x)
 Base.length(x::CategoricalString) = length(get(x))
 Base.endof(x::CategoricalString) = endof(get(x))

--- a/test/01_typedef.jl
+++ b/test/01_typedef.jl
@@ -39,7 +39,7 @@ module TestTypeDef
     for i in 1:3
         x = catvalue(i, pool)
 
-        @test iscatvalue(x)
+        @test CategoricalArrays.iscatvalue(x) === CategoricalArrays.IsCatValue
 
         @test isa(x.level, DefaultRefType)
         @test x.level === DefaultRefType(i)
@@ -89,7 +89,7 @@ module TestTypeDef
     for i in 1:3
         y = catvalue(i, pool)
 
-        @test iscatvalue(y)
+        @test CategoricalArrays.iscatvalue(y) === CategoricalArrays.IsCatValue
 
         @test isa(y.level, DefaultRefType)
         @test y.level === DefaultRefType(i)

--- a/test/01_typedef.jl
+++ b/test/01_typedef.jl
@@ -1,7 +1,7 @@
 module TestTypeDef
     using Base.Test
     using CategoricalArrays
-    using CategoricalArrays: DefaultRefType, level,  reftype, valtype, catvalue, iscatvalue
+    using CategoricalArrays: DefaultRefType, level,  reftype, leveltype, catvalue, iscatvalue
 
     pool = CategoricalPool(
         [
@@ -40,19 +40,19 @@ module TestTypeDef
     @test pool.order[2] === DefaultRefType(2)
     @test pool.order[3] === DefaultRefType(3)
 
-    # valtype() only accepts "categorical value type"
-    @test_throws ArgumentError valtype("abc")
-    @test_throws ArgumentError valtype(String)
-    @test_throws ArgumentError valtype(1.0)
-    @test_throws ArgumentError valtype(Int)
+    # leveltype() only accepts "categorical value type"
+    @test_throws ArgumentError leveltype("abc")
+    @test_throws ArgumentError leveltype(String)
+    @test_throws ArgumentError leveltype(1.0)
+    @test_throws ArgumentError leveltype(Int)
 
     for i in 1:3
         x = catvalue(i, pool)
 
         @test iscatvalue(x)
         @test iscatvalue(typeof(x))
-        @test valtype(x) === String
-        @test valtype(typeof(x)) === String
+        @test leveltype(x) === String
+        @test leveltype(typeof(x)) === String
         @test reftype(x) === DefaultRefType
         @test reftype(typeof(x)) === DefaultRefType
         @test x isa CategoricalArrays.CategoricalString{DefaultRefType}

--- a/test/01_typedef.jl
+++ b/test/01_typedef.jl
@@ -40,6 +40,12 @@ module TestTypeDef
     @test pool.order[2] === DefaultRefType(2)
     @test pool.order[3] === DefaultRefType(3)
 
+    # valtype() only accepts "categorical value type"
+    @test_throws ArgumentError valtype("abc")
+    @test_throws ArgumentError valtype(String)
+    @test_throws ArgumentError valtype(1.0)
+    @test_throws ArgumentError valtype(Int)
+
     for i in 1:3
         x = catvalue(i, pool)
 

--- a/test/01_typedef.jl
+++ b/test/01_typedef.jl
@@ -39,7 +39,7 @@ module TestTypeDef
     for i in 1:3
         x = CategoricalValue(i, pool)
 
-        @test isa(x, CategoricalValue)
+        @test iscatvalue(x)
 
         @test isa(x.level, DefaultRefType)
         @test x.level === DefaultRefType(i)
@@ -89,7 +89,7 @@ module TestTypeDef
     for i in 1:3
         y = CategoricalValue(i, pool)
 
-        @test isa(y, CategoricalValue)
+        @test iscatvalue(y)
 
         @test isa(y.level, DefaultRefType)
         @test y.level === DefaultRefType(i)

--- a/test/01_typedef.jl
+++ b/test/01_typedef.jl
@@ -51,6 +51,8 @@ module TestTypeDef
 
         @test iscatvalue(x)
         @test iscatvalue(typeof(x))
+        @test eltype(x) === String
+        @test eltype(typeof(x)) === String
         @test leveltype(x) === String
         @test leveltype(typeof(x)) === String
         @test reftype(x) === DefaultRefType

--- a/test/01_typedef.jl
+++ b/test/01_typedef.jl
@@ -40,7 +40,7 @@ module TestTypeDef
     @test pool.order[2] === DefaultRefType(2)
     @test pool.order[3] === DefaultRefType(3)
 
-    # leveltype() only accepts "categorical value type"
+    # leveltype() only accepts categorical value type
     @test_throws ArgumentError leveltype("abc")
     @test_throws ArgumentError leveltype(String)
     @test_throws ArgumentError leveltype(1.0)

--- a/test/01_typedef.jl
+++ b/test/01_typedef.jl
@@ -1,7 +1,7 @@
 module TestTypeDef
     using Base.Test
     using CategoricalArrays
-    using CategoricalArrays: DefaultRefType
+    using CategoricalArrays: DefaultRefType, level,  reftype, valtype, catvalue, iscatvalue
 
     pool = CategoricalPool(
         [
@@ -16,9 +16,9 @@ module TestTypeDef
         )
     )
 
-    @test CategoricalArrays.iscatvalue(Int) == false
-    @test CategoricalArrays.iscatvalue(Any) == false
-    @test CategoricalArrays.iscatvalue(Null) == false
+    @test iscatvalue(Int) == false
+    @test iscatvalue(Any) == false
+    @test iscatvalue(Null) == false
 
     @test isa(pool, CategoricalPool)
 
@@ -41,15 +41,17 @@ module TestTypeDef
     @test pool.order[3] === DefaultRefType(3)
 
     for i in 1:3
-        x = CategoricalArrays.catvalue(i, pool)
+        x = catvalue(i, pool)
 
-        @test CategoricalArrays.iscatvalue(x)
+        @test iscatvalue(x)
+        @test valtype(typeof(x)) == String
+        @test reftype(typeof(x)) == DefaultRefType
 
-        @test isa(x.level, DefaultRefType)
-        @test x.level === DefaultRefType(i)
+        @test isa(level(x), DefaultRefType)
+        @test level(x) === DefaultRefType(i)
 
-        @test isa(x.pool, CategoricalPool)
-        @test x.pool === pool
+        @test isa(CategoricalArrays.pool(x), CategoricalPool)
+        @test CategoricalArrays.pool(x) === pool
     end
 
     pool = CategoricalPool(
@@ -91,14 +93,14 @@ module TestTypeDef
     @test pool.order[3] === DefaultRefType(1)
 
     for i in 1:3
-        y = CategoricalArrays.catvalue(i, pool)
+        y = catvalue(i, pool)
 
-        @test CategoricalArrays.iscatvalue(y)
+        @test iscatvalue(y)
 
-        @test isa(y.level, DefaultRefType)
-        @test y.level === DefaultRefType(i)
+        @test isa(level(y), DefaultRefType)
+        @test level(y) === DefaultRefType(i)
 
-        @test isa(y.pool, CategoricalPool)
-        @test y.pool === pool
+        @test isa(CategoricalArrays.pool(y), CategoricalPool)
+        @test CategoricalArrays.pool(y) === pool
     end
 end

--- a/test/01_typedef.jl
+++ b/test/01_typedef.jl
@@ -37,7 +37,7 @@ module TestTypeDef
     @test pool.order[3] === DefaultRefType(3)
 
     for i in 1:3
-        x = CategoricalValue(i, pool)
+        x = catvalue(i, pool)
 
         @test iscatvalue(x)
 
@@ -87,7 +87,7 @@ module TestTypeDef
     @test pool.order[3] === DefaultRefType(1)
 
     for i in 1:3
-        y = CategoricalValue(i, pool)
+        y = catvalue(i, pool)
 
         @test iscatvalue(y)
 

--- a/test/01_typedef.jl
+++ b/test/01_typedef.jl
@@ -16,6 +16,10 @@ module TestTypeDef
         )
     )
 
+    @test CategoricalArrays.iscatvalue(Int) == false
+    @test CategoricalArrays.iscatvalue(Any) == false
+    @test CategoricalArrays.iscatvalue(Null) == false
+
     @test isa(pool, CategoricalPool)
 
     @test isa(pool.index, Vector)
@@ -39,7 +43,7 @@ module TestTypeDef
     for i in 1:3
         x = CategoricalArrays.catvalue(i, pool)
 
-        @test CategoricalArrays.iscatvalue(x) === CategoricalArrays.IsCatValue
+        @test CategoricalArrays.iscatvalue(x)
 
         @test isa(x.level, DefaultRefType)
         @test x.level === DefaultRefType(i)
@@ -89,7 +93,7 @@ module TestTypeDef
     for i in 1:3
         y = CategoricalArrays.catvalue(i, pool)
 
-        @test CategoricalArrays.iscatvalue(y) === CategoricalArrays.IsCatValue
+        @test CategoricalArrays.iscatvalue(y)
 
         @test isa(y.level, DefaultRefType)
         @test y.level === DefaultRefType(i)

--- a/test/01_typedef.jl
+++ b/test/01_typedef.jl
@@ -37,7 +37,7 @@ module TestTypeDef
     @test pool.order[3] === DefaultRefType(3)
 
     for i in 1:3
-        x = catvalue(i, pool)
+        x = CategoricalArrays.catvalue(i, pool)
 
         @test CategoricalArrays.iscatvalue(x) === CategoricalArrays.IsCatValue
 
@@ -87,7 +87,7 @@ module TestTypeDef
     @test pool.order[3] === DefaultRefType(1)
 
     for i in 1:3
-        y = catvalue(i, pool)
+        y = CategoricalArrays.catvalue(i, pool)
 
         @test CategoricalArrays.iscatvalue(y) === CategoricalArrays.IsCatValue
 

--- a/test/01_typedef.jl
+++ b/test/01_typedef.jl
@@ -50,8 +50,12 @@ module TestTypeDef
         x = catvalue(i, pool)
 
         @test iscatvalue(x)
-        @test valtype(typeof(x)) == String
-        @test reftype(typeof(x)) == DefaultRefType
+        @test iscatvalue(typeof(x))
+        @test valtype(x) === String
+        @test valtype(typeof(x)) === String
+        @test reftype(x) === DefaultRefType
+        @test reftype(typeof(x)) === DefaultRefType
+        @test x isa CategoricalArrays.CategoricalString{DefaultRefType}
 
         @test isa(level(x), DefaultRefType)
         @test level(x) === DefaultRefType(i)

--- a/test/04_constructors.jl
+++ b/test/04_constructors.jl
@@ -15,7 +15,7 @@ module TestConstructors
 
     pool = CategoricalPool{Int, UInt8}()
 
-    @test isa(pool, CategoricalPool{Int, UInt8})
+    @test isa(pool, CategoricalPool{Int, UInt8, CategoricalValue{Int, UInt8}})
 
     @test isa(pool.index, Vector{Int})
     @test length(pool.index) == 0
@@ -25,7 +25,7 @@ module TestConstructors
 
     pool = CategoricalPool(["a", "b", "c"])
 
-    @test isa(pool, CategoricalPool)
+    @test isa(pool, CategoricalPool{String, UInt32, CategoricalString{UInt32}})
 
     @test isa(pool.index, Vector{String})
     @test length(pool.index) == 3

--- a/test/04_constructors.jl
+++ b/test/04_constructors.jl
@@ -1,7 +1,7 @@
 module TestConstructors
     using Base.Test
     using CategoricalArrays
-    using CategoricalArrays: DefaultRefType
+    using CategoricalArrays: DefaultRefType, catvalue
 
     pool = CategoricalPool{String}()
 
@@ -197,4 +197,10 @@ module TestConstructors
     @test pool.order[1] === DefaultRefType(1)
     @test pool.order[2] === DefaultRefType(2)
     @test pool.order[3] === DefaultRefType(3)
+
+    # test floating point pool
+    pool = CategoricalPool{Float64, UInt8}([1.0, 2.0, 3.0])
+
+    @test isa(pool, CategoricalPool{Float64, UInt8, CategoricalValue{Float64, UInt8}})
+    @test catvalue(1, pool) isa CategoricalValue{Float64, UInt8}
 end

--- a/test/04_constructors.jl
+++ b/test/04_constructors.jl
@@ -3,6 +3,18 @@ module TestConstructors
     using CategoricalArrays
     using CategoricalArrays: DefaultRefType, catvalue
 
+    # cannot use categorical value as level type
+    @test_throws ArgumentError CategoricalPool{CategoricalValue{Int,UInt8}, UInt8, CategoricalValue{CategoricalValue{Int,UInt8},UInt8}}(
+            CategoricalValue{Int,UInt8}[], Dict{CategoricalValue{Int,UInt8}, UInt8}(), UInt8[], false)
+    # cannot use non-categorical value as categorical value type
+    @test_throws ArgumentError CategoricalPool{Int, UInt8, Int}(Int[], Dict{Int, UInt8}(), UInt8[], false)
+    # level type of the pool and categorical value should match
+    @test_throws ArgumentError CategoricalPool{Int, UInt8, CategoricalString{UInt8}}(Int[], Dict{Int, UInt8}(), UInt8[], false)
+    # reference type of the pool and categorical value should match
+    @test_throws ArgumentError CategoricalPool{Int, UInt8, CategoricalValue{Int, UInt16}}(Int[], Dict{Int, UInt8}(), UInt8[], false)
+    # correct types combination
+    @test CategoricalPool{Int, UInt8, CategoricalValue{Int, UInt8}}(Int[], Dict{Int, UInt8}(), UInt8[], false) isa CategoricalPool
+
     pool = CategoricalPool{String}()
 
     @test isa(pool, CategoricalPool{String})

--- a/test/05_convert.jl
+++ b/test/05_convert.jl
@@ -1,7 +1,7 @@
 module TestConvert
     using Base.Test
     using CategoricalArrays
-    using CategoricalArrays: DefaultRefType, level, reftype, valtype, catvalue, iscatvalue
+    using CategoricalArrays: DefaultRefType, level, reftype, leveltype, catvalue, iscatvalue
 
     pool = CategoricalPool([1, 2, 3])
     @test convert(CategoricalPool{Int, DefaultRefType}, pool) === pool
@@ -16,8 +16,8 @@ module TestConvert
     v3 = catvalue(3, pool)
     @test iscatvalue(v1)
     @test iscatvalue(typeof(v1))
-    @test valtype(v1) === Int
-    @test valtype(typeof(v1)) === Int
+    @test leveltype(v1) === Int
+    @test leveltype(typeof(v1)) === Int
     @test reftype(v1) === DefaultRefType
     @test reftype(typeof(v1)) === DefaultRefType
     @test v1 isa CategoricalArrays.CategoricalValue{Int, DefaultRefType}

--- a/test/05_convert.jl
+++ b/test/05_convert.jl
@@ -16,6 +16,8 @@ module TestConvert
     v3 = catvalue(3, pool)
     @test iscatvalue(v1)
     @test iscatvalue(typeof(v1))
+    @test eltype(v1) === Int
+    @test eltype(typeof(v1)) === Int
     @test leveltype(v1) === Int
     @test leveltype(typeof(v1)) === Int
     @test reftype(v1) === DefaultRefType

--- a/test/05_convert.jl
+++ b/test/05_convert.jl
@@ -1,18 +1,26 @@
 module TestConvert
     using Base.Test
     using CategoricalArrays
+    using CategoricalArrays: DefaultRefType, level, reftype, valtype, catvalue, iscatvalue
 
     pool = CategoricalPool([1, 2, 3])
-    @test convert(CategoricalPool{Int, CategoricalArrays.DefaultRefType}, pool) === pool
+    @test convert(CategoricalPool{Int, DefaultRefType}, pool) === pool
     @test convert(CategoricalPool{Int}, pool) === pool
     @test convert(CategoricalPool, pool) === pool
     convert(CategoricalPool{Float64, UInt8}, pool)
     convert(CategoricalPool{Float64}, pool)
     convert(CategoricalPool, pool)
 
-    v1 = CategoricalArrays.catvalue(1, pool)
-    v2 = CategoricalArrays.catvalue(2, pool)
-    v3 = CategoricalArrays.catvalue(3, pool)
+    v1 = catvalue(1, pool)
+    v2 = catvalue(2, pool)
+    v3 = catvalue(3, pool)
+    @test iscatvalue(v1)
+    @test iscatvalue(typeof(v1))
+    @test valtype(v1) === Int
+    @test valtype(typeof(v1)) === Int
+    @test reftype(v1) === DefaultRefType
+    @test reftype(typeof(v1)) === DefaultRefType
+    @test v1 isa CategoricalArrays.CategoricalValue{Int, DefaultRefType}
 
     @test convert(Int32, v1) === Int32(1)
     @test convert(Int32, v2) === Int32(2)
@@ -24,7 +32,7 @@ module TestConvert
 
     @test convert(CategoricalValue, v1) === v1
     @test convert(CategoricalValue{Int}, v1) === v1
-    @test convert(CategoricalValue{Int, CategoricalArrays.DefaultRefType}, v1) === v1
+    @test convert(CategoricalValue{Int, DefaultRefType}, v1) === v1
     @test convert(Any, v1) === v1
 
     convert(Any, v1)

--- a/test/05_convert.jl
+++ b/test/05_convert.jl
@@ -10,9 +10,9 @@ module TestConvert
     convert(CategoricalPool{Float64}, pool)
     convert(CategoricalPool, pool)
 
-    v1 = catvalue(1, pool)
-    v2 = catvalue(2, pool)
-    v3 = catvalue(3, pool)
+    v1 = CategoricalArrays.catvalue(1, pool)
+    v2 = CategoricalArrays.catvalue(2, pool)
+    v3 = CategoricalArrays.catvalue(3, pool)
 
     @test convert(Int32, v1) === Int32(1)
     @test convert(Int32, v2) === Int32(2)

--- a/test/05_convert.jl
+++ b/test/05_convert.jl
@@ -10,9 +10,9 @@ module TestConvert
     convert(CategoricalPool{Float64}, pool)
     convert(CategoricalPool, pool)
 
-    v1 = CategoricalValue(1, pool)
-    v2 = CategoricalValue(2, pool)
-    v3 = CategoricalValue(3, pool)
+    v1 = catvalue(1, pool)
+    v2 = catvalue(2, pool)
+    v3 = catvalue(3, pool)
 
     @test convert(Int32, v1) === Int32(1)
     @test convert(Int32, v2) === Int32(2)

--- a/test/06_show.jl
+++ b/test/06_show.jl
@@ -17,13 +17,13 @@ module TestShow
     @test sprint(show, pool) == "CategoricalArrays.CategoricalPool{String,UInt32}([\"c\",\"b\",\"a\"])"
     @test sprint(show, opool) == "CategoricalArrays.CategoricalPool{String,UInt32}([\"a\",\"b\",\"c\"]) with ordered levels"
 
-    @test sprint(show, nv1) == "CategoricalArrays.CategoricalValue{String,UInt32} \"c\""
-    @test sprint(show, nv2) == "CategoricalArrays.CategoricalValue{String,UInt32} \"b\""
-    @test sprint(show, nv3) == "CategoricalArrays.CategoricalValue{String,UInt32} \"a\""
+    @test sprint(show, nv1) == "CategoricalArrays.CategoricalString{UInt32} \"c\""
+    @test sprint(show, nv2) == "CategoricalArrays.CategoricalString{UInt32} \"b\""
+    @test sprint(show, nv3) == "CategoricalArrays.CategoricalString{UInt32} \"a\""
 
-    @test sprint(show, ov1) == "CategoricalArrays.CategoricalValue{String,UInt32} \"c\" (3/3)"
-    @test sprint(show, ov2) == "CategoricalArrays.CategoricalValue{String,UInt32} \"b\" (2/3)"
-    @test sprint(show, ov3) == "CategoricalArrays.CategoricalValue{String,UInt32} \"a\" (1/3)"
+    @test sprint(show, ov1) == "CategoricalArrays.CategoricalString{UInt32} \"c\" (3/3)"
+    @test sprint(show, ov2) == "CategoricalArrays.CategoricalString{UInt32} \"b\" (2/3)"
+    @test sprint(show, ov3) == "CategoricalArrays.CategoricalString{UInt32} \"a\" (1/3)"
 
     @test sprint(showcompact, nv1) == sprint(showcompact, ov1) == "\"c\""
     @test sprint(showcompact, nv2) == sprint(showcompact, ov2) == "\"b\""

--- a/test/06_show.jl
+++ b/test/06_show.jl
@@ -6,13 +6,13 @@ module TestShow
 
     opool = CategoricalPool(["c", "b", "a"], ["a", "b", "c"], true)
 
-    nv1 = catvalue(1, pool)
-    nv2 = catvalue(2, pool)
-    nv3 = catvalue(3, pool)
+    nv1 = CategoricalArrays.catvalue(1, pool)
+    nv2 = CategoricalArrays.catvalue(2, pool)
+    nv3 = CategoricalArrays.catvalue(3, pool)
 
-    ov1 = catvalue(1, opool)
-    ov2 = catvalue(2, opool)
-    ov3 = catvalue(3, opool)
+    ov1 = CategoricalArrays.catvalue(1, opool)
+    ov2 = CategoricalArrays.catvalue(2, opool)
+    ov3 = CategoricalArrays.catvalue(3, opool)
 
     @test sprint(show, pool) == "CategoricalArrays.CategoricalPool{String,UInt32}([\"c\",\"b\",\"a\"])"
     @test sprint(show, opool) == "CategoricalArrays.CategoricalPool{String,UInt32}([\"a\",\"b\",\"c\"]) with ordered levels"

--- a/test/06_show.jl
+++ b/test/06_show.jl
@@ -6,13 +6,13 @@ module TestShow
 
     opool = CategoricalPool(["c", "b", "a"], ["a", "b", "c"], true)
 
-    nv1 = CategoricalValue(1, pool)
-    nv2 = CategoricalValue(2, pool)
-    nv3 = CategoricalValue(3, pool)
+    nv1 = catvalue(1, pool)
+    nv2 = catvalue(2, pool)
+    nv3 = catvalue(3, pool)
 
-    ov1 = CategoricalValue(1, opool)
-    ov2 = CategoricalValue(2, opool)
-    ov3 = CategoricalValue(3, opool)
+    ov1 = catvalue(1, opool)
+    ov2 = catvalue(2, opool)
+    ov3 = catvalue(3, opool)
 
     @test sprint(show, pool) == "CategoricalArrays.CategoricalPool{String,UInt32}([\"c\",\"b\",\"a\"])"
     @test sprint(show, opool) == "CategoricalArrays.CategoricalPool{String,UInt32}([\"a\",\"b\",\"c\"]) with ordered levels"

--- a/test/06_show.jl
+++ b/test/06_show.jl
@@ -40,4 +40,45 @@ module TestShow
     @test repr(nv1) == repr(ov1) == "\"c\""
     @test repr(nv2) == repr(ov2) == "\"b\""
     @test repr(nv3) == repr(ov3) == "\"a\""
+
+    # test Date-valued categories pool
+    pool = CategoricalPool([Date(1999, 12), Date(1991, 8), Date(1993, 10)])
+
+    opool = CategoricalPool([Date(1999, 12), Date(1991, 8), Date(1993, 10)],
+                            [Date(1991, 8), Date(1993, 10), Date(1999, 12)], true)
+
+    nv1 = CategoricalArrays.catvalue(1, pool)
+    nv2 = CategoricalArrays.catvalue(2, pool)
+    nv3 = CategoricalArrays.catvalue(3, pool)
+
+    ov1 = CategoricalArrays.catvalue(1, opool)
+    ov2 = CategoricalArrays.catvalue(2, opool)
+    ov3 = CategoricalArrays.catvalue(3, opool)
+
+    @test sprint(show, pool) == "CategoricalArrays.CategoricalPool{Date,UInt32}([1999-12-01,1991-08-01,1993-10-01])"
+    @test sprint(show, opool) == "CategoricalArrays.CategoricalPool{Date,UInt32}([1991-08-01,1993-10-01,1999-12-01]) with ordered levels"
+
+    @test sprint(show, nv1) == "CategoricalArrays.CategoricalValue{Date,UInt32} 1999-12-01"
+    @test sprint(show, nv2) == "CategoricalArrays.CategoricalValue{Date,UInt32} 1991-08-01"
+    @test sprint(show, nv3) == "CategoricalArrays.CategoricalValue{Date,UInt32} 1993-10-01"
+
+    @test sprint(show, ov1) == "CategoricalArrays.CategoricalValue{Date,UInt32} 1999-12-01 (3/3)"
+    @test sprint(show, ov2) == "CategoricalArrays.CategoricalValue{Date,UInt32} 1991-08-01 (1/3)"
+    @test sprint(show, ov3) == "CategoricalArrays.CategoricalValue{Date,UInt32} 1993-10-01 (2/3)"
+
+    @test sprint(showcompact, nv1) == sprint(showcompact, ov1) == "1999-12-01"
+    @test sprint(showcompact, nv2) == sprint(showcompact, ov2) == "1991-08-01"
+    @test sprint(showcompact, nv3) == sprint(showcompact, ov3) == "1993-10-01"
+
+    @test sprint(print, nv1) == sprint(print, ov1) == "1999-12-01"
+    @test sprint(print, nv2) == sprint(print, ov2) == "1991-08-01"
+    @test sprint(print, nv3) == sprint(print, ov3) == "1993-10-01"
+
+    @test string(nv1) == string(ov1) == "1999-12-01"
+    @test string(nv2) == string(ov2) == "1991-08-01"
+    @test string(nv3) == string(ov3) == "1993-10-01"
+
+    @test repr(nv1) == repr(ov1) == "1999-12-01"
+    @test repr(nv2) == repr(ov2) == "1991-08-01"
+    @test repr(nv3) == repr(ov3) == "1993-10-01"
 end

--- a/test/07_levels.jl
+++ b/test/07_levels.jl
@@ -10,7 +10,7 @@ module TestLevels
     @test levels(pool) == pool.index == [2, 1, 3]
     @test pool.invindex == Dict(1=>2, 2=>1, 3=>3)
     @test pool.order == [1, 2, 3]
-    @test pool.valindex == [CategoricalValue(i, pool) for i in 1:3]
+    @test pool.valindex == [catvalue(i, pool) for i in 1:3]
 
     for rep in 1:3
         push!(pool, 4)
@@ -22,8 +22,8 @@ module TestLevels
         @test pool.order == [1, 2, 3, 4]
         @test pool.levels == [2, 1, 3, 4]
         @test get(pool, 4) === DefaultRefType(4)
-        @test pool[4] === CategoricalValue(4, pool)
-        @test pool.valindex == [CategoricalValue(i, pool) for i in 1:4]
+        @test pool[4] === catvalue(4, pool)
+        @test pool.valindex == [catvalue(i, pool) for i in 1:4]
     end
 
     for rep in 1:3
@@ -36,8 +36,8 @@ module TestLevels
         @test pool.order == [1, 2, 3, 4, 5]
         @test pool.levels == [2, 1, 3, 4, 0]
         @test get(pool, 0) === DefaultRefType(5)
-        @test pool[5] === CategoricalValue(5, pool)
-        @test pool.valindex == [CategoricalValue(i, pool) for i in 1:5]
+        @test pool[5] === catvalue(5, pool)
+        @test pool.valindex == [catvalue(i, pool) for i in 1:5]
     end
 
     for rep in 1:3
@@ -51,9 +51,9 @@ module TestLevels
         @test pool.levels == [2, 1, 3, 4, 0, 10, 11]
         @test get(pool, 10) === DefaultRefType(6)
         @test get(pool, 11) === DefaultRefType(7)
-        @test pool[6] === CategoricalValue(6, pool)
-        @test pool[7] === CategoricalValue(7, pool)
-        @test pool.valindex == [CategoricalValue(i, pool) for i in 1:7]
+        @test pool[6] === catvalue(6, pool)
+        @test pool[7] === catvalue(7, pool)
+        @test pool.valindex == [catvalue(i, pool) for i in 1:7]
     end
 
     for rep in 1:3
@@ -67,9 +67,9 @@ module TestLevels
         @test pool.levels == [2, 1, 3, 4, 0, 10, 11, 12, 13]
         @test get(pool, 12) === DefaultRefType(8)
         @test get(pool, 13) === DefaultRefType(9)
-        @test pool[8] === CategoricalValue(8, pool)
-        @test pool[9] === CategoricalValue(9, pool)
-        @test pool.valindex == [CategoricalValue(i, pool) for i in 1:9]
+        @test pool[8] === catvalue(8, pool)
+        @test pool[9] === catvalue(9, pool)
+        @test pool.valindex == [catvalue(i, pool) for i in 1:9]
     end
 
     for rep in 1:3
@@ -82,7 +82,7 @@ module TestLevels
         @test pool.order == [1, 2, 3, 4, 5, 6, 7, 8]
         @test pool.levels == [2, 1, 3, 4, 0, 10, 11, 12]
         @test_throws KeyError get(pool, 13)
-        @test pool.valindex == [CategoricalValue(i, pool) for i in 1:8]
+        @test pool.valindex == [catvalue(i, pool) for i in 1:8]
     end
 
     for rep in 1:3
@@ -96,7 +96,7 @@ module TestLevels
         @test pool.levels == [2, 1, 3, 4, 0, 10]
         @test_throws KeyError get(pool, 11)
         @test_throws KeyError get(pool, 12)
-        @test pool.valindex == [CategoricalValue(i, pool) for i in 1:6]
+        @test pool.valindex == [catvalue(i, pool) for i in 1:6]
     end
 
     for rep in 1:3
@@ -109,7 +109,7 @@ module TestLevels
         @test pool.order == [1, 2, 3, 4, 5]
         @test pool.levels == [2, 1, 3, 0, 10]
         @test_throws KeyError get(pool, 4)
-        @test pool.valindex == [CategoricalValue(i, pool) for i in 1:5]
+        @test pool.valindex == [catvalue(i, pool) for i in 1:5]
     end
 
     @test levels!(pool, [1, 2, 3]) === pool
@@ -125,7 +125,7 @@ module TestLevels
     @test get(pool, 1) === DefaultRefType(1)
     @test_throws KeyError get(pool, 0)
     @test_throws KeyError get(pool, 10)
-    @test pool.valindex == [CategoricalValue(i, pool) for i in 1:3]
+    @test pool.valindex == [catvalue(i, pool) for i in 1:3]
 
     @test levels!(pool, [1, 2, 4]) === pool
     @test levels(pool) == [1, 2, 4]
@@ -139,7 +139,7 @@ module TestLevels
     @test pool.levels == [1, 2, 4]
     @test get(pool, 1) === DefaultRefType(1)
     @test_throws KeyError get(pool, 3)
-    @test pool.valindex == [CategoricalValue(i, pool) for i in 1:3]
+    @test pool.valindex == [catvalue(i, pool) for i in 1:3]
 
     @test levels!(pool, [6, 5, 4]) === pool
     @test levels(pool) == [6, 5, 4]
@@ -153,7 +153,7 @@ module TestLevels
     @test pool.levels == [6, 5, 4]
     @test get(pool, 5) === DefaultRefType(2)
     @test_throws KeyError get(pool, 3)
-    @test pool.valindex == [CategoricalValue(i, pool) for i in 1:3]
+    @test pool.valindex == [catvalue(i, pool) for i in 1:3]
 
     # Changing order while preserving existing levels
     @test levels!(pool, [5, 6, 4]) === pool
@@ -168,7 +168,7 @@ module TestLevels
     @test pool.order == [2, 1, 3]
     @test pool.levels == [5, 6, 4]
     @test get(pool, 5) === DefaultRefType(2)
-    @test pool.valindex == [CategoricalValue(i, pool) for i in 1:3]
+    @test pool.valindex == [catvalue(i, pool) for i in 1:3]
 
     # Adding levels while preserving existing ones
     @test levels!(pool, [5, 2, 3, 6, 4]) === pool
@@ -184,7 +184,7 @@ module TestLevels
     @test pool.levels == [5, 2, 3, 6, 4]
     @test get(pool, 2) === DefaultRefType(4)
     @test get(pool, 3) === DefaultRefType(5)
-    @test pool.valindex == [CategoricalValue(i, pool) for i in 1:5]
+    @test pool.valindex == [catvalue(i, pool) for i in 1:5]
 
     for rep in 1:3
         delete!(pool, 6)
@@ -199,7 +199,7 @@ module TestLevels
         @test pool.levels == [5, 2, 3, 4]
         @test get(pool, 4) === DefaultRefType(2)
         @test_throws KeyError get(pool, 6)
-        @test pool.valindex == [CategoricalValue(i, pool) for i in 1:4]
+        @test pool.valindex == [catvalue(i, pool) for i in 1:4]
     end
 
 

--- a/test/07_levels.jl
+++ b/test/07_levels.jl
@@ -10,7 +10,7 @@ module TestLevels
     @test levels(pool) == pool.index == [2, 1, 3]
     @test pool.invindex == Dict(1=>2, 2=>1, 3=>3)
     @test pool.order == [1, 2, 3]
-    @test pool.valindex == [catvalue(i, pool) for i in 1:3]
+    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:3]
 
     for rep in 1:3
         push!(pool, 4)
@@ -22,8 +22,8 @@ module TestLevels
         @test pool.order == [1, 2, 3, 4]
         @test pool.levels == [2, 1, 3, 4]
         @test get(pool, 4) === DefaultRefType(4)
-        @test pool[4] === catvalue(4, pool)
-        @test pool.valindex == [catvalue(i, pool) for i in 1:4]
+        @test pool[4] === CategoricalArrays.catvalue(4, pool)
+        @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:4]
     end
 
     for rep in 1:3
@@ -36,8 +36,8 @@ module TestLevels
         @test pool.order == [1, 2, 3, 4, 5]
         @test pool.levels == [2, 1, 3, 4, 0]
         @test get(pool, 0) === DefaultRefType(5)
-        @test pool[5] === catvalue(5, pool)
-        @test pool.valindex == [catvalue(i, pool) for i in 1:5]
+        @test pool[5] === CategoricalArrays.catvalue(5, pool)
+        @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:5]
     end
 
     for rep in 1:3
@@ -51,9 +51,9 @@ module TestLevels
         @test pool.levels == [2, 1, 3, 4, 0, 10, 11]
         @test get(pool, 10) === DefaultRefType(6)
         @test get(pool, 11) === DefaultRefType(7)
-        @test pool[6] === catvalue(6, pool)
-        @test pool[7] === catvalue(7, pool)
-        @test pool.valindex == [catvalue(i, pool) for i in 1:7]
+        @test pool[6] === CategoricalArrays.catvalue(6, pool)
+        @test pool[7] === CategoricalArrays.catvalue(7, pool)
+        @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:7]
     end
 
     for rep in 1:3
@@ -67,9 +67,9 @@ module TestLevels
         @test pool.levels == [2, 1, 3, 4, 0, 10, 11, 12, 13]
         @test get(pool, 12) === DefaultRefType(8)
         @test get(pool, 13) === DefaultRefType(9)
-        @test pool[8] === catvalue(8, pool)
-        @test pool[9] === catvalue(9, pool)
-        @test pool.valindex == [catvalue(i, pool) for i in 1:9]
+        @test pool[8] === CategoricalArrays.catvalue(8, pool)
+        @test pool[9] === CategoricalArrays.catvalue(9, pool)
+        @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:9]
     end
 
     for rep in 1:3
@@ -82,7 +82,7 @@ module TestLevels
         @test pool.order == [1, 2, 3, 4, 5, 6, 7, 8]
         @test pool.levels == [2, 1, 3, 4, 0, 10, 11, 12]
         @test_throws KeyError get(pool, 13)
-        @test pool.valindex == [catvalue(i, pool) for i in 1:8]
+        @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:8]
     end
 
     for rep in 1:3
@@ -96,7 +96,7 @@ module TestLevels
         @test pool.levels == [2, 1, 3, 4, 0, 10]
         @test_throws KeyError get(pool, 11)
         @test_throws KeyError get(pool, 12)
-        @test pool.valindex == [catvalue(i, pool) for i in 1:6]
+        @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:6]
     end
 
     for rep in 1:3
@@ -109,7 +109,7 @@ module TestLevels
         @test pool.order == [1, 2, 3, 4, 5]
         @test pool.levels == [2, 1, 3, 0, 10]
         @test_throws KeyError get(pool, 4)
-        @test pool.valindex == [catvalue(i, pool) for i in 1:5]
+        @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:5]
     end
 
     @test levels!(pool, [1, 2, 3]) === pool
@@ -125,7 +125,7 @@ module TestLevels
     @test get(pool, 1) === DefaultRefType(1)
     @test_throws KeyError get(pool, 0)
     @test_throws KeyError get(pool, 10)
-    @test pool.valindex == [catvalue(i, pool) for i in 1:3]
+    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:3]
 
     @test levels!(pool, [1, 2, 4]) === pool
     @test levels(pool) == [1, 2, 4]
@@ -139,7 +139,7 @@ module TestLevels
     @test pool.levels == [1, 2, 4]
     @test get(pool, 1) === DefaultRefType(1)
     @test_throws KeyError get(pool, 3)
-    @test pool.valindex == [catvalue(i, pool) for i in 1:3]
+    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:3]
 
     @test levels!(pool, [6, 5, 4]) === pool
     @test levels(pool) == [6, 5, 4]
@@ -153,7 +153,7 @@ module TestLevels
     @test pool.levels == [6, 5, 4]
     @test get(pool, 5) === DefaultRefType(2)
     @test_throws KeyError get(pool, 3)
-    @test pool.valindex == [catvalue(i, pool) for i in 1:3]
+    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:3]
 
     # Changing order while preserving existing levels
     @test levels!(pool, [5, 6, 4]) === pool
@@ -168,7 +168,7 @@ module TestLevels
     @test pool.order == [2, 1, 3]
     @test pool.levels == [5, 6, 4]
     @test get(pool, 5) === DefaultRefType(2)
-    @test pool.valindex == [catvalue(i, pool) for i in 1:3]
+    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:3]
 
     # Adding levels while preserving existing ones
     @test levels!(pool, [5, 2, 3, 6, 4]) === pool
@@ -184,7 +184,7 @@ module TestLevels
     @test pool.levels == [5, 2, 3, 6, 4]
     @test get(pool, 2) === DefaultRefType(4)
     @test get(pool, 3) === DefaultRefType(5)
-    @test pool.valindex == [catvalue(i, pool) for i in 1:5]
+    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:5]
 
     for rep in 1:3
         delete!(pool, 6)
@@ -199,7 +199,7 @@ module TestLevels
         @test pool.levels == [5, 2, 3, 4]
         @test get(pool, 4) === DefaultRefType(2)
         @test_throws KeyError get(pool, 6)
-        @test pool.valindex == [catvalue(i, pool) for i in 1:4]
+        @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:4]
     end
 
 

--- a/test/08_equality.jl
+++ b/test/08_equality.jl
@@ -32,10 +32,10 @@ module TestEquality
     @test (opool1 === opool2) === false
     @test (opool2 === opool2) === true
 
-    nv1a = CategoricalValue(1, pool1)
-    nv2a = CategoricalValue(1, pool2)
-    nv1b = CategoricalValue(2, pool1)
-    nv2b = CategoricalValue(2, pool2)
+    nv1a = catvalue(1, pool1)
+    nv2a = catvalue(1, pool2)
+    nv1b = catvalue(2, pool1)
+    nv2b = catvalue(2, pool2)
 
     @test isequal(nv1a, nv1a) == true
     @test isequal(nv1a, nv2a) == false
@@ -67,10 +67,10 @@ module TestEquality
     @test isequal(nv1b, 2) == true
     @test isequal(nv2b, 2) == false
 
-    ov1a = CategoricalValue(1, opool1)
-    ov2a = CategoricalValue(1, opool2)
-    ov1b = CategoricalValue(2, opool1)
-    ov2b = CategoricalValue(2, opool2)
+    ov1a = catvalue(1, opool1)
+    ov2a = catvalue(1, opool2)
+    ov1b = catvalue(2, opool1)
+    ov2b = catvalue(2, opool2)
 
     @test isequal(ov1a, ov1a) == true
     @test isequal(ov1a, ov2a) == false
@@ -156,7 +156,7 @@ module TestEquality
 
     # Check in()
     pool = CategoricalPool([5, 1, 3])
-    nv = CategoricalValue(2, pool)
+    nv = catvalue(2, pool)
 
     @test (nv in 1:3) === true
     @test (nv in [1, 2, 3]) === true

--- a/test/08_equality.jl
+++ b/test/08_equality.jl
@@ -32,10 +32,10 @@ module TestEquality
     @test (opool1 === opool2) === false
     @test (opool2 === opool2) === true
 
-    nv1a = catvalue(1, pool1)
-    nv2a = catvalue(1, pool2)
-    nv1b = catvalue(2, pool1)
-    nv2b = catvalue(2, pool2)
+    nv1a = CategoricalArrays.catvalue(1, pool1)
+    nv2a = CategoricalArrays.catvalue(1, pool2)
+    nv1b = CategoricalArrays.catvalue(2, pool1)
+    nv2b = CategoricalArrays.catvalue(2, pool2)
 
     @test isequal(nv1a, nv1a) == true
     @test isequal(nv1a, nv2a) == false
@@ -67,10 +67,10 @@ module TestEquality
     @test isequal(nv1b, 2) == true
     @test isequal(nv2b, 2) == false
 
-    ov1a = catvalue(1, opool1)
-    ov2a = catvalue(1, opool2)
-    ov1b = catvalue(2, opool1)
-    ov2b = catvalue(2, opool2)
+    ov1a = CategoricalArrays.catvalue(1, opool1)
+    ov2a = CategoricalArrays.catvalue(1, opool2)
+    ov1b = CategoricalArrays.catvalue(2, opool1)
+    ov2b = CategoricalArrays.catvalue(2, opool2)
 
     @test isequal(ov1a, ov1a) == true
     @test isequal(ov1a, ov2a) == false
@@ -156,7 +156,7 @@ module TestEquality
 
     # Check in()
     pool = CategoricalPool([5, 1, 3])
-    nv = catvalue(2, pool)
+    nv = CategoricalArrays.catvalue(2, pool)
 
     @test (nv in 1:3) === true
     @test (nv in [1, 2, 3]) === true

--- a/test/08_string.jl
+++ b/test/08_string.jl
@@ -4,8 +4,8 @@ module TestString
 
     pool = CategoricalPool(["", "café"])
 
-    v1 = CategoricalValue(1, pool)
-    v2 = CategoricalValue(2, pool)
+    v1 = catvalue(1, pool)
+    v2 = catvalue(2, pool)
 
     @test v1 isa AbstractString
     @test v2 isa AbstractString

--- a/test/08_string.jl
+++ b/test/08_string.jl
@@ -218,4 +218,7 @@ module TestString
 
     @test escape_string(v1) == ""
     @test escape_string(v2) == "café"
+
+    @test collect(v1) == Char[]
+    @test collect(v2) == Char['c', 'a', 'f', 'é']
 end

--- a/test/08_string.jl
+++ b/test/08_string.jl
@@ -4,8 +4,8 @@ module TestString
 
     pool = CategoricalPool(["", "café"])
 
-    v1 = catvalue(1, pool)
-    v2 = catvalue(2, pool)
+    v1 = CategoricalArrays.catvalue(1, pool)
+    v2 = CategoricalArrays.catvalue(2, pool)
 
     @test v1 isa AbstractString
     @test v2 isa AbstractString

--- a/test/09_hash.jl
+++ b/test/09_hash.jl
@@ -16,10 +16,10 @@ module TestHash
     @test (hash(opool1) == hash(opool2)) === false
     @test (hash(opool2) == hash(opool2)) === true
 
-    nv1a = catvalue(1, pool1)
-    nv2a = catvalue(1, pool2)
-    nv1b = catvalue(2, pool1)
-    nv2b = catvalue(2, pool2)
+    nv1a = CategoricalArrays.catvalue(1, pool1)
+    nv2a = CategoricalArrays.catvalue(1, pool2)
+    nv1b = CategoricalArrays.catvalue(2, pool1)
+    nv2b = CategoricalArrays.catvalue(2, pool2)
 
     @test (hash(nv1a) == hash(nv1a)) === true
     @test (hash(nv1a) == hash(nv2a)) === false
@@ -41,10 +41,10 @@ module TestHash
     @test (hash(nv2b) == hash(nv1b)) === false
     @test (hash(nv2b) == hash(nv2b)) === true
 
-    ov1a = catvalue(1, opool1)
-    ov2a = catvalue(1, opool2)
-    ov1b = catvalue(2, opool1)
-    ov2b = catvalue(2, opool2)
+    ov1a = CategoricalArrays.catvalue(1, opool1)
+    ov2a = CategoricalArrays.catvalue(1, opool2)
+    ov1b = CategoricalArrays.catvalue(2, opool1)
+    ov2b = CategoricalArrays.catvalue(2, opool2)
 
     @test (hash(ov1a) == hash(ov1a)) === true
     @test (hash(ov1a) == hash(ov2a)) === false

--- a/test/09_hash.jl
+++ b/test/09_hash.jl
@@ -16,10 +16,10 @@ module TestHash
     @test (hash(opool1) == hash(opool2)) === false
     @test (hash(opool2) == hash(opool2)) === true
 
-    nv1a = CategoricalValue(1, pool1)
-    nv2a = CategoricalValue(1, pool2)
-    nv1b = CategoricalValue(2, pool1)
-    nv2b = CategoricalValue(2, pool2)
+    nv1a = catvalue(1, pool1)
+    nv2a = catvalue(1, pool2)
+    nv1b = catvalue(2, pool1)
+    nv2b = catvalue(2, pool2)
 
     @test (hash(nv1a) == hash(nv1a)) === true
     @test (hash(nv1a) == hash(nv2a)) === false
@@ -41,10 +41,10 @@ module TestHash
     @test (hash(nv2b) == hash(nv1b)) === false
     @test (hash(nv2b) == hash(nv2b)) === true
 
-    ov1a = CategoricalValue(1, opool1)
-    ov2a = CategoricalValue(1, opool2)
-    ov1b = CategoricalValue(2, opool1)
-    ov2b = CategoricalValue(2, opool2)
+    ov1a = catvalue(1, opool1)
+    ov2a = catvalue(1, opool2)
+    ov1b = catvalue(2, opool1)
+    ov2b = catvalue(2, opool2)
 
     @test (hash(ov1a) == hash(ov1a)) === true
     @test (hash(ov1a) == hash(ov2a)) === false

--- a/test/10_isless.jl
+++ b/test/10_isless.jl
@@ -4,9 +4,9 @@ module TestIsLess
 
     pool = CategoricalPool([1, 2, 3])
 
-    v1 = CategoricalValue(1, pool)
-    v2 = CategoricalValue(2, pool)
-    v3 = CategoricalValue(3, pool)
+    v1 = catvalue(1, pool)
+    v2 = catvalue(2, pool)
+    v3 = catvalue(3, pool)
 
     @test_throws ArgumentError v1 < v1
     @test_throws ArgumentError v1 < v2
@@ -246,9 +246,9 @@ module TestIsLess
     # (since the AbstractString fallback could break this)
     pool = CategoricalPool(["a", "b", "c"])
 
-    v1 = CategoricalValue(1, pool)
-    v2 = CategoricalValue(2, pool)
-    v3 = CategoricalValue(3, pool)
+    v1 = catvalue(1, pool)
+    v2 = catvalue(2, pool)
+    v3 = catvalue(3, pool)
 
     @test_throws ArgumentError v1 < v1
     @test_throws ArgumentError v1 < v2
@@ -305,7 +305,7 @@ module TestIsLess
     pool2 = CategoricalPool([1, 2, 3])
     ordered!(pool2, true)
 
-    v = CategoricalValue(1, pool2)
+    v = catvalue(1, pool2)
 
     @test_throws ArgumentError v < v1
     @test_throws ArgumentError v <= v1

--- a/test/10_isless.jl
+++ b/test/10_isless.jl
@@ -4,9 +4,9 @@ module TestIsLess
 
     pool = CategoricalPool([1, 2, 3])
 
-    v1 = catvalue(1, pool)
-    v2 = catvalue(2, pool)
-    v3 = catvalue(3, pool)
+    v1 = CategoricalArrays.catvalue(1, pool)
+    v2 = CategoricalArrays.catvalue(2, pool)
+    v3 = CategoricalArrays.catvalue(3, pool)
 
     @test_throws ArgumentError v1 < v1
     @test_throws ArgumentError v1 < v2
@@ -246,9 +246,9 @@ module TestIsLess
     # (since the AbstractString fallback could break this)
     pool = CategoricalPool(["a", "b", "c"])
 
-    v1 = catvalue(1, pool)
-    v2 = catvalue(2, pool)
-    v3 = catvalue(3, pool)
+    v1 = CategoricalArrays.catvalue(1, pool)
+    v2 = CategoricalArrays.catvalue(2, pool)
+    v3 = CategoricalArrays.catvalue(3, pool)
 
     @test_throws ArgumentError v1 < v1
     @test_throws ArgumentError v1 < v2
@@ -305,7 +305,7 @@ module TestIsLess
     pool2 = CategoricalPool([1, 2, 3])
     ordered!(pool2, true)
 
-    v = catvalue(1, pool2)
+    v = CategoricalArrays.catvalue(1, pool2)
 
     @test_throws ArgumentError v < v1
     @test_throws ArgumentError v <= v1

--- a/test/11_array.jl
+++ b/test/11_array.jl
@@ -2,7 +2,7 @@ module TestArray
 
 using Base.Test
 using CategoricalArrays
-using CategoricalArrays: DefaultRefType
+using CategoricalArrays: DefaultRefType, catvaluetype, leveltype
 
 for ordered in (false, true)
     for R in (CategoricalArrays.DefaultRefType, UInt8, UInt, Int8, Int)
@@ -11,6 +11,10 @@ for ordered in (false, true)
         x = CategoricalVector{String, R}(a, ordered=ordered)
 
         @test x == a
+        @test leveltype(typeof(x)) === String
+        @test leveltype(x) === String
+        @test catvaluetype(typeof(x)) === CategoricalArrays.CategoricalString{R}
+        @test catvaluetype(x) === CategoricalArrays.CategoricalString{R}
         @test isordered(x) === ordered
         @test levels(x) == sort(unique(a))
         @test size(x) === (3,)
@@ -62,11 +66,15 @@ for ordered in (false, true)
             @test x2 == x
             @test isa(x2, CategoricalVector{String, R1})
             @test isordered(x2) === ordered
+            @test leveltype(x2) === String
+            @test catvaluetype(x2) === CategoricalArrays.CategoricalString{R1}
 
             x2 = categorical(y, comp, ordered=ordered)
             @test x2 == x
             @test isa(x2, CategoricalVector{String, R2})
             @test isordered(x2) === ordered
+            @test leveltype(x2) === String
+            @test catvaluetype(x2) === CategoricalArrays.CategoricalString{R2}
         end
 
         x2 = compress(x)
@@ -217,6 +225,8 @@ for ordered in (false, true)
         @test levels(x) == unique(a)
         @test size(x) === (4,)
         @test length(x) === 4
+        @test leveltype(x) === Float64
+        @test catvaluetype(x) <: CategoricalArrays.CategoricalValue{Float64}
 
         @test convert(CategoricalArray, x) === x
         @test convert(CategoricalArray{Float64}, x) === x
@@ -278,11 +288,15 @@ for ordered in (false, true)
             @test x2 == x
             @test isa(x2, CategoricalVector{Float64, R1})
             @test isordered(x2) === ordered
+            @test leveltype(x2) === Float64
+            @test catvaluetype(x2) === CategoricalArrays.CategoricalValue{Float64, R1}
 
             x2 = categorical(y, comp, ordered=ordered)
             @test x2 == x
             @test isa(x2, CategoricalVector{Float64, R2})
             @test isordered(x2) === ordered
+            @test leveltype(x2) === Float64
+            @test catvaluetype(x2) === CategoricalArrays.CategoricalValue{Float64, R2}
         end
 
         x2 = copy(x)

--- a/test/11_array.jl
+++ b/test/11_array.jl
@@ -571,7 +571,7 @@ for ordered in (false, true)
             @test levels(x) == []
 
             x2 = compress(x)
-            @test isa(x2, CategoricalArray{String, ndims(x), UInt8})
+            @test isa(x2, CategoricalArray{leveltype(x), ndims(x), UInt8})
             @test !isassigned(x2, 1) && isdefined(x2, 1)
             @test !isassigned(x2, 2) && isdefined(x2, 2)
             @test_throws UndefRefError x2[1]

--- a/test/12_nullablearray.jl
+++ b/test/12_nullablearray.jl
@@ -2,7 +2,7 @@ module TestNullableArray
 
 using Base.Test
 using CategoricalArrays
-using CategoricalArrays: DefaultRefType
+using CategoricalArrays: DefaultRefType, catvaluetype, leveltype
 
 const ≅ = isequal
 
@@ -14,6 +14,10 @@ for ordered in (false, true)
             x = CategoricalVector{Union{String, Null}, R}(a, ordered=ordered)
 
             @test x == a
+            @test leveltype(typeof(x)) === String
+            @test leveltype(x) === String
+            @test catvaluetype(typeof(x)) === CategoricalArrays.CategoricalString{R}
+            @test catvaluetype(x) === CategoricalArrays.CategoricalString{R}
             @test isordered(x) === ordered
             @test levels(x) == sort(unique(a))
             @test size(x) === (3,)
@@ -62,6 +66,8 @@ for ordered in (false, true)
                                       (x, R, UInt8, true),
                                       (x, R, R, false))
                 x2 = categorical(y, ordered=ordered)
+                @test leveltype(x2) === String
+                @test catvaluetype(x2) === CategoricalArrays.CategoricalString{R1}
                 @test x2 == y
                 if eltype(y) >: Null
                     @test isa(x2, CategoricalVector{Union{String, Null}, R1})
@@ -72,6 +78,8 @@ for ordered in (false, true)
 
                 x2 = categorical(y, comp, ordered=ordered)
                 @test x2 == y
+                @test leveltype(x2) === String
+                @test catvaluetype(x2) === CategoricalArrays.CategoricalString{R2}
                 if eltype(y) >: Null
                     @test isa(x2, CategoricalVector{Union{String, Null}, R2})
                 else
@@ -384,6 +392,8 @@ for ordered in (false, true)
         @test levels(x) == unique(a)
         @test size(x) === (4,)
         @test length(x) === 4
+        @test leveltype(x) === Float64
+        @test catvaluetype(x) <: CategoricalArrays.CategoricalValue{Float64}
 
         @test convert(CategoricalArray, x) === x
         @test convert(CategoricalArray{Union{Float64, Null}}, x) === x
@@ -449,6 +459,8 @@ for ordered in (false, true)
                 @test isa(x2, CategoricalVector{Float64, R1})
             end
             @test isordered(x2) === ordered
+            @test leveltype(x2) === Float64
+            @test catvaluetype(x2) === CategoricalArrays.CategoricalValue{Float64, R1}
 
             x2 = categorical(y, comp, ordered=ordered)
             @test x2 == collect(y)
@@ -458,6 +470,8 @@ for ordered in (false, true)
                 @test isa(x2, CategoricalVector{Float64, R2})
             end
             @test isordered(x2) === ordered
+            @test leveltype(x2) === Float64
+            @test catvaluetype(x2) === CategoricalArrays.CategoricalValue{Float64, R2}
         end
 
         x2 = compress(x)

--- a/test/12_nullablearray.jl
+++ b/test/12_nullablearray.jl
@@ -920,7 +920,7 @@ for ordered in (false, true)
 
             x2 = compress(x)
             @test x2 ≅ x
-            @test isa(x2, CategoricalArray{Union{String, Null}, ndims(x), UInt8})
+            @test isa(x2, CategoricalArray{Union{leveltype(x), Null}, ndims(x), UInt8})
             @test isordered(x2) === isordered(x)
             @test levels(x2) == []
 

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -461,9 +461,9 @@ a4 = [4, 3, 2]
 a5 = [1 2; 3 4]
 ca1 = CategoricalArray(a1)
 ca2 = CategoricalArray{Union{Int, Null}}(a2)
-ca2b = CategoricalArray{Union{Int, Null}, 1, UInt32}(ca2.refs, ca2.pool)
+ca2b = CategoricalArray{Union{Int, Null}, 1}(ca2.refs, ca2.pool)
 ca3 = CategoricalArray(a3)
-ca3b = CategoricalArray{Union{Int, Null}, 1, UInt32}(ca3.refs, ca2.pool)
+ca3b = CategoricalArray{Union{Int, Null}, 1}(ca3.refs, ca2.pool)
 ca4 = CategoricalArray(a4)
 ca5 = CategoricalArray(a5)
 


### PR DESCRIPTION
To transparently support string data, string categorical value type need to be inherited from `AbstractString`, which would conflict with the other categorical types (e.g. numeric) if all are implemented by the same `CategoricalValue{T, R}`.
Based on the discussions in #77, I put this very early draft of the changes that allow `AbstractString` inheritance and dispatch for the string categories, while preserving the old behavior for any other categorical types.
Please give your early feedback on the approach taken.

This PR allows `CategoricalArray` to use arbitrary categorical value type and introduces `CategoricalString{R} <: AbstractString` to be used by default for `String` categorical values (`CategoricalValue{T,R}` is used for the rest).
Both `CategoricalString` and `CategoricalValue` should support "categorical value" concept, which currently requires to "iscatvalue/pool/level/valtype/reftype()" methods.

Since `CategoricalValue` and `CategoricalString` are not relatives, `CatValue = Union{CategoricalValue, CategoricalString}` is introduced to reduce the dispatch rules.
This is not a very good design as `CatValue` definition would have to be updated for each new "categorical value" implementation, making external categorical value types not possible.
However, it should be possible to avoid `CatValue` by employing categorical value traits (dispatching by the result of `iscatvalue(T)`).