### PR TITLE
Fix vcat() return type in corner cases

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -343,9 +343,11 @@ function mergelevels(ordered, levels...)
 
     # Fast path in case all levels are equal
     if all(l -> l == levels[1], levels[2:end])
-        return copy(levels[1]), ordered
+        append!(res, levels[1])
+        return res, ordered
     elseif sum(l -> !isempty(l), levels) == 1
-        return copy(levels[findfirst(l -> !isempty(l), levels)]), ordered
+        append!(res, levels[findfirst(l -> !isempty(l), levels)])
+        return res, ordered
     end
 
     for l in levels

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -512,4 +512,25 @@ ca5 = CategoricalArray(a5)
     ("1×3 CategoricalArrays.CategoricalArray{Union{Nulls.Null, $Int},2,UInt32}",
      "1×3 CategoricalArrays.CategoricalArray{Union{$Int, Nulls.Null},2,UInt32}")
 
+# Test that vcat() takes into account element type even when array is empty
+# or when both arrays have the same levels but of different types
+x = CategoricalVector{String}(0)
+y = CategoricalVector{Int}(0)
+z1 = CategoricalVector{Float64}([1.0])
+z2 = CategoricalVector{Int}([1])
+@inferred vcat(x, y)
+@test vcat(x, y) isa CategoricalVector{Any}
+@inferred vcat(x, z1)
+@test vcat(x, z1) isa CategoricalVector{Any}
+@inferred vcat(y, z1)
+@test vcat(y, z1) isa CategoricalVector{Float64}
+@inferred vcat(x, x)
+@test vcat(x, x) isa CategoricalVector{String}
+@inferred vcat(y, y)
+@test vcat(y, y) isa CategoricalVector{Int}
+@inferred vcat(z1, z1)
+@test vcat(z1, z1) isa CategoricalVector{Float64}
+@inferred vcat(z1, z2)
+@test vcat(z1, z2) isa CategoricalVector{Float64}
+
 end


### PR DESCRIPTION
`mergelevels()`  has fast paths for simple cases which discarded the element type of empty arrays and of arrays with the same levels, and were not type-stable.

Cf. https://github.com/JuliaData/CategoricalArrays.jl/pull/87#discussion_r146276910

Cc: @alyst 