### PR TITLE
Fix CategoricalPool levels

### DIFF
--- a/src/typedefs.jl
+++ b/src/typedefs.jl
@@ -17,7 +17,9 @@ mutable struct CategoricalPool{T, R <: Integer, V}
                                       invindex::Dict{T, R},
                                       order::Vector{R},
                                       ordered::Bool) where {T, R, V}
-        pool = new(index, invindex, order, index[order], V[], ordered)
+        levels = similar(index)
+        levels[order] = index
+        pool = new(index, invindex, order, levels, V[], ordered)
         buildvalues!(pool)
         return pool
     end

--- a/src/typedefs.jl
+++ b/src/typedefs.jl
@@ -6,11 +6,11 @@ const DefaultRefType = UInt32
 # This workaround is needed since this type not defined yet
 # See JuliaLang/julia#269
 mutable struct CategoricalPool{T, R <: Integer, V}
-    index::Vector{T}
-    invindex::Dict{T, R}
-    order::Vector{R}
-    levels::Vector{T}
-    valindex::Vector{V}
+    index::Vector{T}        # category levels ordered by their reference codes
+    invindex::Dict{T, R}    # map from category levels to their reference codes
+    order::Vector{R}        # 1-to-1 map from `index` to `level` (position of i-th category in `levels`)
+    levels::Vector{T}       # category levels ordered by externally specified order
+    valindex::Vector{V}     # "category value" objects 1-to-1 matching `index`
     ordered::Bool
 
     function CategoricalPool{T, R, V}(index::Vector{T},

--- a/test/02_buildorder.jl
+++ b/test/02_buildorder.jl
@@ -23,4 +23,12 @@ module TestUpdateOrder
     @test order[1] == convert(DefaultRefType, 2)
     @test order[2] == convert(DefaultRefType, 1)
     @test order[3] == convert(DefaultRefType, 3)
+
+    # test that levels are built correctly
+    orig_index = [2, 5, 1, 3, 4]
+    orig_levels = [1, 2, 3, 4, 5]
+    pool = CategoricalPool(orig_index, orig_levels, true)
+    @test orig_index == CategoricalArrays.index(pool)
+    @test orig_levels == levels(pool)
+    @test CategoricalArrays.index(pool) == levels(pool)[CategoricalArrays.order(pool)]
 end


### PR DESCRIPTION
Since `order` are the positions of `index` elements in the `levels`, it should be that `index == levels[order]`, not `levels == index[order]`.

The tests happen to pass because with 3 elements it's easy to generate a permutation that is inverse to itself.  