### PR TITLE
Add @testsets

### DIFF
--- a/test/01_typedef.jl
+++ b/test/01_typedef.jl
@@ -3,117 +3,121 @@ using Base.Test
 using CategoricalArrays
 using CategoricalArrays: DefaultRefType, level,  reftype, leveltype, catvalue, iscatvalue
 
-pool = CategoricalPool(
-    [
-        "a",
-        "b",
-        "c"
-    ],
-    Dict(
-        "a" => DefaultRefType(1),
-        "b" => DefaultRefType(2),
-        "c" => DefaultRefType(3),
+@testset "CategoricalPool, a b c order" begin
+    pool = CategoricalPool(
+        [
+            "a",
+            "b",
+            "c"
+        ],
+        Dict(
+            "a" => DefaultRefType(1),
+            "b" => DefaultRefType(2),
+            "c" => DefaultRefType(3),
+        )
     )
-)
 
-@test iscatvalue(Int) == false
-@test iscatvalue(Any) == false
-@test iscatvalue(Null) == false
+    @test iscatvalue(Int) == false
+    @test iscatvalue(Any) == false
+    @test iscatvalue(Null) == false
 
-@test isa(pool, CategoricalPool)
+    @test isa(pool, CategoricalPool)
 
-@test isa(pool.index, Vector)
-@test length(pool.index) == 3
-@test pool.index[1] == "a"
-@test pool.index[2] == "b"
-@test pool.index[3] == "c"
+    @test isa(pool.index, Vector)
+    @test length(pool.index) == 3
+    @test pool.index[1] == "a"
+    @test pool.index[2] == "b"
+    @test pool.index[3] == "c"
 
-@test isa(pool.invindex, Dict)
-@test length(pool.invindex) == 3
-@test pool.invindex["a"] === DefaultRefType(1)
-@test pool.invindex["b"] === DefaultRefType(2)
-@test pool.invindex["c"] === DefaultRefType(3)
+    @test isa(pool.invindex, Dict)
+    @test length(pool.invindex) == 3
+    @test pool.invindex["a"] === DefaultRefType(1)
+    @test pool.invindex["b"] === DefaultRefType(2)
+    @test pool.invindex["c"] === DefaultRefType(3)
 
-@test isa(pool.order, Vector{DefaultRefType})
-@test length(pool.order) == 3
-@test pool.order[1] === DefaultRefType(1)
-@test pool.order[2] === DefaultRefType(2)
-@test pool.order[3] === DefaultRefType(3)
+    @test isa(pool.order, Vector{DefaultRefType})
+    @test length(pool.order) == 3
+    @test pool.order[1] === DefaultRefType(1)
+    @test pool.order[2] === DefaultRefType(2)
+    @test pool.order[3] === DefaultRefType(3)
 
-# leveltype() only accepts categorical value type
-@test_throws ArgumentError leveltype("abc")
-@test_throws ArgumentError leveltype(String)
-@test_throws ArgumentError leveltype(1.0)
-@test_throws ArgumentError leveltype(Int)
+    # leveltype() only accepts categorical value type
+    @test_throws ArgumentError leveltype("abc")
+    @test_throws ArgumentError leveltype(String)
+    @test_throws ArgumentError leveltype(1.0)
+    @test_throws ArgumentError leveltype(Int)
 
-for i in 1:3
-    x = catvalue(i, pool)
+    for i in 1:3
+        x = catvalue(i, pool)
 
-    @test iscatvalue(x)
-    @test iscatvalue(typeof(x))
-    @test eltype(x) === String
-    @test eltype(typeof(x)) === String
-    @test leveltype(x) === String
-    @test leveltype(typeof(x)) === String
-    @test reftype(x) === DefaultRefType
-    @test reftype(typeof(x)) === DefaultRefType
-    @test x isa CategoricalArrays.CategoricalString{DefaultRefType}
+        @test iscatvalue(x)
+        @test iscatvalue(typeof(x))
+        @test eltype(x) === String
+        @test eltype(typeof(x)) === String
+        @test leveltype(x) === String
+        @test leveltype(typeof(x)) === String
+        @test reftype(x) === DefaultRefType
+        @test reftype(typeof(x)) === DefaultRefType
+        @test x isa CategoricalArrays.CategoricalString{DefaultRefType}
 
-    @test isa(level(x), DefaultRefType)
-    @test level(x) === DefaultRefType(i)
+        @test isa(level(x), DefaultRefType)
+        @test level(x) === DefaultRefType(i)
 
-    @test isa(CategoricalArrays.pool(x), CategoricalPool)
-    @test CategoricalArrays.pool(x) === pool
+        @test isa(CategoricalArrays.pool(x), CategoricalPool)
+        @test CategoricalArrays.pool(x) === pool
+    end
 end
 
-pool = CategoricalPool(
-    [
-        "a",
-        "b",
-        "c"
-    ],
-    Dict(
-        "a" => DefaultRefType(1),
-        "b" => DefaultRefType(2),
-        "c" => DefaultRefType(3),
-    ),
-    [
-        DefaultRefType(3),
-        DefaultRefType(2),
-        DefaultRefType(1),
-    ]
-)
+@testset "CategoricalPool, c b a order" begin
+    pool = CategoricalPool(
+        [
+            "a",
+            "b",
+            "c"
+        ],
+        Dict(
+            "a" => DefaultRefType(1),
+            "b" => DefaultRefType(2),
+            "c" => DefaultRefType(3),
+        ),
+        [
+            DefaultRefType(3),
+            DefaultRefType(2),
+            DefaultRefType(1),
+        ]
+    )
 
-@test isa(pool, CategoricalPool)
+    @test isa(pool, CategoricalPool)
 
-@test isa(pool.index, Vector)
-@test length(pool.index) == 3
-@test pool.index[1] == "a"
-@test pool.index[2] == "b"
-@test pool.index[3] == "c"
+    @test isa(pool.index, Vector)
+    @test length(pool.index) == 3
+    @test pool.index[1] == "a"
+    @test pool.index[2] == "b"
+    @test pool.index[3] == "c"
 
-@test isa(pool.invindex, Dict)
-@test length(pool.invindex) == 3
-@test pool.invindex["a"] === DefaultRefType(1)
-@test pool.invindex["b"] === DefaultRefType(2)
-@test pool.invindex["c"] === DefaultRefType(3)
+    @test isa(pool.invindex, Dict)
+    @test length(pool.invindex) == 3
+    @test pool.invindex["a"] === DefaultRefType(1)
+    @test pool.invindex["b"] === DefaultRefType(2)
+    @test pool.invindex["c"] === DefaultRefType(3)
 
-@test isa(pool.order, Vector{DefaultRefType})
-@test length(pool.order) == 3
-@test pool.order[1] === DefaultRefType(3)
-@test pool.order[2] === DefaultRefType(2)
-@test pool.order[3] === DefaultRefType(1)
+    @test isa(pool.order, Vector{DefaultRefType})
+    @test length(pool.order) == 3
+    @test pool.order[1] === DefaultRefType(3)
+    @test pool.order[2] === DefaultRefType(2)
+    @test pool.order[3] === DefaultRefType(1)
 
-for i in 1:3
-    y = catvalue(i, pool)
+    for i in 1:3
+        y = catvalue(i, pool)
 
-    @test iscatvalue(y)
+        @test iscatvalue(y)
 
-    @test isa(level(y), DefaultRefType)
-    @test level(y) === DefaultRefType(i)
+        @test isa(level(y), DefaultRefType)
+        @test level(y) === DefaultRefType(i)
 
-    @test isa(CategoricalArrays.pool(y), CategoricalPool)
-    @test CategoricalArrays.pool(y) === pool
+        @test isa(CategoricalArrays.pool(y), CategoricalPool)
+        @test CategoricalArrays.pool(y) === pool
+    end
 end
 
 end

--- a/test/01_typedef.jl
+++ b/test/01_typedef.jl
@@ -1,118 +1,119 @@
 module TestTypeDef
-    using Base.Test
-    using CategoricalArrays
-    using CategoricalArrays: DefaultRefType, level,  reftype, leveltype, catvalue, iscatvalue
+using Base.Test
+using CategoricalArrays
+using CategoricalArrays: DefaultRefType, level,  reftype, leveltype, catvalue, iscatvalue
 
-    pool = CategoricalPool(
-        [
-            "a",
-            "b",
-            "c"
-        ],
-        Dict(
-            "a" => DefaultRefType(1),
-            "b" => DefaultRefType(2),
-            "c" => DefaultRefType(3),
-        )
+pool = CategoricalPool(
+    [
+        "a",
+        "b",
+        "c"
+    ],
+    Dict(
+        "a" => DefaultRefType(1),
+        "b" => DefaultRefType(2),
+        "c" => DefaultRefType(3),
     )
+)
 
-    @test iscatvalue(Int) == false
-    @test iscatvalue(Any) == false
-    @test iscatvalue(Null) == false
+@test iscatvalue(Int) == false
+@test iscatvalue(Any) == false
+@test iscatvalue(Null) == false
 
-    @test isa(pool, CategoricalPool)
+@test isa(pool, CategoricalPool)
 
-    @test isa(pool.index, Vector)
-    @test length(pool.index) == 3
-    @test pool.index[1] == "a"
-    @test pool.index[2] == "b"
-    @test pool.index[3] == "c"
+@test isa(pool.index, Vector)
+@test length(pool.index) == 3
+@test pool.index[1] == "a"
+@test pool.index[2] == "b"
+@test pool.index[3] == "c"
 
-    @test isa(pool.invindex, Dict)
-    @test length(pool.invindex) == 3
-    @test pool.invindex["a"] === DefaultRefType(1)
-    @test pool.invindex["b"] === DefaultRefType(2)
-    @test pool.invindex["c"] === DefaultRefType(3)
+@test isa(pool.invindex, Dict)
+@test length(pool.invindex) == 3
+@test pool.invindex["a"] === DefaultRefType(1)
+@test pool.invindex["b"] === DefaultRefType(2)
+@test pool.invindex["c"] === DefaultRefType(3)
 
-    @test isa(pool.order, Vector{DefaultRefType})
-    @test length(pool.order) == 3
-    @test pool.order[1] === DefaultRefType(1)
-    @test pool.order[2] === DefaultRefType(2)
-    @test pool.order[3] === DefaultRefType(3)
+@test isa(pool.order, Vector{DefaultRefType})
+@test length(pool.order) == 3
+@test pool.order[1] === DefaultRefType(1)
+@test pool.order[2] === DefaultRefType(2)
+@test pool.order[3] === DefaultRefType(3)
 
-    # leveltype() only accepts categorical value type
-    @test_throws ArgumentError leveltype("abc")
-    @test_throws ArgumentError leveltype(String)
-    @test_throws ArgumentError leveltype(1.0)
-    @test_throws ArgumentError leveltype(Int)
+# leveltype() only accepts categorical value type
+@test_throws ArgumentError leveltype("abc")
+@test_throws ArgumentError leveltype(String)
+@test_throws ArgumentError leveltype(1.0)
+@test_throws ArgumentError leveltype(Int)
 
-    for i in 1:3
-        x = catvalue(i, pool)
+for i in 1:3
+    x = catvalue(i, pool)
 
-        @test iscatvalue(x)
-        @test iscatvalue(typeof(x))
-        @test eltype(x) === String
-        @test eltype(typeof(x)) === String
-        @test leveltype(x) === String
-        @test leveltype(typeof(x)) === String
-        @test reftype(x) === DefaultRefType
-        @test reftype(typeof(x)) === DefaultRefType
-        @test x isa CategoricalArrays.CategoricalString{DefaultRefType}
+    @test iscatvalue(x)
+    @test iscatvalue(typeof(x))
+    @test eltype(x) === String
+    @test eltype(typeof(x)) === String
+    @test leveltype(x) === String
+    @test leveltype(typeof(x)) === String
+    @test reftype(x) === DefaultRefType
+    @test reftype(typeof(x)) === DefaultRefType
+    @test x isa CategoricalArrays.CategoricalString{DefaultRefType}
 
-        @test isa(level(x), DefaultRefType)
-        @test level(x) === DefaultRefType(i)
+    @test isa(level(x), DefaultRefType)
+    @test level(x) === DefaultRefType(i)
 
-        @test isa(CategoricalArrays.pool(x), CategoricalPool)
-        @test CategoricalArrays.pool(x) === pool
-    end
+    @test isa(CategoricalArrays.pool(x), CategoricalPool)
+    @test CategoricalArrays.pool(x) === pool
+end
 
-    pool = CategoricalPool(
-        [
-            "a",
-            "b",
-            "c"
-        ],
-        Dict(
-            "a" => DefaultRefType(1),
-            "b" => DefaultRefType(2),
-            "c" => DefaultRefType(3),
-        ),
-        [
-            DefaultRefType(3),
-            DefaultRefType(2),
-            DefaultRefType(1),
-        ]
-    )
+pool = CategoricalPool(
+    [
+        "a",
+        "b",
+        "c"
+    ],
+    Dict(
+        "a" => DefaultRefType(1),
+        "b" => DefaultRefType(2),
+        "c" => DefaultRefType(3),
+    ),
+    [
+        DefaultRefType(3),
+        DefaultRefType(2),
+        DefaultRefType(1),
+    ]
+)
 
-    @test isa(pool, CategoricalPool)
+@test isa(pool, CategoricalPool)
 
-    @test isa(pool.index, Vector)
-    @test length(pool.index) == 3
-    @test pool.index[1] == "a"
-    @test pool.index[2] == "b"
-    @test pool.index[3] == "c"
+@test isa(pool.index, Vector)
+@test length(pool.index) == 3
+@test pool.index[1] == "a"
+@test pool.index[2] == "b"
+@test pool.index[3] == "c"
 
-    @test isa(pool.invindex, Dict)
-    @test length(pool.invindex) == 3
-    @test pool.invindex["a"] === DefaultRefType(1)
-    @test pool.invindex["b"] === DefaultRefType(2)
-    @test pool.invindex["c"] === DefaultRefType(3)
+@test isa(pool.invindex, Dict)
+@test length(pool.invindex) == 3
+@test pool.invindex["a"] === DefaultRefType(1)
+@test pool.invindex["b"] === DefaultRefType(2)
+@test pool.invindex["c"] === DefaultRefType(3)
 
-    @test isa(pool.order, Vector{DefaultRefType})
-    @test length(pool.order) == 3
-    @test pool.order[1] === DefaultRefType(3)
-    @test pool.order[2] === DefaultRefType(2)
-    @test pool.order[3] === DefaultRefType(1)
+@test isa(pool.order, Vector{DefaultRefType})
+@test length(pool.order) == 3
+@test pool.order[1] === DefaultRefType(3)
+@test pool.order[2] === DefaultRefType(2)
+@test pool.order[3] === DefaultRefType(1)
 
-    for i in 1:3
-        y = catvalue(i, pool)
+for i in 1:3
+    y = catvalue(i, pool)
 
-        @test iscatvalue(y)
+    @test iscatvalue(y)
 
-        @test isa(level(y), DefaultRefType)
-        @test level(y) === DefaultRefType(i)
+    @test isa(level(y), DefaultRefType)
+    @test level(y) === DefaultRefType(i)
 
-        @test isa(CategoricalArrays.pool(y), CategoricalPool)
-        @test CategoricalArrays.pool(y) === pool
-    end
+    @test isa(CategoricalArrays.pool(y), CategoricalPool)
+    @test CategoricalArrays.pool(y) === pool
+end
+
 end

--- a/test/02_buildorder.jl
+++ b/test/02_buildorder.jl
@@ -3,26 +3,28 @@ using Base.Test
 using CategoricalArrays
 using CategoricalArrays: DefaultRefType
 
-pool = CategoricalPool(
-    [
-        "a",
-        "b",
-        "c"
-    ],
-    Dict(
-        "a" => convert(DefaultRefType, 1),
-        "b" => convert(DefaultRefType, 2),
-        "c" => convert(DefaultRefType, 3),
+@testset "buildorder!(b a c)" begin
+    pool = CategoricalPool(
+        [
+            "a",
+            "b",
+            "c"
+        ],
+        Dict(
+            "a" => convert(DefaultRefType, 1),
+            "b" => convert(DefaultRefType, 2),
+            "c" => convert(DefaultRefType, 3),
+        )
     )
-)
 
-order = Vector{DefaultRefType}(length(pool.index))
+    order = Vector{DefaultRefType}(length(pool.index))
 
-CategoricalArrays.buildorder!(order, pool.invindex, ["b", "a", "c"])
+    CategoricalArrays.buildorder!(order, pool.invindex, ["b", "a", "c"])
 
-@test order[1] == convert(DefaultRefType, 2)
-@test order[2] == convert(DefaultRefType, 1)
-@test order[3] == convert(DefaultRefType, 3)
+    @test order[1] == convert(DefaultRefType, 2)
+    @test order[2] == convert(DefaultRefType, 1)
+    @test order[3] == convert(DefaultRefType, 3)
+end
 
 @testset "levels are built correctly" begin
     orig_index = [2, 5, 1, 3, 4]

--- a/test/02_buildorder.jl
+++ b/test/02_buildorder.jl
@@ -1,34 +1,36 @@
 module TestUpdateOrder
-    using Base.Test
-    using CategoricalArrays
-    using CategoricalArrays: DefaultRefType
+using Base.Test
+using CategoricalArrays
+using CategoricalArrays: DefaultRefType
 
-    pool = CategoricalPool(
-        [
-            "a",
-            "b",
-            "c"
-        ],
-        Dict(
-            "a" => convert(DefaultRefType, 1),
-            "b" => convert(DefaultRefType, 2),
-            "c" => convert(DefaultRefType, 3),
-        )
+pool = CategoricalPool(
+    [
+        "a",
+        "b",
+        "c"
+    ],
+    Dict(
+        "a" => convert(DefaultRefType, 1),
+        "b" => convert(DefaultRefType, 2),
+        "c" => convert(DefaultRefType, 3),
     )
+)
 
-    order = Vector{DefaultRefType}(length(pool.index))
+order = Vector{DefaultRefType}(length(pool.index))
 
-    CategoricalArrays.buildorder!(order, pool.invindex, ["b", "a", "c"])
+CategoricalArrays.buildorder!(order, pool.invindex, ["b", "a", "c"])
 
-    @test order[1] == convert(DefaultRefType, 2)
-    @test order[2] == convert(DefaultRefType, 1)
-    @test order[3] == convert(DefaultRefType, 3)
+@test order[1] == convert(DefaultRefType, 2)
+@test order[2] == convert(DefaultRefType, 1)
+@test order[3] == convert(DefaultRefType, 3)
 
-    # test that levels are built correctly
+@testset "levels are built correctly" begin
     orig_index = [2, 5, 1, 3, 4]
     orig_levels = [1, 2, 3, 4, 5]
     pool = CategoricalPool(orig_index, orig_levels, true)
     @test orig_index == CategoricalArrays.index(pool)
     @test orig_levels == levels(pool)
     @test CategoricalArrays.index(pool) == levels(pool)[CategoricalArrays.order(pool)]
+end
+
 end

--- a/test/03_buildfields.jl
+++ b/test/03_buildfields.jl
@@ -3,40 +3,42 @@ using Base.Test
 using CategoricalArrays
 using CategoricalArrays: DefaultRefType
 
-index = ["b", "a", "c"]
+@testset "buildindex(), buildinvindex(), buildorder() for b a c" begin
+    index = ["b", "a", "c"]
 
-invindex = Dict(
-    "b" => DefaultRefType(1),
-    "a" => DefaultRefType(2),
-    "c" => DefaultRefType(3),
-)
+    invindex = Dict(
+        "b" => DefaultRefType(1),
+        "a" => DefaultRefType(2),
+        "c" => DefaultRefType(3),
+    )
 
-order = [
-    DefaultRefType(2),
-    DefaultRefType(1),
-    DefaultRefType(3),
-]
+    order = [
+        DefaultRefType(2),
+        DefaultRefType(1),
+        DefaultRefType(3),
+    ]
 
-pool = CategoricalPool(index, invindex)
+    pool = CategoricalPool(index, invindex)
 
-levels = ["c", "a", "b"]
+    levels = ["c", "a", "b"]
 
-built_index = CategoricalArrays.buildindex(invindex)
-@test isa(index, Vector)
-@test built_index == index
+    built_index = CategoricalArrays.buildindex(invindex)
+    @test isa(index, Vector)
+    @test built_index == index
 
-built_invindex = CategoricalArrays.buildinvindex(index)
-@test isa(invindex, Dict)
-@test built_invindex == invindex
+    built_invindex = CategoricalArrays.buildinvindex(index)
+    @test isa(invindex, Dict)
+    @test built_invindex == invindex
 
-neworder = [
-    DefaultRefType(3),
-    DefaultRefType(2),
-    DefaultRefType(1),
-]
+    neworder = [
+        DefaultRefType(3),
+        DefaultRefType(2),
+        DefaultRefType(1),
+    ]
 
-built_order = CategoricalArrays.buildorder(pool.invindex, levels)
-@test isa(order, Vector{DefaultRefType})
-@test built_order == neworder
+    built_order = CategoricalArrays.buildorder(pool.invindex, levels)
+    @test isa(order, Vector{DefaultRefType})
+    @test built_order == neworder
+end
 
 end

--- a/test/03_buildfields.jl
+++ b/test/03_buildfields.jl
@@ -1,41 +1,42 @@
 module TestBuildFields
-    using Base.Test
-    using CategoricalArrays
-    using CategoricalArrays: DefaultRefType
+using Base.Test
+using CategoricalArrays
+using CategoricalArrays: DefaultRefType
 
-    index = ["b", "a", "c"]
+index = ["b", "a", "c"]
 
-    invindex = Dict(
-        "b" => DefaultRefType(1),
-        "a" => DefaultRefType(2),
-        "c" => DefaultRefType(3),
-    )
+invindex = Dict(
+    "b" => DefaultRefType(1),
+    "a" => DefaultRefType(2),
+    "c" => DefaultRefType(3),
+)
 
-    order = [
-        DefaultRefType(2),
-        DefaultRefType(1),
-        DefaultRefType(3),
-    ]
+order = [
+    DefaultRefType(2),
+    DefaultRefType(1),
+    DefaultRefType(3),
+]
 
-    pool = CategoricalPool(index, invindex)
+pool = CategoricalPool(index, invindex)
 
-    levels = ["c", "a", "b"]
+levels = ["c", "a", "b"]
 
-    built_index = CategoricalArrays.buildindex(invindex)
-    @test isa(index, Vector)
-    @test built_index == index
+built_index = CategoricalArrays.buildindex(invindex)
+@test isa(index, Vector)
+@test built_index == index
 
-    built_invindex = CategoricalArrays.buildinvindex(index)
-    @test isa(invindex, Dict)
-    @test built_invindex == invindex
+built_invindex = CategoricalArrays.buildinvindex(index)
+@test isa(invindex, Dict)
+@test built_invindex == invindex
 
-    neworder = [
-        DefaultRefType(3),
-        DefaultRefType(2),
-        DefaultRefType(1),
-    ]
+neworder = [
+    DefaultRefType(3),
+    DefaultRefType(2),
+    DefaultRefType(1),
+]
 
-    built_order = CategoricalArrays.buildorder(pool.invindex, levels)
-    @test isa(order, Vector{DefaultRefType})
-    @test built_order == neworder
+built_order = CategoricalArrays.buildorder(pool.invindex, levels)
+@test isa(order, Vector{DefaultRefType})
+@test built_order == neworder
+
 end

--- a/test/04_constructors.jl
+++ b/test/04_constructors.jl
@@ -1,8 +1,9 @@
 module TestConstructors
-    using Base.Test
-    using CategoricalArrays
-    using CategoricalArrays: DefaultRefType, catvalue
+using Base.Test
+using CategoricalArrays
+using CategoricalArrays: DefaultRefType, catvalue
 
+@testset "Type parameter constraints" begin
     # cannot use categorical value as level type
     @test_throws ArgumentError CategoricalPool{CategoricalValue{Int,UInt8}, UInt8, CategoricalValue{CategoricalValue{Int,UInt8},UInt8}}(
             CategoricalValue{Int,UInt8}[], Dict{CategoricalValue{Int,UInt8}, UInt8}(), UInt8[], false)
@@ -14,205 +15,207 @@ module TestConstructors
     @test_throws ArgumentError CategoricalPool{Int, UInt8, CategoricalValue{Int, UInt16}}(Int[], Dict{Int, UInt8}(), UInt8[], false)
     # correct types combination
     @test CategoricalPool{Int, UInt8, CategoricalValue{Int, UInt8}}(Int[], Dict{Int, UInt8}(), UInt8[], false) isa CategoricalPool
+end
 
-    pool = CategoricalPool{String}()
+pool = CategoricalPool{String}()
 
-    @test isa(pool, CategoricalPool{String})
+@test isa(pool, CategoricalPool{String})
 
-    @test isa(pool.index, Vector{String})
-    @test length(pool.index) == 0
+@test isa(pool.index, Vector{String})
+@test length(pool.index) == 0
 
-    @test isa(pool.invindex, Dict{String, DefaultRefType})
-    @test length(pool.invindex) == 0
+@test isa(pool.invindex, Dict{String, DefaultRefType})
+@test length(pool.invindex) == 0
 
-    pool = CategoricalPool{Int, UInt8}()
+pool = CategoricalPool{Int, UInt8}()
 
-    @test isa(pool, CategoricalPool{Int, UInt8, CategoricalValue{Int, UInt8}})
+@test isa(pool, CategoricalPool{Int, UInt8, CategoricalValue{Int, UInt8}})
 
-    @test isa(pool.index, Vector{Int})
-    @test length(pool.index) == 0
+@test isa(pool.index, Vector{Int})
+@test length(pool.index) == 0
 
-    @test isa(pool.invindex, Dict{Int, UInt8})
-    @test length(pool.invindex) == 0
+@test isa(pool.invindex, Dict{Int, UInt8})
+@test length(pool.invindex) == 0
 
-    pool = CategoricalPool(["a", "b", "c"])
+pool = CategoricalPool(["a", "b", "c"])
 
-    @test isa(pool, CategoricalPool{String, UInt32, CategoricalString{UInt32}})
+@test isa(pool, CategoricalPool{String, UInt32, CategoricalString{UInt32}})
 
-    @test isa(pool.index, Vector{String})
-    @test length(pool.index) == 3
-    @test pool.index[1] == "a"
-    @test pool.index[2] == "b"
-    @test pool.index[3] == "c"
+@test isa(pool.index, Vector{String})
+@test length(pool.index) == 3
+@test pool.index[1] == "a"
+@test pool.index[2] == "b"
+@test pool.index[3] == "c"
 
-    @test isa(pool.invindex, Dict{String, DefaultRefType})
-    @test length(pool.invindex) == 3
-    @test pool.invindex["a"] === DefaultRefType(1)
-    @test pool.invindex["b"] === DefaultRefType(2)
-    @test pool.invindex["c"] === DefaultRefType(3)
+@test isa(pool.invindex, Dict{String, DefaultRefType})
+@test length(pool.invindex) == 3
+@test pool.invindex["a"] === DefaultRefType(1)
+@test pool.invindex["b"] === DefaultRefType(2)
+@test pool.invindex["c"] === DefaultRefType(3)
 
-    pool = CategoricalPool{String, UInt8}(["a", "b", "c"])
+pool = CategoricalPool{String, UInt8}(["a", "b", "c"])
 
-    @test isa(pool, CategoricalPool)
+@test isa(pool, CategoricalPool)
 
-    @test isa(pool.index, Vector{String})
-    @test length(pool.index) == 3
-    @test pool.index[1] == "a"
-    @test pool.index[2] == "b"
-    @test pool.index[3] == "c"
+@test isa(pool.index, Vector{String})
+@test length(pool.index) == 3
+@test pool.index[1] == "a"
+@test pool.index[2] == "b"
+@test pool.index[3] == "c"
 
-    @test isa(pool.invindex, Dict{String, UInt8})
-    @test length(pool.invindex) == 3
-    @test pool.invindex["a"] === UInt8(1)
-    @test pool.invindex["b"] === UInt8(2)
-    @test pool.invindex["c"] === UInt8(3)
+@test isa(pool.invindex, Dict{String, UInt8})
+@test length(pool.invindex) == 3
+@test pool.invindex["a"] === UInt8(1)
+@test pool.invindex["b"] === UInt8(2)
+@test pool.invindex["c"] === UInt8(3)
 
-    pool = CategoricalPool(
-        Dict(
-            "a" => DefaultRefType(1),
-            "b" => DefaultRefType(2),
-            "c" => DefaultRefType(3),
-        )
+pool = CategoricalPool(
+    Dict(
+        "a" => DefaultRefType(1),
+        "b" => DefaultRefType(2),
+        "c" => DefaultRefType(3),
     )
+)
 
-    @test isa(pool, CategoricalPool)
+@test isa(pool, CategoricalPool)
 
-    @test isa(pool.index, Vector{String})
-    @test length(pool.index) == 3
-    @test pool.index[1] == "a"
-    @test pool.index[2] == "b"
-    @test pool.index[3] == "c"
+@test isa(pool.index, Vector{String})
+@test length(pool.index) == 3
+@test pool.index[1] == "a"
+@test pool.index[2] == "b"
+@test pool.index[3] == "c"
 
-    @test isa(pool.invindex, Dict{String, DefaultRefType})
-    @test length(pool.invindex) == 3
-    @test pool.invindex["a"] === DefaultRefType(1)
-    @test pool.invindex["b"] === DefaultRefType(2)
-    @test pool.invindex["c"] === DefaultRefType(3)
+@test isa(pool.invindex, Dict{String, DefaultRefType})
+@test length(pool.invindex) == 3
+@test pool.invindex["a"] === DefaultRefType(1)
+@test pool.invindex["b"] === DefaultRefType(2)
+@test pool.invindex["c"] === DefaultRefType(3)
 
-    # TODO: Make sure that invindex input is exhaustive
-    # Raise an error if map misses any entries
-    pool = CategoricalPool(
-        Dict(
-            "a" => 1,
-            "b" => 2,
-            "c" => 3,
-        )
+# TODO: Make sure that invindex input is exhaustive
+# Raise an error if map misses any entries
+pool = CategoricalPool(
+    Dict(
+        "a" => 1,
+        "b" => 2,
+        "c" => 3,
     )
+)
 
-    @test isa(pool, CategoricalPool)
+@test isa(pool, CategoricalPool)
 
-    @test isa(pool.index, Vector{String})
-    @test length(pool.index) == 3
-    @test pool.index[1] == "a"
-    @test pool.index[2] == "b"
-    @test pool.index[3] == "c"
+@test isa(pool.index, Vector{String})
+@test length(pool.index) == 3
+@test pool.index[1] == "a"
+@test pool.index[2] == "b"
+@test pool.index[3] == "c"
 
-    @test isa(pool.invindex, Dict{String, DefaultRefType})
-    @test length(pool.invindex) == 3
-    @test pool.invindex["a"] === DefaultRefType(1)
-    @test pool.invindex["b"] === DefaultRefType(2)
-    @test pool.invindex["c"] === DefaultRefType(3)
+@test isa(pool.invindex, Dict{String, DefaultRefType})
+@test length(pool.invindex) == 3
+@test pool.invindex["a"] === DefaultRefType(1)
+@test pool.invindex["b"] === DefaultRefType(2)
+@test pool.invindex["c"] === DefaultRefType(3)
 
-    pool = CategoricalPool(["c", "b", "a"])
+pool = CategoricalPool(["c", "b", "a"])
 
-    @test isa(pool, CategoricalPool)
+@test isa(pool, CategoricalPool)
 
-    @test length(pool.index) == 3
-    @test pool.index[1] == "c"
-    @test pool.index[2] == "b"
-    @test pool.index[3] == "a"
+@test length(pool.index) == 3
+@test pool.index[1] == "c"
+@test pool.index[2] == "b"
+@test pool.index[3] == "a"
 
-    @test isa(pool.invindex, Dict{String, DefaultRefType})
-    @test length(pool.invindex) == 3
-    @test pool.invindex["c"] === DefaultRefType(1)
-    @test pool.invindex["b"] === DefaultRefType(2)
-    @test pool.invindex["a"] === DefaultRefType(3)
+@test isa(pool.invindex, Dict{String, DefaultRefType})
+@test length(pool.invindex) == 3
+@test pool.invindex["c"] === DefaultRefType(1)
+@test pool.invindex["b"] === DefaultRefType(2)
+@test pool.invindex["a"] === DefaultRefType(3)
 
-    @test isa(pool.order, Vector{DefaultRefType})
-    @test length(pool.order) == 3
-    @test pool.order[1] === DefaultRefType(1)
-    @test pool.order[2] === DefaultRefType(2)
-    @test pool.order[3] === DefaultRefType(3)
+@test isa(pool.order, Vector{DefaultRefType})
+@test length(pool.order) == 3
+@test pool.order[1] === DefaultRefType(1)
+@test pool.order[2] === DefaultRefType(2)
+@test pool.order[3] === DefaultRefType(3)
 
-    pool = CategoricalPool(
-        Dict(
-            "a" => DefaultRefType(3),
-            "b" => DefaultRefType(2),
-            "c" => DefaultRefType(1),
-        )
+pool = CategoricalPool(
+    Dict(
+        "a" => DefaultRefType(3),
+        "b" => DefaultRefType(2),
+        "c" => DefaultRefType(1),
     )
+)
 
-    @test isa(pool, CategoricalPool)
+@test isa(pool, CategoricalPool)
 
-    @test length(pool.index) == 3
-    @test pool.index[1] == "c"
-    @test pool.index[2] == "b"
-    @test pool.index[3] == "a"
+@test length(pool.index) == 3
+@test pool.index[1] == "c"
+@test pool.index[2] == "b"
+@test pool.index[3] == "a"
 
-    @test isa(pool.invindex, Dict{String, DefaultRefType})
-    @test length(pool.invindex) == 3
-    @test pool.invindex["c"] === DefaultRefType(1)
-    @test pool.invindex["b"] === DefaultRefType(2)
-    @test pool.invindex["a"] === DefaultRefType(3)
+@test isa(pool.invindex, Dict{String, DefaultRefType})
+@test length(pool.invindex) == 3
+@test pool.invindex["c"] === DefaultRefType(1)
+@test pool.invindex["b"] === DefaultRefType(2)
+@test pool.invindex["a"] === DefaultRefType(3)
 
-    @test isa(pool.order, Vector{DefaultRefType})
-    @test length(pool.order) == 3
-    @test pool.order[1] === DefaultRefType(1)
-    @test pool.order[2] === DefaultRefType(2)
-    @test pool.order[3] === DefaultRefType(3)
+@test isa(pool.order, Vector{DefaultRefType})
+@test length(pool.order) == 3
+@test pool.order[1] === DefaultRefType(1)
+@test pool.order[2] === DefaultRefType(2)
+@test pool.order[3] === DefaultRefType(3)
 
-    pool = CategoricalPool(["c", "b", "a"], ["c", "b", "a"])
+pool = CategoricalPool(["c", "b", "a"], ["c", "b", "a"])
 
-    @test isa(pool, CategoricalPool)
+@test isa(pool, CategoricalPool)
 
-    @test length(pool.index) == 3
-    @test pool.index[1] == "c"
-    @test pool.index[2] == "b"
-    @test pool.index[3] == "a"
+@test length(pool.index) == 3
+@test pool.index[1] == "c"
+@test pool.index[2] == "b"
+@test pool.index[3] == "a"
 
-    @test isa(pool.invindex, Dict{String, DefaultRefType})
-    @test length(pool.invindex) == 3
-    @test pool.invindex["c"] === DefaultRefType(1)
-    @test pool.invindex["b"] === DefaultRefType(2)
-    @test pool.invindex["a"] === DefaultRefType(3)
+@test isa(pool.invindex, Dict{String, DefaultRefType})
+@test length(pool.invindex) == 3
+@test pool.invindex["c"] === DefaultRefType(1)
+@test pool.invindex["b"] === DefaultRefType(2)
+@test pool.invindex["a"] === DefaultRefType(3)
 
-    @test isa(pool.order, Vector{DefaultRefType})
-    @test length(pool.order) == 3
-    @test pool.order[1] === DefaultRefType(1)
-    @test pool.order[2] === DefaultRefType(2)
-    @test pool.order[3] === DefaultRefType(3)
+@test isa(pool.order, Vector{DefaultRefType})
+@test length(pool.order) == 3
+@test pool.order[1] === DefaultRefType(1)
+@test pool.order[2] === DefaultRefType(2)
+@test pool.order[3] === DefaultRefType(3)
 
-    pool = CategoricalPool(
-        Dict(
-            "a" => DefaultRefType(3),
-            "b" => DefaultRefType(2),
-            "c" => DefaultRefType(1),
-        ),
-        ["c", "b", "a"]
-    )
+pool = CategoricalPool(
+    Dict(
+        "a" => DefaultRefType(3),
+        "b" => DefaultRefType(2),
+        "c" => DefaultRefType(1),
+    ),
+    ["c", "b", "a"]
+)
 
-    @test isa(pool, CategoricalPool)
+@test isa(pool, CategoricalPool)
 
-    @test length(pool.index) == 3
-    @test pool.index[1] == "c"
-    @test pool.index[2] == "b"
-    @test pool.index[3] == "a"
+@test length(pool.index) == 3
+@test pool.index[1] == "c"
+@test pool.index[2] == "b"
+@test pool.index[3] == "a"
 
-    @test isa(pool.invindex, Dict{String, DefaultRefType})
-    @test length(pool.invindex) == 3
-    @test pool.invindex["c"] === DefaultRefType(1)
-    @test pool.invindex["b"] === DefaultRefType(2)
-    @test pool.invindex["a"] === DefaultRefType(3)
+@test isa(pool.invindex, Dict{String, DefaultRefType})
+@test length(pool.invindex) == 3
+@test pool.invindex["c"] === DefaultRefType(1)
+@test pool.invindex["b"] === DefaultRefType(2)
+@test pool.invindex["a"] === DefaultRefType(3)
 
-    @test isa(pool.order, Vector{DefaultRefType})
-    @test length(pool.order) == 3
-    @test pool.order[1] === DefaultRefType(1)
-    @test pool.order[2] === DefaultRefType(2)
-    @test pool.order[3] === DefaultRefType(3)
+@test isa(pool.order, Vector{DefaultRefType})
+@test length(pool.order) == 3
+@test pool.order[1] === DefaultRefType(1)
+@test pool.order[2] === DefaultRefType(2)
+@test pool.order[3] === DefaultRefType(3)
 
-    # test floating point pool
-    pool = CategoricalPool{Float64, UInt8}([1.0, 2.0, 3.0])
+# test floating point pool
+pool = CategoricalPool{Float64, UInt8}([1.0, 2.0, 3.0])
 
-    @test isa(pool, CategoricalPool{Float64, UInt8, CategoricalValue{Float64, UInt8}})
-    @test catvalue(1, pool) isa CategoricalValue{Float64, UInt8}
+@test isa(pool, CategoricalPool{Float64, UInt8, CategoricalValue{Float64, UInt8}})
+@test catvalue(1, pool) isa CategoricalValue{Float64, UInt8}
+
 end

--- a/test/04_constructors.jl
+++ b/test/04_constructors.jl
@@ -17,205 +17,226 @@ using CategoricalArrays: DefaultRefType, catvalue
     @test CategoricalPool{Int, UInt8, CategoricalValue{Int, UInt8}}(Int[], Dict{Int, UInt8}(), UInt8[], false) isa CategoricalPool
 end
 
-pool = CategoricalPool{String}()
+@testset "empty CategoricalPool{String}" begin
+    pool = CategoricalPool{String}()
 
-@test isa(pool, CategoricalPool{String})
+    @test isa(pool, CategoricalPool{String})
 
-@test isa(pool.index, Vector{String})
-@test length(pool.index) == 0
+    @test isa(pool.index, Vector{String})
+    @test length(pool.index) == 0
 
-@test isa(pool.invindex, Dict{String, DefaultRefType})
-@test length(pool.invindex) == 0
+    @test isa(pool.invindex, Dict{String, DefaultRefType})
+    @test length(pool.invindex) == 0
+end
 
-pool = CategoricalPool{Int, UInt8}()
+@testset "empty CategoricalPool{Int}" begin
+    pool = CategoricalPool{Int, UInt8}()
 
-@test isa(pool, CategoricalPool{Int, UInt8, CategoricalValue{Int, UInt8}})
+    @test isa(pool, CategoricalPool{Int, UInt8, CategoricalValue{Int, UInt8}})
 
-@test isa(pool.index, Vector{Int})
-@test length(pool.index) == 0
+    @test isa(pool.index, Vector{Int})
+    @test length(pool.index) == 0
 
-@test isa(pool.invindex, Dict{Int, UInt8})
-@test length(pool.invindex) == 0
+    @test isa(pool.invindex, Dict{Int, UInt8})
+    @test length(pool.invindex) == 0
+end
 
-pool = CategoricalPool(["a", "b", "c"])
+@testset "CategoricalPool{String, DefaultRefType}(a b c)" begin
+    pool = CategoricalPool(["a", "b", "c"])
 
-@test isa(pool, CategoricalPool{String, UInt32, CategoricalString{UInt32}})
+    @test isa(pool, CategoricalPool{String, UInt32, CategoricalString{UInt32}})
 
-@test isa(pool.index, Vector{String})
-@test length(pool.index) == 3
-@test pool.index[1] == "a"
-@test pool.index[2] == "b"
-@test pool.index[3] == "c"
+    @test isa(pool.index, Vector{String})
+    @test length(pool.index) == 3
+    @test pool.index[1] == "a"
+    @test pool.index[2] == "b"
+    @test pool.index[3] == "c"
 
-@test isa(pool.invindex, Dict{String, DefaultRefType})
-@test length(pool.invindex) == 3
-@test pool.invindex["a"] === DefaultRefType(1)
-@test pool.invindex["b"] === DefaultRefType(2)
-@test pool.invindex["c"] === DefaultRefType(3)
+    @test isa(pool.invindex, Dict{String, DefaultRefType})
+    @test length(pool.invindex) == 3
+    @test pool.invindex["a"] === DefaultRefType(1)
+    @test pool.invindex["b"] === DefaultRefType(2)
+    @test pool.invindex["c"] === DefaultRefType(3)
+end
 
-pool = CategoricalPool{String, UInt8}(["a", "b", "c"])
+@testset "CategoricalPool{String, UInt8}(a b c)" begin
+    pool = CategoricalPool{String, UInt8}(["a", "b", "c"])
 
-@test isa(pool, CategoricalPool)
+    @test isa(pool, CategoricalPool)
 
-@test isa(pool.index, Vector{String})
-@test length(pool.index) == 3
-@test pool.index[1] == "a"
-@test pool.index[2] == "b"
-@test pool.index[3] == "c"
+    @test isa(pool.index, Vector{String})
+    @test length(pool.index) == 3
+    @test pool.index[1] == "a"
+    @test pool.index[2] == "b"
+    @test pool.index[3] == "c"
 
-@test isa(pool.invindex, Dict{String, UInt8})
-@test length(pool.invindex) == 3
-@test pool.invindex["a"] === UInt8(1)
-@test pool.invindex["b"] === UInt8(2)
-@test pool.invindex["c"] === UInt8(3)
+    @test isa(pool.invindex, Dict{String, UInt8})
+    @test length(pool.invindex) == 3
+    @test pool.invindex["a"] === UInt8(1)
+    @test pool.invindex["b"] === UInt8(2)
+    @test pool.invindex["c"] === UInt8(3)
+end
 
-pool = CategoricalPool(
-    Dict(
-        "a" => DefaultRefType(1),
-        "b" => DefaultRefType(2),
-        "c" => DefaultRefType(3),
+@testset "CategoricalPool(a b c) with specified reference codes" begin
+    pool = CategoricalPool(
+        Dict(
+            "a" => DefaultRefType(1),
+            "b" => DefaultRefType(2),
+            "c" => DefaultRefType(3),
+        )
     )
-)
 
-@test isa(pool, CategoricalPool)
+    @test isa(pool, CategoricalPool)
 
-@test isa(pool.index, Vector{String})
-@test length(pool.index) == 3
-@test pool.index[1] == "a"
-@test pool.index[2] == "b"
-@test pool.index[3] == "c"
+    @test isa(pool.index, Vector{String})
+    @test length(pool.index) == 3
+    @test pool.index[1] == "a"
+    @test pool.index[2] == "b"
+    @test pool.index[3] == "c"
 
-@test isa(pool.invindex, Dict{String, DefaultRefType})
-@test length(pool.invindex) == 3
-@test pool.invindex["a"] === DefaultRefType(1)
-@test pool.invindex["b"] === DefaultRefType(2)
-@test pool.invindex["c"] === DefaultRefType(3)
+    @test isa(pool.invindex, Dict{String, DefaultRefType})
+    @test length(pool.invindex) == 3
+    @test pool.invindex["a"] === DefaultRefType(1)
+    @test pool.invindex["b"] === DefaultRefType(2)
+    @test pool.invindex["c"] === DefaultRefType(3)
+end
 
-# TODO: Make sure that invindex input is exhaustive
-# Raise an error if map misses any entries
-pool = CategoricalPool(
-    Dict(
-        "a" => 1,
-        "b" => 2,
-        "c" => 3,
+@testset "CategoricalPool(a b c) with specified Int ref codes" begin
+    # TODO: Make sure that invindex input is exhaustive
+    # Raise an error if map misses any entries
+    pool = CategoricalPool(
+        Dict(
+            "a" => 1,
+            "b" => 2,
+            "c" => 3,
+        )
     )
-)
 
-@test isa(pool, CategoricalPool)
+    @test isa(pool, CategoricalPool)
 
-@test isa(pool.index, Vector{String})
-@test length(pool.index) == 3
-@test pool.index[1] == "a"
-@test pool.index[2] == "b"
-@test pool.index[3] == "c"
+    @test isa(pool.index, Vector{String})
+    @test length(pool.index) == 3
+    @test pool.index[1] == "a"
+    @test pool.index[2] == "b"
+    @test pool.index[3] == "c"
 
-@test isa(pool.invindex, Dict{String, DefaultRefType})
-@test length(pool.invindex) == 3
-@test pool.invindex["a"] === DefaultRefType(1)
-@test pool.invindex["b"] === DefaultRefType(2)
-@test pool.invindex["c"] === DefaultRefType(3)
+    @test isa(pool.invindex, Dict{String, DefaultRefType})
+    @test length(pool.invindex) == 3
+    @test pool.invindex["a"] === DefaultRefType(1)
+    @test pool.invindex["b"] === DefaultRefType(2)
+    @test pool.invindex["c"] === DefaultRefType(3)
+end
 
-pool = CategoricalPool(["c", "b", "a"])
+@testset "CategoricalPool(c b a)" begin
+    pool = CategoricalPool(["c", "b", "a"])
 
-@test isa(pool, CategoricalPool)
+    @test isa(pool, CategoricalPool)
 
-@test length(pool.index) == 3
-@test pool.index[1] == "c"
-@test pool.index[2] == "b"
-@test pool.index[3] == "a"
+    @test length(pool.index) == 3
+    @test pool.index[1] == "c"
+    @test pool.index[2] == "b"
+    @test pool.index[3] == "a"
 
-@test isa(pool.invindex, Dict{String, DefaultRefType})
-@test length(pool.invindex) == 3
-@test pool.invindex["c"] === DefaultRefType(1)
-@test pool.invindex["b"] === DefaultRefType(2)
-@test pool.invindex["a"] === DefaultRefType(3)
+    @test isa(pool.invindex, Dict{String, DefaultRefType})
+    @test length(pool.invindex) == 3
+    @test pool.invindex["c"] === DefaultRefType(1)
+    @test pool.invindex["b"] === DefaultRefType(2)
+    @test pool.invindex["a"] === DefaultRefType(3)
 
-@test isa(pool.order, Vector{DefaultRefType})
-@test length(pool.order) == 3
-@test pool.order[1] === DefaultRefType(1)
-@test pool.order[2] === DefaultRefType(2)
-@test pool.order[3] === DefaultRefType(3)
+    @test isa(pool.order, Vector{DefaultRefType})
+    @test length(pool.order) == 3
+    @test pool.order[1] === DefaultRefType(1)
+    @test pool.order[2] === DefaultRefType(2)
+    @test pool.order[3] === DefaultRefType(3)
+end
 
-pool = CategoricalPool(
-    Dict(
-        "a" => DefaultRefType(3),
-        "b" => DefaultRefType(2),
-        "c" => DefaultRefType(1),
+@testset "CategoricalPool(a b c) with ref codes not matching the natural order" begin
+    pool = CategoricalPool(
+        Dict(
+            "a" => DefaultRefType(3),
+            "b" => DefaultRefType(2),
+            "c" => DefaultRefType(1),
+        )
     )
-)
 
-@test isa(pool, CategoricalPool)
+    @test isa(pool, CategoricalPool)
 
-@test length(pool.index) == 3
-@test pool.index[1] == "c"
-@test pool.index[2] == "b"
-@test pool.index[3] == "a"
+    @test length(pool.index) == 3
+    @test pool.index[1] == "c"
+    @test pool.index[2] == "b"
+    @test pool.index[3] == "a"
 
-@test isa(pool.invindex, Dict{String, DefaultRefType})
-@test length(pool.invindex) == 3
-@test pool.invindex["c"] === DefaultRefType(1)
-@test pool.invindex["b"] === DefaultRefType(2)
-@test pool.invindex["a"] === DefaultRefType(3)
+    @test isa(pool.invindex, Dict{String, DefaultRefType})
+    @test length(pool.invindex) == 3
+    @test pool.invindex["c"] === DefaultRefType(1)
+    @test pool.invindex["b"] === DefaultRefType(2)
+    @test pool.invindex["a"] === DefaultRefType(3)
 
-@test isa(pool.order, Vector{DefaultRefType})
-@test length(pool.order) == 3
-@test pool.order[1] === DefaultRefType(1)
-@test pool.order[2] === DefaultRefType(2)
-@test pool.order[3] === DefaultRefType(3)
+    @test isa(pool.order, Vector{DefaultRefType})
+    @test length(pool.order) == 3
+    @test pool.order[1] === DefaultRefType(1)
+    @test pool.order[2] === DefaultRefType(2)
+    @test pool.order[3] === DefaultRefType(3)
+end
 
-pool = CategoricalPool(["c", "b", "a"], ["c", "b", "a"])
+@testset "CategoricalPool(a b c) with specified levels order" begin
+    pool = CategoricalPool(["c", "b", "a"], ["c", "b", "a"])
 
-@test isa(pool, CategoricalPool)
+    @test isa(pool, CategoricalPool)
 
-@test length(pool.index) == 3
-@test pool.index[1] == "c"
-@test pool.index[2] == "b"
-@test pool.index[3] == "a"
+    @test length(pool.index) == 3
+    @test pool.index[1] == "c"
+    @test pool.index[2] == "b"
+    @test pool.index[3] == "a"
 
-@test isa(pool.invindex, Dict{String, DefaultRefType})
-@test length(pool.invindex) == 3
-@test pool.invindex["c"] === DefaultRefType(1)
-@test pool.invindex["b"] === DefaultRefType(2)
-@test pool.invindex["a"] === DefaultRefType(3)
+    @test isa(pool.invindex, Dict{String, DefaultRefType})
+    @test length(pool.invindex) == 3
+    @test pool.invindex["c"] === DefaultRefType(1)
+    @test pool.invindex["b"] === DefaultRefType(2)
+    @test pool.invindex["a"] === DefaultRefType(3)
 
-@test isa(pool.order, Vector{DefaultRefType})
-@test length(pool.order) == 3
-@test pool.order[1] === DefaultRefType(1)
-@test pool.order[2] === DefaultRefType(2)
-@test pool.order[3] === DefaultRefType(3)
+    @test isa(pool.order, Vector{DefaultRefType})
+    @test length(pool.order) == 3
+    @test pool.order[1] === DefaultRefType(1)
+    @test pool.order[2] === DefaultRefType(2)
+    @test pool.order[3] === DefaultRefType(3)
+end
 
-pool = CategoricalPool(
-    Dict(
-        "a" => DefaultRefType(3),
-        "b" => DefaultRefType(2),
-        "c" => DefaultRefType(1),
-    ),
-    ["c", "b", "a"]
-)
+@testset "CategoricalPool(a b c) with specified index and levels order" begin
+    pool = CategoricalPool(
+        Dict(
+            "a" => DefaultRefType(3),
+            "b" => DefaultRefType(2),
+            "c" => DefaultRefType(1),
+        ),
+        ["c", "b", "a"]
+    )
 
-@test isa(pool, CategoricalPool)
+    @test isa(pool, CategoricalPool)
 
-@test length(pool.index) == 3
-@test pool.index[1] == "c"
-@test pool.index[2] == "b"
-@test pool.index[3] == "a"
+    @test length(pool.index) == 3
+    @test pool.index[1] == "c"
+    @test pool.index[2] == "b"
+    @test pool.index[3] == "a"
 
-@test isa(pool.invindex, Dict{String, DefaultRefType})
-@test length(pool.invindex) == 3
-@test pool.invindex["c"] === DefaultRefType(1)
-@test pool.invindex["b"] === DefaultRefType(2)
-@test pool.invindex["a"] === DefaultRefType(3)
+    @test isa(pool.invindex, Dict{String, DefaultRefType})
+    @test length(pool.invindex) == 3
+    @test pool.invindex["c"] === DefaultRefType(1)
+    @test pool.invindex["b"] === DefaultRefType(2)
+    @test pool.invindex["a"] === DefaultRefType(3)
 
-@test isa(pool.order, Vector{DefaultRefType})
-@test length(pool.order) == 3
-@test pool.order[1] === DefaultRefType(1)
-@test pool.order[2] === DefaultRefType(2)
-@test pool.order[3] === DefaultRefType(3)
+    @test isa(pool.order, Vector{DefaultRefType})
+    @test length(pool.order) == 3
+    @test pool.order[1] === DefaultRefType(1)
+    @test pool.order[2] === DefaultRefType(2)
+    @test pool.order[3] === DefaultRefType(3)
+end
 
-# test floating point pool
-pool = CategoricalPool{Float64, UInt8}([1.0, 2.0, 3.0])
+@testset "CategoricalPool{Float64, UInt8}()" begin
+    pool = CategoricalPool{Float64, UInt8}([1.0, 2.0, 3.0])
 
-@test isa(pool, CategoricalPool{Float64, UInt8, CategoricalValue{Float64, UInt8}})
-@test catvalue(1, pool) isa CategoricalValue{Float64, UInt8}
+    @test isa(pool, CategoricalPool{Float64, UInt8, CategoricalValue{Float64, UInt8}})
+    @test catvalue(1, pool) isa CategoricalValue{Float64, UInt8}
+end
 
 end

--- a/test/05_convert.jl
+++ b/test/05_convert.jl
@@ -3,59 +3,62 @@ using Base.Test
 using CategoricalArrays
 using CategoricalArrays: DefaultRefType, level, reftype, leveltype, catvalue, iscatvalue
 
-pool = CategoricalPool([1, 2, 3])
-@test convert(CategoricalPool{Int, DefaultRefType}, pool) === pool
-@test convert(CategoricalPool{Int}, pool) === pool
-@test convert(CategoricalPool, pool) === pool
-convert(CategoricalPool{Float64, UInt8}, pool)
-convert(CategoricalPool{Float64}, pool)
-convert(CategoricalPool, pool)
+@testset "convert() for CategoricalPool{Int, DefaultRefType} and values" begin
+    pool = CategoricalPool([1, 2, 3])
+    @test convert(CategoricalPool{Int, DefaultRefType}, pool) === pool
+    @test convert(CategoricalPool{Int}, pool) === pool
+    @test convert(CategoricalPool, pool) === pool
+    convert(CategoricalPool{Float64, UInt8}, pool)
+    convert(CategoricalPool{Float64}, pool)
+    convert(CategoricalPool, pool)
 
-v1 = catvalue(1, pool)
-v2 = catvalue(2, pool)
-v3 = catvalue(3, pool)
-@test iscatvalue(v1)
-@test iscatvalue(typeof(v1))
-@test eltype(v1) === Int
-@test eltype(typeof(v1)) === Int
-@test leveltype(v1) === Int
-@test leveltype(typeof(v1)) === Int
-@test reftype(v1) === DefaultRefType
-@test reftype(typeof(v1)) === DefaultRefType
-@test v1 isa CategoricalArrays.CategoricalValue{Int, DefaultRefType}
+    v1 = catvalue(1, pool)
+    v2 = catvalue(2, pool)
+    v3 = catvalue(3, pool)
+    @test iscatvalue(v1)
+    @test iscatvalue(typeof(v1))
+    @test eltype(v1) === Int
+    @test eltype(typeof(v1)) === Int
+    @test leveltype(v1) === Int
+    @test leveltype(typeof(v1)) === Int
+    @test reftype(v1) === DefaultRefType
+    @test reftype(typeof(v1)) === DefaultRefType
+    @test v1 isa CategoricalArrays.CategoricalValue{Int, DefaultRefType}
 
-@test convert(Int32, v1) === Int32(1)
-@test convert(Int32, v2) === Int32(2)
-@test convert(Int32, v3) === Int32(3)
+    @test convert(Int32, v1) === Int32(1)
+    @test convert(Int32, v2) === Int32(2)
+    @test convert(Int32, v3) === Int32(3)
 
-@test convert(UInt8, v1) === 0x01
-@test convert(UInt8, v2) === 0x02
-@test convert(UInt8, v3) === 0x03
+    @test convert(UInt8, v1) === 0x01
+    @test convert(UInt8, v2) === 0x02
+    @test convert(UInt8, v3) === 0x03
 
-@test convert(CategoricalValue, v1) === v1
-@test convert(CategoricalValue{Int}, v1) === v1
-@test convert(CategoricalValue{Int, DefaultRefType}, v1) === v1
-@test convert(Any, v1) === v1
+    @test convert(CategoricalValue, v1) === v1
+    @test convert(CategoricalValue{Int}, v1) === v1
+    @test convert(CategoricalValue{Int, DefaultRefType}, v1) === v1
+    @test convert(Any, v1) === v1
 
-convert(Any, v1)
-convert(Any, v2)
-convert(Any, v3)
+    convert(Any, v1)
+    convert(Any, v2)
+    convert(Any, v3)
 
-@test get(v1) === 1
-@test get(v2) === 2
-@test get(v3) === 3
+    @test get(v1) === 1
+    @test get(v2) === 2
+    @test get(v3) === 3
 
-@test promote(1, v1) === (1, 1)
-@test promote(1.0, v1) === (1.0, 1.0)
-@test promote(0x1, v1) === (1, 1)
+    @test promote(1, v1) === (1, 1)
+    @test promote(1.0, v1) === (1.0, 1.0)
+    @test promote(0x1, v1) === (1, 1)
 
-@test promote_type(CategoricalValue, Null) === Union{CategoricalValue, Null}
-@test promote_type(CategoricalValue{Int}, Null) === Union{CategoricalValue{Int}, Null}
-@test promote_type(CategoricalValue{Int, UInt32}, Null) ===
-    Union{CategoricalValue{Int, UInt32}, Null}
+    @test promote_type(CategoricalValue, Null) === Union{CategoricalValue, Null}
+    @test promote_type(CategoricalValue{Int}, Null) === Union{CategoricalValue{Int}, Null}
+    @test promote_type(CategoricalValue{Int, UInt32}, Null) ===
+        Union{CategoricalValue{Int, UInt32}, Null}
+end
 
-# Test that ordered property is preserved
-pool = CategoricalPool([1, 2, 3], true)
-@test convert(CategoricalPool{Float64, UInt8}, pool).ordered === true
+@testset "convert() preserves `ordered`" begin
+    pool = CategoricalPool([1, 2, 3], true)
+    @test convert(CategoricalPool{Float64, UInt8}, pool).ordered === true
+end
 
 end

--- a/test/05_convert.jl
+++ b/test/05_convert.jl
@@ -1,60 +1,61 @@
 module TestConvert
-    using Base.Test
-    using CategoricalArrays
-    using CategoricalArrays: DefaultRefType, level, reftype, leveltype, catvalue, iscatvalue
+using Base.Test
+using CategoricalArrays
+using CategoricalArrays: DefaultRefType, level, reftype, leveltype, catvalue, iscatvalue
 
-    pool = CategoricalPool([1, 2, 3])
-    @test convert(CategoricalPool{Int, DefaultRefType}, pool) === pool
-    @test convert(CategoricalPool{Int}, pool) === pool
-    @test convert(CategoricalPool, pool) === pool
-    convert(CategoricalPool{Float64, UInt8}, pool)
-    convert(CategoricalPool{Float64}, pool)
-    convert(CategoricalPool, pool)
+pool = CategoricalPool([1, 2, 3])
+@test convert(CategoricalPool{Int, DefaultRefType}, pool) === pool
+@test convert(CategoricalPool{Int}, pool) === pool
+@test convert(CategoricalPool, pool) === pool
+convert(CategoricalPool{Float64, UInt8}, pool)
+convert(CategoricalPool{Float64}, pool)
+convert(CategoricalPool, pool)
 
-    v1 = catvalue(1, pool)
-    v2 = catvalue(2, pool)
-    v3 = catvalue(3, pool)
-    @test iscatvalue(v1)
-    @test iscatvalue(typeof(v1))
-    @test eltype(v1) === Int
-    @test eltype(typeof(v1)) === Int
-    @test leveltype(v1) === Int
-    @test leveltype(typeof(v1)) === Int
-    @test reftype(v1) === DefaultRefType
-    @test reftype(typeof(v1)) === DefaultRefType
-    @test v1 isa CategoricalArrays.CategoricalValue{Int, DefaultRefType}
+v1 = catvalue(1, pool)
+v2 = catvalue(2, pool)
+v3 = catvalue(3, pool)
+@test iscatvalue(v1)
+@test iscatvalue(typeof(v1))
+@test eltype(v1) === Int
+@test eltype(typeof(v1)) === Int
+@test leveltype(v1) === Int
+@test leveltype(typeof(v1)) === Int
+@test reftype(v1) === DefaultRefType
+@test reftype(typeof(v1)) === DefaultRefType
+@test v1 isa CategoricalArrays.CategoricalValue{Int, DefaultRefType}
 
-    @test convert(Int32, v1) === Int32(1)
-    @test convert(Int32, v2) === Int32(2)
-    @test convert(Int32, v3) === Int32(3)
+@test convert(Int32, v1) === Int32(1)
+@test convert(Int32, v2) === Int32(2)
+@test convert(Int32, v3) === Int32(3)
 
-    @test convert(UInt8, v1) === 0x01
-    @test convert(UInt8, v2) === 0x02
-    @test convert(UInt8, v3) === 0x03
+@test convert(UInt8, v1) === 0x01
+@test convert(UInt8, v2) === 0x02
+@test convert(UInt8, v3) === 0x03
 
-    @test convert(CategoricalValue, v1) === v1
-    @test convert(CategoricalValue{Int}, v1) === v1
-    @test convert(CategoricalValue{Int, DefaultRefType}, v1) === v1
-    @test convert(Any, v1) === v1
+@test convert(CategoricalValue, v1) === v1
+@test convert(CategoricalValue{Int}, v1) === v1
+@test convert(CategoricalValue{Int, DefaultRefType}, v1) === v1
+@test convert(Any, v1) === v1
 
-    convert(Any, v1)
-    convert(Any, v2)
-    convert(Any, v3)
+convert(Any, v1)
+convert(Any, v2)
+convert(Any, v3)
 
-    @test get(v1) === 1
-    @test get(v2) === 2
-    @test get(v3) === 3
+@test get(v1) === 1
+@test get(v2) === 2
+@test get(v3) === 3
 
-    @test promote(1, v1) === (1, 1)
-    @test promote(1.0, v1) === (1.0, 1.0)
-    @test promote(0x1, v1) === (1, 1)
+@test promote(1, v1) === (1, 1)
+@test promote(1.0, v1) === (1.0, 1.0)
+@test promote(0x1, v1) === (1, 1)
 
-    @test promote_type(CategoricalValue, Null) === Union{CategoricalValue, Null}
-    @test promote_type(CategoricalValue{Int}, Null) === Union{CategoricalValue{Int}, Null}
-    @test promote_type(CategoricalValue{Int, UInt32}, Null) ===
-        Union{CategoricalValue{Int, UInt32}, Null}
+@test promote_type(CategoricalValue, Null) === Union{CategoricalValue, Null}
+@test promote_type(CategoricalValue{Int}, Null) === Union{CategoricalValue{Int}, Null}
+@test promote_type(CategoricalValue{Int, UInt32}, Null) ===
+    Union{CategoricalValue{Int, UInt32}, Null}
 
-    # Test that ordered property is preserved
-    pool = CategoricalPool([1, 2, 3], true)
-    @test convert(CategoricalPool{Float64, UInt8}, pool).ordered === true
+# Test that ordered property is preserved
+pool = CategoricalPool([1, 2, 3], true)
+@test convert(CategoricalPool{Float64, UInt8}, pool).ordered === true
+
 end

--- a/test/06_length.jl
+++ b/test/06_length.jl
@@ -1,10 +1,10 @@
 module TestLength
-    using Base.Test
-    using CategoricalArrays
+using Base.Test
+using CategoricalArrays
 
-    pool = CategoricalPool([1, 2, 3])
-    @test length(pool) == 3
+pool = CategoricalPool([1, 2, 3])
+@test length(pool) == 3
 
-    pool = CategoricalPool([1, 2, 3], [3, 2, 1])
-    @test length(pool) == 3
+pool = CategoricalPool([1, 2, 3], [3, 2, 1])
+@test length(pool) == 3
 end

--- a/test/06_length.jl
+++ b/test/06_length.jl
@@ -2,9 +2,12 @@ module TestLength
 using Base.Test
 using CategoricalArrays
 
-pool = CategoricalPool([1, 2, 3])
-@test length(pool) == 3
+@testset "length(pool)" begin
+    pool = CategoricalPool([1, 2, 3])
+    @test length(pool) == 3
 
-pool = CategoricalPool([1, 2, 3], [3, 2, 1])
-@test length(pool) == 3
+    pool = CategoricalPool([1, 2, 3], [3, 2, 1])
+    @test length(pool) == 3
+end
+
 end

--- a/test/06_show.jl
+++ b/test/06_show.jl
@@ -2,7 +2,7 @@ module TestShow
 using Base.Test
 using CategoricalArrays
 
-@testset "String-valued CategoricalPool" begin
+@testset "show() for CategoricalPool{String} and its values" begin
     pool = CategoricalPool(["c", "b", "a"])
 
     opool = CategoricalPool(["c", "b", "a"], ["a", "b", "c"], true)
@@ -43,7 +43,7 @@ using CategoricalArrays
     @test repr(nv3) == repr(ov3) == "\"a\""
 end
 
-@testset "Date-valued CategoricalPool" begin
+@testset "show() for CategoricalPool{Date} and its values" begin
     pool = CategoricalPool([Date(1999, 12), Date(1991, 8), Date(1993, 10)])
 
     opool = CategoricalPool([Date(1999, 12), Date(1991, 8), Date(1993, 10)],

--- a/test/06_show.jl
+++ b/test/06_show.jl
@@ -1,7 +1,8 @@
 module TestShow
-    using Base.Test
-    using CategoricalArrays
+using Base.Test
+using CategoricalArrays
 
+@testset "String-valued CategoricalPool" begin
     pool = CategoricalPool(["c", "b", "a"])
 
     opool = CategoricalPool(["c", "b", "a"], ["a", "b", "c"], true)
@@ -40,8 +41,9 @@ module TestShow
     @test repr(nv1) == repr(ov1) == "\"c\""
     @test repr(nv2) == repr(ov2) == "\"b\""
     @test repr(nv3) == repr(ov3) == "\"a\""
+end
 
-    # test Date-valued categories pool
+@testset "Date-valued CategoricalPool" begin
     pool = CategoricalPool([Date(1999, 12), Date(1991, 8), Date(1993, 10)])
 
     opool = CategoricalPool([Date(1999, 12), Date(1991, 8), Date(1993, 10)],
@@ -81,4 +83,6 @@ module TestShow
     @test repr(nv1) == repr(ov1) == "1999-12-01"
     @test repr(nv2) == repr(ov2) == "1991-08-01"
     @test repr(nv3) == repr(ov3) == "1993-10-01"
+end
+
 end

--- a/test/07_levels.jl
+++ b/test/07_levels.jl
@@ -3,223 +3,224 @@ using Base.Test
 using CategoricalArrays
 using CategoricalArrays: DefaultRefType, levels!
 
-pool = CategoricalPool([2, 1, 3])
+@testset "CategoricalPool{Int} updates levels/index/order correctly" begin
+    pool = CategoricalPool([2, 1, 3])
 
-@test isa(levels(pool), Vector{Int})
-@test length(levels(pool)) === 3
-@test levels(pool) == pool.index == [2, 1, 3]
-@test pool.invindex == Dict(1=>2, 2=>1, 3=>3)
-@test pool.order == [1, 2, 3]
-@test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:3]
+    @test isa(levels(pool), Vector{Int})
+    @test length(levels(pool)) === 3
+    @test levels(pool) == pool.index == [2, 1, 3]
+    @test pool.invindex == Dict(1=>2, 2=>1, 3=>3)
+    @test pool.order == [1, 2, 3]
+    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:3]
 
-for rep in 1:3
-    push!(pool, 4)
+    for rep in 1:3
+        push!(pool, 4)
+
+        @test isa(pool.index, Vector{Int})
+        @test length(pool) === 4
+        @test pool.index == [2, 1, 3, 4]
+        @test pool.invindex == Dict(1=>2, 2=>1, 3=>3, 4=>4)
+        @test pool.order == [1, 2, 3, 4]
+        @test pool.levels == [2, 1, 3, 4]
+        @test get(pool, 4) === DefaultRefType(4)
+        @test pool[4] === CategoricalArrays.catvalue(4, pool)
+        @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:4]
+    end
+
+    for rep in 1:3
+        push!(pool, 0)
+
+        @test isa(pool.index, Vector{Int})
+        @test length(pool) === 5
+        @test levels(pool) == pool.index == [2, 1, 3, 4, 0]
+        @test pool.invindex == Dict(1=>2, 2=>1, 3=>3, 4=>4, 0=>5)
+        @test pool.order == [1, 2, 3, 4, 5]
+        @test pool.levels == [2, 1, 3, 4, 0]
+        @test get(pool, 0) === DefaultRefType(5)
+        @test pool[5] === CategoricalArrays.catvalue(5, pool)
+        @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:5]
+    end
+
+    for rep in 1:3
+        push!(pool, 10, 11)
+
+        @test isa(pool.index, Vector{Int})
+        @test length(pool) === 7
+        @test levels(pool) == pool.index == [2, 1, 3, 4, 0, 10, 11]
+        @test pool.invindex == Dict(1=>2, 2=>1, 3=>3, 4=>4, 0=>5, 10=>6, 11=>7)
+        @test pool.order == [1, 2, 3, 4, 5, 6, 7]
+        @test pool.levels == [2, 1, 3, 4, 0, 10, 11]
+        @test get(pool, 10) === DefaultRefType(6)
+        @test get(pool, 11) === DefaultRefType(7)
+        @test pool[6] === CategoricalArrays.catvalue(6, pool)
+        @test pool[7] === CategoricalArrays.catvalue(7, pool)
+        @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:7]
+    end
+
+    for rep in 1:3
+        push!(pool, 12, 13)
+
+        @test isa(pool.index, Vector{Int})
+        @test length(pool) === 9
+        @test levels(pool) == pool.index == [2, 1, 3, 4, 0, 10, 11, 12, 13]
+        @test pool.invindex == Dict(1=>2, 2=>1, 3=>3, 4=>4, 0=>5, 10=>6, 11=>7, 12=>8, 13=>9)
+        @test pool.order == [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        @test pool.levels == [2, 1, 3, 4, 0, 10, 11, 12, 13]
+        @test get(pool, 12) === DefaultRefType(8)
+        @test get(pool, 13) === DefaultRefType(9)
+        @test pool[8] === CategoricalArrays.catvalue(8, pool)
+        @test pool[9] === CategoricalArrays.catvalue(9, pool)
+        @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:9]
+    end
+
+    for rep in 1:3
+        delete!(pool, 13)
+
+        @test isa(pool.index, Vector{Int})
+        @test length(pool) == 8
+        @test levels(pool) == pool.index == [2, 1, 3, 4, 0, 10, 11, 12]
+        @test pool.invindex == Dict(1=>2, 2=>1, 3=>3, 4=>4, 0=>5, 10=>6, 11=>7, 12=>8)
+        @test pool.order == [1, 2, 3, 4, 5, 6, 7, 8]
+        @test pool.levels == [2, 1, 3, 4, 0, 10, 11, 12]
+        @test_throws KeyError get(pool, 13)
+        @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:8]
+    end
+
+    for rep in 1:3
+        delete!(pool, 12, 11)
+
+        @test isa(pool.index, Vector{Int})
+        @test length(pool) == 6
+        @test levels(pool) == pool.index == [2, 1, 3, 4, 0, 10]
+        @test pool.invindex == Dict(1=>2, 2=>1, 3=>3, 4=>4, 0=>5, 10=>6)
+        @test pool.order == [1, 2, 3, 4, 5, 6]
+        @test pool.levels == [2, 1, 3, 4, 0, 10]
+        @test_throws KeyError get(pool, 11)
+        @test_throws KeyError get(pool, 12)
+        @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:6]
+    end
+
+    for rep in 1:3
+        delete!(pool, 4)
+
+        @test isa(pool.index, Vector{Int})
+        @test length(pool) == 5
+        @test levels(pool) == pool.index == [2, 1, 3, 0, 10]
+        @test pool.invindex == Dict(1=>2, 2=>1, 3=>3, 0=>4, 10=>5)
+        @test pool.order == [1, 2, 3, 4, 5]
+        @test pool.levels == [2, 1, 3, 0, 10]
+        @test_throws KeyError get(pool, 4)
+        @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:5]
+    end
+
+    @test levels!(pool, [1, 2, 3]) === pool
+    @test levels(pool) == [1, 2, 3]
 
     @test isa(pool.index, Vector{Int})
-    @test length(pool) === 4
-    @test pool.index == [2, 1, 3, 4]
-    @test pool.invindex == Dict(1=>2, 2=>1, 3=>3, 4=>4)
-    @test pool.order == [1, 2, 3, 4]
-    @test pool.levels == [2, 1, 3, 4]
-    @test get(pool, 4) === DefaultRefType(4)
-    @test pool[4] === CategoricalArrays.catvalue(4, pool)
-    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:4]
-end
+    @test length(pool) == 3
+    @test length(pool.valindex) == 3
+    @test levels(pool) == pool.index == [1, 2, 3]
+    @test pool.invindex == Dict(1=>1, 2=>2, 3=>3)
+    @test pool.order == [1, 2, 3]
+    @test pool.levels == [1, 2, 3]
+    @test get(pool, 1) === DefaultRefType(1)
+    @test_throws KeyError get(pool, 0)
+    @test_throws KeyError get(pool, 10)
+    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:3]
 
-for rep in 1:3
-    push!(pool, 0)
-
-    @test isa(pool.index, Vector{Int})
-    @test length(pool) === 5
-    @test levels(pool) == pool.index == [2, 1, 3, 4, 0]
-    @test pool.invindex == Dict(1=>2, 2=>1, 3=>3, 4=>4, 0=>5)
-    @test pool.order == [1, 2, 3, 4, 5]
-    @test pool.levels == [2, 1, 3, 4, 0]
-    @test get(pool, 0) === DefaultRefType(5)
-    @test pool[5] === CategoricalArrays.catvalue(5, pool)
-    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:5]
-end
-
-for rep in 1:3
-    push!(pool, 10, 11)
+    @test levels!(pool, [1, 2, 4]) === pool
+    @test levels(pool) == [1, 2, 4]
 
     @test isa(pool.index, Vector{Int})
-    @test length(pool) === 7
-    @test levels(pool) == pool.index == [2, 1, 3, 4, 0, 10, 11]
-    @test pool.invindex == Dict(1=>2, 2=>1, 3=>3, 4=>4, 0=>5, 10=>6, 11=>7)
-    @test pool.order == [1, 2, 3, 4, 5, 6, 7]
-    @test pool.levels == [2, 1, 3, 4, 0, 10, 11]
-    @test get(pool, 10) === DefaultRefType(6)
-    @test get(pool, 11) === DefaultRefType(7)
-    @test pool[6] === CategoricalArrays.catvalue(6, pool)
-    @test pool[7] === CategoricalArrays.catvalue(7, pool)
-    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:7]
-end
+    @test length(pool) == 3
+    @test length(pool.valindex) == 3
+    @test levels(pool) == pool.index == [1, 2, 4]
+    @test pool.invindex == Dict(1=>1, 2=>2, 4=>3)
+    @test pool.order == [1, 2, 3]
+    @test pool.levels == [1, 2, 4]
+    @test get(pool, 1) === DefaultRefType(1)
+    @test_throws KeyError get(pool, 3)
+    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:3]
 
-for rep in 1:3
-    push!(pool, 12, 13)
+    @test levels!(pool, [6, 5, 4]) === pool
+    @test levels(pool) == [6, 5, 4]
 
     @test isa(pool.index, Vector{Int})
-    @test length(pool) === 9
-    @test levels(pool) == pool.index == [2, 1, 3, 4, 0, 10, 11, 12, 13]
-    @test pool.invindex == Dict(1=>2, 2=>1, 3=>3, 4=>4, 0=>5, 10=>6, 11=>7, 12=>8, 13=>9)
-    @test pool.order == [1, 2, 3, 4, 5, 6, 7, 8, 9]
-    @test pool.levels == [2, 1, 3, 4, 0, 10, 11, 12, 13]
-    @test get(pool, 12) === DefaultRefType(8)
-    @test get(pool, 13) === DefaultRefType(9)
-    @test pool[8] === CategoricalArrays.catvalue(8, pool)
-    @test pool[9] === CategoricalArrays.catvalue(9, pool)
-    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:9]
-end
+    @test length(pool) == 3
+    @test length(pool.valindex) == 3
+    @test levels(pool) == pool.index == [6, 5, 4]
+    @test pool.invindex == Dict(6=>1, 5=>2, 4=>3)
+    @test pool.order == [1, 2, 3]
+    @test pool.levels == [6, 5, 4]
+    @test get(pool, 5) === DefaultRefType(2)
+    @test_throws KeyError get(pool, 3)
+    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:3]
 
-for rep in 1:3
-    delete!(pool, 13)
-
-    @test isa(pool.index, Vector{Int})
-    @test length(pool) == 8
-    @test levels(pool) == pool.index == [2, 1, 3, 4, 0, 10, 11, 12]
-    @test pool.invindex == Dict(1=>2, 2=>1, 3=>3, 4=>4, 0=>5, 10=>6, 11=>7, 12=>8)
-    @test pool.order == [1, 2, 3, 4, 5, 6, 7, 8]
-    @test pool.levels == [2, 1, 3, 4, 0, 10, 11, 12]
-    @test_throws KeyError get(pool, 13)
-    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:8]
-end
-
-for rep in 1:3
-    delete!(pool, 12, 11)
+    # Changing order while preserving existing levels
+    @test levels!(pool, [5, 6, 4]) === pool
+    @test levels(pool) == [5, 6, 4]
 
     @test isa(pool.index, Vector{Int})
-    @test length(pool) == 6
-    @test levels(pool) == pool.index == [2, 1, 3, 4, 0, 10]
-    @test pool.invindex == Dict(1=>2, 2=>1, 3=>3, 4=>4, 0=>5, 10=>6)
-    @test pool.order == [1, 2, 3, 4, 5, 6]
-    @test pool.levels == [2, 1, 3, 4, 0, 10]
-    @test_throws KeyError get(pool, 11)
-    @test_throws KeyError get(pool, 12)
-    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:6]
-end
+    @test length(pool) == 3
+    @test length(pool.valindex) == 3
+    @test levels(pool) == [5, 6, 4]
+    @test pool.index == [6, 5, 4]
+    @test pool.invindex == Dict(6=>1, 5=>2, 4=>3)
+    @test pool.order == [2, 1, 3]
+    @test pool.levels == [5, 6, 4]
+    @test get(pool, 5) === DefaultRefType(2)
+    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:3]
 
-for rep in 1:3
-    delete!(pool, 4)
+    # Adding levels while preserving existing ones
+    @test levels!(pool, [5, 2, 3, 6, 4]) === pool
+    @test levels(pool) == [5, 2, 3, 6, 4]
 
     @test isa(pool.index, Vector{Int})
     @test length(pool) == 5
-    @test levels(pool) == pool.index == [2, 1, 3, 0, 10]
-    @test pool.invindex == Dict(1=>2, 2=>1, 3=>3, 0=>4, 10=>5)
-    @test pool.order == [1, 2, 3, 4, 5]
-    @test pool.levels == [2, 1, 3, 0, 10]
-    @test_throws KeyError get(pool, 4)
+    @test length(pool.valindex) == 5
+    @test levels(pool) == [5, 2, 3, 6, 4]
+    @test pool.index == [6, 5, 4, 2, 3]
+    @test pool.invindex == Dict(6=>1, 5=>2, 4=>3, 2=>4, 3=>5)
+    @test pool.order == [4, 1, 5, 2, 3]
+    @test pool.levels == [5, 2, 3, 6, 4]
+    @test get(pool, 2) === DefaultRefType(4)
+    @test get(pool, 3) === DefaultRefType(5)
     @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:5]
+
+    for rep in 1:3
+        delete!(pool, 6)
+
+        @test isa(pool.index, Vector{Int})
+        @test length(pool) == 4
+        @test length(pool.valindex) == 4
+        @test levels(pool) == [5, 2, 3, 4]
+        @test pool.index == [5, 4, 2, 3]
+        @test pool.invindex == Dict(5=>1, 4=>2, 2=>3, 3=>4)
+        @test pool.order == [1, 4, 2, 3]
+        @test pool.levels == [5, 2, 3, 4]
+        @test get(pool, 4) === DefaultRefType(2)
+        @test_throws KeyError get(pool, 6)
+        @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:4]
+    end
 end
 
-@test levels!(pool, [1, 2, 3]) === pool
-@test levels(pool) == [1, 2, 3]
+@testset "overflow of reftype is detected and doesn't corrupt levels" begin
+    res = @test_throws LevelsException{Int, UInt8} CategoricalPool{Int, UInt8}(collect(256:-1:1))
+    @test res.value.levels == [1]
+    @test sprint(showerror, res.value) == "cannot store level(s) 1 since reference type UInt8 can only hold 255 levels. Use the decompress function to make room for more levels."
 
-@test isa(pool.index, Vector{Int})
-@test length(pool) == 3
-@test length(pool.valindex) == 3
-@test levels(pool) == pool.index == [1, 2, 3]
-@test pool.invindex == Dict(1=>1, 2=>2, 3=>3)
-@test pool.order == [1, 2, 3]
-@test pool.levels == [1, 2, 3]
-@test get(pool, 1) === DefaultRefType(1)
-@test_throws KeyError get(pool, 0)
-@test_throws KeyError get(pool, 10)
-@test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:3]
+    pool = CategoricalPool(collect(30:288))
+    res = @test_throws LevelsException{Int, UInt8} convert(CategoricalPool{Int, UInt8}, pool)
+    @test res.value.levels == collect(285:288)
+    @test sprint(showerror, res.value) == "cannot store level(s) 285, 286, 287 and 288 since reference type UInt8 can only hold 255 levels. Use the decompress function to make room for more levels."
 
-@test levels!(pool, [1, 2, 4]) === pool
-@test levels(pool) == [1, 2, 4]
-
-@test isa(pool.index, Vector{Int})
-@test length(pool) == 3
-@test length(pool.valindex) == 3
-@test levels(pool) == pool.index == [1, 2, 4]
-@test pool.invindex == Dict(1=>1, 2=>2, 4=>3)
-@test pool.order == [1, 2, 3]
-@test pool.levels == [1, 2, 4]
-@test get(pool, 1) === DefaultRefType(1)
-@test_throws KeyError get(pool, 3)
-@test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:3]
-
-@test levels!(pool, [6, 5, 4]) === pool
-@test levels(pool) == [6, 5, 4]
-
-@test isa(pool.index, Vector{Int})
-@test length(pool) == 3
-@test length(pool.valindex) == 3
-@test levels(pool) == pool.index == [6, 5, 4]
-@test pool.invindex == Dict(6=>1, 5=>2, 4=>3)
-@test pool.order == [1, 2, 3]
-@test pool.levels == [6, 5, 4]
-@test get(pool, 5) === DefaultRefType(2)
-@test_throws KeyError get(pool, 3)
-@test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:3]
-
-# Changing order while preserving existing levels
-@test levels!(pool, [5, 6, 4]) === pool
-@test levels(pool) == [5, 6, 4]
-
-@test isa(pool.index, Vector{Int})
-@test length(pool) == 3
-@test length(pool.valindex) == 3
-@test levels(pool) == [5, 6, 4]
-@test pool.index == [6, 5, 4]
-@test pool.invindex == Dict(6=>1, 5=>2, 4=>3)
-@test pool.order == [2, 1, 3]
-@test pool.levels == [5, 6, 4]
-@test get(pool, 5) === DefaultRefType(2)
-@test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:3]
-
-# Adding levels while preserving existing ones
-@test levels!(pool, [5, 2, 3, 6, 4]) === pool
-@test levels(pool) == [5, 2, 3, 6, 4]
-
-@test isa(pool.index, Vector{Int})
-@test length(pool) == 5
-@test length(pool.valindex) == 5
-@test levels(pool) == [5, 2, 3, 6, 4]
-@test pool.index == [6, 5, 4, 2, 3]
-@test pool.invindex == Dict(6=>1, 5=>2, 4=>3, 2=>4, 3=>5)
-@test pool.order == [4, 1, 5, 2, 3]
-@test pool.levels == [5, 2, 3, 6, 4]
-@test get(pool, 2) === DefaultRefType(4)
-@test get(pool, 3) === DefaultRefType(5)
-@test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:5]
-
-for rep in 1:3
-    delete!(pool, 6)
-
-    @test isa(pool.index, Vector{Int})
-    @test length(pool) == 4
-    @test length(pool.valindex) == 4
-    @test levels(pool) == [5, 2, 3, 4]
-    @test pool.index == [5, 4, 2, 3]
-    @test pool.invindex == Dict(5=>1, 4=>2, 2=>3, 3=>4)
-    @test pool.order == [1, 4, 2, 3]
-    @test pool.levels == [5, 2, 3, 4]
-    @test get(pool, 4) === DefaultRefType(2)
-    @test_throws KeyError get(pool, 6)
-    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:4]
+    pool = CategoricalPool{String, UInt8}(string.(318:-1:65))
+    res = @test_throws LevelsException{String, UInt8} levels!(pool, vcat("az", levels(pool), "bz", "cz"))
+    @test res.value.levels == ["bz", "cz"]
+    @test sprint(showerror, res.value) == "cannot store level(s) \"bz\" and \"cz\" since reference type UInt8 can only hold 255 levels. Use the decompress function to make room for more levels."
+    lev = copy(levels(pool))
+    levels!(pool, vcat(lev, "az"))
+    @test levels(pool) == vcat(lev, "az")
 end
-
-
-# Test that overflow of reftype is detected and doesn't corrupt levels
-
-res = @test_throws LevelsException{Int, UInt8} CategoricalPool{Int, UInt8}(collect(256:-1:1))
-@test res.value.levels == [1]
-@test sprint(showerror, res.value) == "cannot store level(s) 1 since reference type UInt8 can only hold 255 levels. Use the decompress function to make room for more levels."
-
-pool = CategoricalPool(collect(30:288))
-res = @test_throws LevelsException{Int, UInt8} convert(CategoricalPool{Int, UInt8}, pool)
-@test res.value.levels == collect(285:288)
-@test sprint(showerror, res.value) == "cannot store level(s) 285, 286, 287 and 288 since reference type UInt8 can only hold 255 levels. Use the decompress function to make room for more levels."
-
-pool = CategoricalPool{String, UInt8}(string.(318:-1:65))
-res = @test_throws LevelsException{String, UInt8} levels!(pool, vcat("az", levels(pool), "bz", "cz"))
-@test res.value.levels == ["bz", "cz"]
-@test sprint(showerror, res.value) == "cannot store level(s) \"bz\" and \"cz\" since reference type UInt8 can only hold 255 levels. Use the decompress function to make room for more levels."
-lev = copy(levels(pool))
-levels!(pool, vcat(lev, "az"))
-@test levels(pool) == vcat(lev, "az")
 
 end

--- a/test/07_levels.jl
+++ b/test/07_levels.jl
@@ -1,224 +1,225 @@
 module TestLevels
-    using Base.Test
-    using CategoricalArrays
-    using CategoricalArrays: DefaultRefType, levels!
+using Base.Test
+using CategoricalArrays
+using CategoricalArrays: DefaultRefType, levels!
 
-    pool = CategoricalPool([2, 1, 3])
+pool = CategoricalPool([2, 1, 3])
 
-    @test isa(levels(pool), Vector{Int})
-    @test length(levels(pool)) === 3
-    @test levels(pool) == pool.index == [2, 1, 3]
-    @test pool.invindex == Dict(1=>2, 2=>1, 3=>3)
-    @test pool.order == [1, 2, 3]
-    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:3]
+@test isa(levels(pool), Vector{Int})
+@test length(levels(pool)) === 3
+@test levels(pool) == pool.index == [2, 1, 3]
+@test pool.invindex == Dict(1=>2, 2=>1, 3=>3)
+@test pool.order == [1, 2, 3]
+@test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:3]
 
-    for rep in 1:3
-        push!(pool, 4)
-
-        @test isa(pool.index, Vector{Int})
-        @test length(pool) === 4
-        @test pool.index == [2, 1, 3, 4]
-        @test pool.invindex == Dict(1=>2, 2=>1, 3=>3, 4=>4)
-        @test pool.order == [1, 2, 3, 4]
-        @test pool.levels == [2, 1, 3, 4]
-        @test get(pool, 4) === DefaultRefType(4)
-        @test pool[4] === CategoricalArrays.catvalue(4, pool)
-        @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:4]
-    end
-
-    for rep in 1:3
-        push!(pool, 0)
-
-        @test isa(pool.index, Vector{Int})
-        @test length(pool) === 5
-        @test levels(pool) == pool.index == [2, 1, 3, 4, 0]
-        @test pool.invindex == Dict(1=>2, 2=>1, 3=>3, 4=>4, 0=>5)
-        @test pool.order == [1, 2, 3, 4, 5]
-        @test pool.levels == [2, 1, 3, 4, 0]
-        @test get(pool, 0) === DefaultRefType(5)
-        @test pool[5] === CategoricalArrays.catvalue(5, pool)
-        @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:5]
-    end
-
-    for rep in 1:3
-        push!(pool, 10, 11)
-
-        @test isa(pool.index, Vector{Int})
-        @test length(pool) === 7
-        @test levels(pool) == pool.index == [2, 1, 3, 4, 0, 10, 11]
-        @test pool.invindex == Dict(1=>2, 2=>1, 3=>3, 4=>4, 0=>5, 10=>6, 11=>7)
-        @test pool.order == [1, 2, 3, 4, 5, 6, 7]
-        @test pool.levels == [2, 1, 3, 4, 0, 10, 11]
-        @test get(pool, 10) === DefaultRefType(6)
-        @test get(pool, 11) === DefaultRefType(7)
-        @test pool[6] === CategoricalArrays.catvalue(6, pool)
-        @test pool[7] === CategoricalArrays.catvalue(7, pool)
-        @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:7]
-    end
-
-    for rep in 1:3
-        push!(pool, 12, 13)
-
-        @test isa(pool.index, Vector{Int})
-        @test length(pool) === 9
-        @test levels(pool) == pool.index == [2, 1, 3, 4, 0, 10, 11, 12, 13]
-        @test pool.invindex == Dict(1=>2, 2=>1, 3=>3, 4=>4, 0=>5, 10=>6, 11=>7, 12=>8, 13=>9)
-        @test pool.order == [1, 2, 3, 4, 5, 6, 7, 8, 9]
-        @test pool.levels == [2, 1, 3, 4, 0, 10, 11, 12, 13]
-        @test get(pool, 12) === DefaultRefType(8)
-        @test get(pool, 13) === DefaultRefType(9)
-        @test pool[8] === CategoricalArrays.catvalue(8, pool)
-        @test pool[9] === CategoricalArrays.catvalue(9, pool)
-        @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:9]
-    end
-
-    for rep in 1:3
-        delete!(pool, 13)
-
-        @test isa(pool.index, Vector{Int})
-        @test length(pool) == 8
-        @test levels(pool) == pool.index == [2, 1, 3, 4, 0, 10, 11, 12]
-        @test pool.invindex == Dict(1=>2, 2=>1, 3=>3, 4=>4, 0=>5, 10=>6, 11=>7, 12=>8)
-        @test pool.order == [1, 2, 3, 4, 5, 6, 7, 8]
-        @test pool.levels == [2, 1, 3, 4, 0, 10, 11, 12]
-        @test_throws KeyError get(pool, 13)
-        @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:8]
-    end
-
-    for rep in 1:3
-        delete!(pool, 12, 11)
-
-        @test isa(pool.index, Vector{Int})
-        @test length(pool) == 6
-        @test levels(pool) == pool.index == [2, 1, 3, 4, 0, 10]
-        @test pool.invindex == Dict(1=>2, 2=>1, 3=>3, 4=>4, 0=>5, 10=>6)
-        @test pool.order == [1, 2, 3, 4, 5, 6]
-        @test pool.levels == [2, 1, 3, 4, 0, 10]
-        @test_throws KeyError get(pool, 11)
-        @test_throws KeyError get(pool, 12)
-        @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:6]
-    end
-
-    for rep in 1:3
-        delete!(pool, 4)
-
-        @test isa(pool.index, Vector{Int})
-        @test length(pool) == 5
-        @test levels(pool) == pool.index == [2, 1, 3, 0, 10]
-        @test pool.invindex == Dict(1=>2, 2=>1, 3=>3, 0=>4, 10=>5)
-        @test pool.order == [1, 2, 3, 4, 5]
-        @test pool.levels == [2, 1, 3, 0, 10]
-        @test_throws KeyError get(pool, 4)
-        @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:5]
-    end
-
-    @test levels!(pool, [1, 2, 3]) === pool
-    @test levels(pool) == [1, 2, 3]
+for rep in 1:3
+    push!(pool, 4)
 
     @test isa(pool.index, Vector{Int})
-    @test length(pool) == 3
-    @test length(pool.valindex) == 3
-    @test levels(pool) == pool.index == [1, 2, 3]
-    @test pool.invindex == Dict(1=>1, 2=>2, 3=>3)
-    @test pool.order == [1, 2, 3]
-    @test pool.levels == [1, 2, 3]
-    @test get(pool, 1) === DefaultRefType(1)
-    @test_throws KeyError get(pool, 0)
-    @test_throws KeyError get(pool, 10)
-    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:3]
+    @test length(pool) === 4
+    @test pool.index == [2, 1, 3, 4]
+    @test pool.invindex == Dict(1=>2, 2=>1, 3=>3, 4=>4)
+    @test pool.order == [1, 2, 3, 4]
+    @test pool.levels == [2, 1, 3, 4]
+    @test get(pool, 4) === DefaultRefType(4)
+    @test pool[4] === CategoricalArrays.catvalue(4, pool)
+    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:4]
+end
 
-    @test levels!(pool, [1, 2, 4]) === pool
-    @test levels(pool) == [1, 2, 4]
-
-    @test isa(pool.index, Vector{Int})
-    @test length(pool) == 3
-    @test length(pool.valindex) == 3
-    @test levels(pool) == pool.index == [1, 2, 4]
-    @test pool.invindex == Dict(1=>1, 2=>2, 4=>3)
-    @test pool.order == [1, 2, 3]
-    @test pool.levels == [1, 2, 4]
-    @test get(pool, 1) === DefaultRefType(1)
-    @test_throws KeyError get(pool, 3)
-    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:3]
-
-    @test levels!(pool, [6, 5, 4]) === pool
-    @test levels(pool) == [6, 5, 4]
+for rep in 1:3
+    push!(pool, 0)
 
     @test isa(pool.index, Vector{Int})
-    @test length(pool) == 3
-    @test length(pool.valindex) == 3
-    @test levels(pool) == pool.index == [6, 5, 4]
-    @test pool.invindex == Dict(6=>1, 5=>2, 4=>3)
-    @test pool.order == [1, 2, 3]
-    @test pool.levels == [6, 5, 4]
-    @test get(pool, 5) === DefaultRefType(2)
-    @test_throws KeyError get(pool, 3)
-    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:3]
+    @test length(pool) === 5
+    @test levels(pool) == pool.index == [2, 1, 3, 4, 0]
+    @test pool.invindex == Dict(1=>2, 2=>1, 3=>3, 4=>4, 0=>5)
+    @test pool.order == [1, 2, 3, 4, 5]
+    @test pool.levels == [2, 1, 3, 4, 0]
+    @test get(pool, 0) === DefaultRefType(5)
+    @test pool[5] === CategoricalArrays.catvalue(5, pool)
+    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:5]
+end
 
-    # Changing order while preserving existing levels
-    @test levels!(pool, [5, 6, 4]) === pool
-    @test levels(pool) == [5, 6, 4]
+for rep in 1:3
+    push!(pool, 10, 11)
 
     @test isa(pool.index, Vector{Int})
-    @test length(pool) == 3
-    @test length(pool.valindex) == 3
-    @test levels(pool) == [5, 6, 4]
-    @test pool.index == [6, 5, 4]
-    @test pool.invindex == Dict(6=>1, 5=>2, 4=>3)
-    @test pool.order == [2, 1, 3]
-    @test pool.levels == [5, 6, 4]
-    @test get(pool, 5) === DefaultRefType(2)
-    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:3]
+    @test length(pool) === 7
+    @test levels(pool) == pool.index == [2, 1, 3, 4, 0, 10, 11]
+    @test pool.invindex == Dict(1=>2, 2=>1, 3=>3, 4=>4, 0=>5, 10=>6, 11=>7)
+    @test pool.order == [1, 2, 3, 4, 5, 6, 7]
+    @test pool.levels == [2, 1, 3, 4, 0, 10, 11]
+    @test get(pool, 10) === DefaultRefType(6)
+    @test get(pool, 11) === DefaultRefType(7)
+    @test pool[6] === CategoricalArrays.catvalue(6, pool)
+    @test pool[7] === CategoricalArrays.catvalue(7, pool)
+    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:7]
+end
 
-    # Adding levels while preserving existing ones
-    @test levels!(pool, [5, 2, 3, 6, 4]) === pool
-    @test levels(pool) == [5, 2, 3, 6, 4]
+for rep in 1:3
+    push!(pool, 12, 13)
+
+    @test isa(pool.index, Vector{Int})
+    @test length(pool) === 9
+    @test levels(pool) == pool.index == [2, 1, 3, 4, 0, 10, 11, 12, 13]
+    @test pool.invindex == Dict(1=>2, 2=>1, 3=>3, 4=>4, 0=>5, 10=>6, 11=>7, 12=>8, 13=>9)
+    @test pool.order == [1, 2, 3, 4, 5, 6, 7, 8, 9]
+    @test pool.levels == [2, 1, 3, 4, 0, 10, 11, 12, 13]
+    @test get(pool, 12) === DefaultRefType(8)
+    @test get(pool, 13) === DefaultRefType(9)
+    @test pool[8] === CategoricalArrays.catvalue(8, pool)
+    @test pool[9] === CategoricalArrays.catvalue(9, pool)
+    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:9]
+end
+
+for rep in 1:3
+    delete!(pool, 13)
+
+    @test isa(pool.index, Vector{Int})
+    @test length(pool) == 8
+    @test levels(pool) == pool.index == [2, 1, 3, 4, 0, 10, 11, 12]
+    @test pool.invindex == Dict(1=>2, 2=>1, 3=>3, 4=>4, 0=>5, 10=>6, 11=>7, 12=>8)
+    @test pool.order == [1, 2, 3, 4, 5, 6, 7, 8]
+    @test pool.levels == [2, 1, 3, 4, 0, 10, 11, 12]
+    @test_throws KeyError get(pool, 13)
+    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:8]
+end
+
+for rep in 1:3
+    delete!(pool, 12, 11)
+
+    @test isa(pool.index, Vector{Int})
+    @test length(pool) == 6
+    @test levels(pool) == pool.index == [2, 1, 3, 4, 0, 10]
+    @test pool.invindex == Dict(1=>2, 2=>1, 3=>3, 4=>4, 0=>5, 10=>6)
+    @test pool.order == [1, 2, 3, 4, 5, 6]
+    @test pool.levels == [2, 1, 3, 4, 0, 10]
+    @test_throws KeyError get(pool, 11)
+    @test_throws KeyError get(pool, 12)
+    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:6]
+end
+
+for rep in 1:3
+    delete!(pool, 4)
 
     @test isa(pool.index, Vector{Int})
     @test length(pool) == 5
-    @test length(pool.valindex) == 5
-    @test levels(pool) == [5, 2, 3, 6, 4]
-    @test pool.index == [6, 5, 4, 2, 3]
-    @test pool.invindex == Dict(6=>1, 5=>2, 4=>3, 2=>4, 3=>5)
-    @test pool.order == [4, 1, 5, 2, 3]
-    @test pool.levels == [5, 2, 3, 6, 4]
-    @test get(pool, 2) === DefaultRefType(4)
-    @test get(pool, 3) === DefaultRefType(5)
+    @test levels(pool) == pool.index == [2, 1, 3, 0, 10]
+    @test pool.invindex == Dict(1=>2, 2=>1, 3=>3, 0=>4, 10=>5)
+    @test pool.order == [1, 2, 3, 4, 5]
+    @test pool.levels == [2, 1, 3, 0, 10]
+    @test_throws KeyError get(pool, 4)
     @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:5]
+end
 
-    for rep in 1:3
-        delete!(pool, 6)
+@test levels!(pool, [1, 2, 3]) === pool
+@test levels(pool) == [1, 2, 3]
 
-        @test isa(pool.index, Vector{Int})
-        @test length(pool) == 4
-        @test length(pool.valindex) == 4
-        @test levels(pool) == [5, 2, 3, 4]
-        @test pool.index == [5, 4, 2, 3]
-        @test pool.invindex == Dict(5=>1, 4=>2, 2=>3, 3=>4)
-        @test pool.order == [1, 4, 2, 3]
-        @test pool.levels == [5, 2, 3, 4]
-        @test get(pool, 4) === DefaultRefType(2)
-        @test_throws KeyError get(pool, 6)
-        @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:4]
-    end
+@test isa(pool.index, Vector{Int})
+@test length(pool) == 3
+@test length(pool.valindex) == 3
+@test levels(pool) == pool.index == [1, 2, 3]
+@test pool.invindex == Dict(1=>1, 2=>2, 3=>3)
+@test pool.order == [1, 2, 3]
+@test pool.levels == [1, 2, 3]
+@test get(pool, 1) === DefaultRefType(1)
+@test_throws KeyError get(pool, 0)
+@test_throws KeyError get(pool, 10)
+@test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:3]
+
+@test levels!(pool, [1, 2, 4]) === pool
+@test levels(pool) == [1, 2, 4]
+
+@test isa(pool.index, Vector{Int})
+@test length(pool) == 3
+@test length(pool.valindex) == 3
+@test levels(pool) == pool.index == [1, 2, 4]
+@test pool.invindex == Dict(1=>1, 2=>2, 4=>3)
+@test pool.order == [1, 2, 3]
+@test pool.levels == [1, 2, 4]
+@test get(pool, 1) === DefaultRefType(1)
+@test_throws KeyError get(pool, 3)
+@test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:3]
+
+@test levels!(pool, [6, 5, 4]) === pool
+@test levels(pool) == [6, 5, 4]
+
+@test isa(pool.index, Vector{Int})
+@test length(pool) == 3
+@test length(pool.valindex) == 3
+@test levels(pool) == pool.index == [6, 5, 4]
+@test pool.invindex == Dict(6=>1, 5=>2, 4=>3)
+@test pool.order == [1, 2, 3]
+@test pool.levels == [6, 5, 4]
+@test get(pool, 5) === DefaultRefType(2)
+@test_throws KeyError get(pool, 3)
+@test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:3]
+
+# Changing order while preserving existing levels
+@test levels!(pool, [5, 6, 4]) === pool
+@test levels(pool) == [5, 6, 4]
+
+@test isa(pool.index, Vector{Int})
+@test length(pool) == 3
+@test length(pool.valindex) == 3
+@test levels(pool) == [5, 6, 4]
+@test pool.index == [6, 5, 4]
+@test pool.invindex == Dict(6=>1, 5=>2, 4=>3)
+@test pool.order == [2, 1, 3]
+@test pool.levels == [5, 6, 4]
+@test get(pool, 5) === DefaultRefType(2)
+@test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:3]
+
+# Adding levels while preserving existing ones
+@test levels!(pool, [5, 2, 3, 6, 4]) === pool
+@test levels(pool) == [5, 2, 3, 6, 4]
+
+@test isa(pool.index, Vector{Int})
+@test length(pool) == 5
+@test length(pool.valindex) == 5
+@test levels(pool) == [5, 2, 3, 6, 4]
+@test pool.index == [6, 5, 4, 2, 3]
+@test pool.invindex == Dict(6=>1, 5=>2, 4=>3, 2=>4, 3=>5)
+@test pool.order == [4, 1, 5, 2, 3]
+@test pool.levels == [5, 2, 3, 6, 4]
+@test get(pool, 2) === DefaultRefType(4)
+@test get(pool, 3) === DefaultRefType(5)
+@test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:5]
+
+for rep in 1:3
+    delete!(pool, 6)
+
+    @test isa(pool.index, Vector{Int})
+    @test length(pool) == 4
+    @test length(pool.valindex) == 4
+    @test levels(pool) == [5, 2, 3, 4]
+    @test pool.index == [5, 4, 2, 3]
+    @test pool.invindex == Dict(5=>1, 4=>2, 2=>3, 3=>4)
+    @test pool.order == [1, 4, 2, 3]
+    @test pool.levels == [5, 2, 3, 4]
+    @test get(pool, 4) === DefaultRefType(2)
+    @test_throws KeyError get(pool, 6)
+    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:4]
+end
 
 
-    # Test that overflow of reftype is detected and doesn't corrupt levels
+# Test that overflow of reftype is detected and doesn't corrupt levels
 
-    res = @test_throws LevelsException{Int, UInt8} CategoricalPool{Int, UInt8}(collect(256:-1:1))
-    @test res.value.levels == [1]
-    @test sprint(showerror, res.value) == "cannot store level(s) 1 since reference type UInt8 can only hold 255 levels. Use the decompress function to make room for more levels."
+res = @test_throws LevelsException{Int, UInt8} CategoricalPool{Int, UInt8}(collect(256:-1:1))
+@test res.value.levels == [1]
+@test sprint(showerror, res.value) == "cannot store level(s) 1 since reference type UInt8 can only hold 255 levels. Use the decompress function to make room for more levels."
 
-    pool = CategoricalPool(collect(30:288))
-    res = @test_throws LevelsException{Int, UInt8} convert(CategoricalPool{Int, UInt8}, pool)
-    @test res.value.levels == collect(285:288)
-    @test sprint(showerror, res.value) == "cannot store level(s) 285, 286, 287 and 288 since reference type UInt8 can only hold 255 levels. Use the decompress function to make room for more levels."
+pool = CategoricalPool(collect(30:288))
+res = @test_throws LevelsException{Int, UInt8} convert(CategoricalPool{Int, UInt8}, pool)
+@test res.value.levels == collect(285:288)
+@test sprint(showerror, res.value) == "cannot store level(s) 285, 286, 287 and 288 since reference type UInt8 can only hold 255 levels. Use the decompress function to make room for more levels."
 
-    pool = CategoricalPool{String, UInt8}(string.(318:-1:65))
-    res = @test_throws LevelsException{String, UInt8} levels!(pool, vcat("az", levels(pool), "bz", "cz"))
-    @test res.value.levels == ["bz", "cz"]
-    @test sprint(showerror, res.value) == "cannot store level(s) \"bz\" and \"cz\" since reference type UInt8 can only hold 255 levels. Use the decompress function to make room for more levels."
-    lev = copy(levels(pool))
-    levels!(pool, vcat(lev, "az"))
-    @test levels(pool) == vcat(lev, "az")
+pool = CategoricalPool{String, UInt8}(string.(318:-1:65))
+res = @test_throws LevelsException{String, UInt8} levels!(pool, vcat("az", levels(pool), "bz", "cz"))
+@test res.value.levels == ["bz", "cz"]
+@test sprint(showerror, res.value) == "cannot store level(s) \"bz\" and \"cz\" since reference type UInt8 can only hold 255 levels. Use the decompress function to make room for more levels."
+lev = copy(levels(pool))
+levels!(pool, vcat(lev, "az"))
+@test levels(pool) == vcat(lev, "az")
+
 end

--- a/test/08_equality.jl
+++ b/test/08_equality.jl
@@ -1,128 +1,128 @@
 module TestEquality
-    using Base.Test
-    using CategoricalArrays
+using Base.Test
+using CategoricalArrays
 
-    pool1 = CategoricalPool([1, 2, 3])
-    pool2 = CategoricalPool([2.0, 1.0, 3.0])
+pool1 = CategoricalPool([1, 2, 3])
+pool2 = CategoricalPool([2.0, 1.0, 3.0])
 
-    @test isequal(pool1, pool1) === true
-    @test isequal(pool1, pool2) === false
-    @test isequal(pool2, pool2) === true
+@test isequal(pool1, pool1) === true
+@test isequal(pool1, pool2) === false
+@test isequal(pool2, pool2) === true
 
-    @test (pool1 == pool1) === true
-    @test (pool1 == pool2) === false
-    @test (pool2 == pool2) === true
+@test (pool1 == pool1) === true
+@test (pool1 == pool2) === false
+@test (pool2 == pool2) === true
 
-    @test (pool1 === pool1) === true
-    @test (pool1 === pool2) === false
-    @test (pool2 === pool2) === true
+@test (pool1 === pool1) === true
+@test (pool1 === pool2) === false
+@test (pool2 === pool2) === true
 
-    opool1 = CategoricalPool([1, 2, 3], true)
-    opool2 = CategoricalPool([2.0, 1.0, 3.0], true)
+opool1 = CategoricalPool([1, 2, 3], true)
+opool2 = CategoricalPool([2.0, 1.0, 3.0], true)
 
-    @test isequal(opool1, opool1) === true
-    @test isequal(opool1, opool2) === false
-    @test isequal(opool2, opool2) === true
+@test isequal(opool1, opool1) === true
+@test isequal(opool1, opool2) === false
+@test isequal(opool2, opool2) === true
 
-    @test (opool1 == opool1) === true
-    @test (opool1 == opool2) === false
-    @test (opool2 == opool2) === true
+@test (opool1 == opool1) === true
+@test (opool1 == opool2) === false
+@test (opool2 == opool2) === true
 
-    @test (opool1 === opool1) === true
-    @test (opool1 === opool2) === false
-    @test (opool2 === opool2) === true
+@test (opool1 === opool1) === true
+@test (opool1 === opool2) === false
+@test (opool2 === opool2) === true
 
-    nv1a = CategoricalArrays.catvalue(1, pool1)
-    nv2a = CategoricalArrays.catvalue(1, pool2)
-    nv1b = CategoricalArrays.catvalue(2, pool1)
-    nv2b = CategoricalArrays.catvalue(2, pool2)
+nv1a = CategoricalArrays.catvalue(1, pool1)
+nv2a = CategoricalArrays.catvalue(1, pool2)
+nv1b = CategoricalArrays.catvalue(2, pool1)
+nv2b = CategoricalArrays.catvalue(2, pool2)
 
-    @test isequal(nv1a, nv1a) == true
-    @test isequal(nv1a, nv2a) == false
-    @test isequal(nv1a, nv1b) == false
-    @test isequal(nv1a, nv2b) == true
+@test isequal(nv1a, nv1a) == true
+@test isequal(nv1a, nv2a) == false
+@test isequal(nv1a, nv1b) == false
+@test isequal(nv1a, nv2b) == true
 
-    @test isequal(nv1b, nv1a) == false
-    @test isequal(nv1b, nv2a) == true
-    @test isequal(nv1b, nv1b) == true
-    @test isequal(nv1b, nv2b) == false
+@test isequal(nv1b, nv1a) == false
+@test isequal(nv1b, nv2a) == true
+@test isequal(nv1b, nv1b) == true
+@test isequal(nv1b, nv2b) == false
 
-    @test isequal(nv2a, nv1a) == false
-    @test isequal(nv2a, nv2a) == true
-    @test isequal(nv2a, nv1b) == true
-    @test isequal(nv2a, nv2b) == false
+@test isequal(nv2a, nv1a) == false
+@test isequal(nv2a, nv2a) == true
+@test isequal(nv2a, nv1b) == true
+@test isequal(nv2a, nv2b) == false
 
-    @test isequal(nv2b, nv1a) == true
-    @test isequal(nv2b, nv2a) == false
-    @test isequal(nv2b, nv1b) == false
-    @test isequal(nv2b, nv2b) == true
+@test isequal(nv2b, nv1a) == true
+@test isequal(nv2b, nv2a) == false
+@test isequal(nv2b, nv1b) == false
+@test isequal(nv2b, nv2b) == true
 
-    @test isequal(1, nv1a) == true
-    @test isequal(1, nv2a) == false
-    @test isequal(1, nv1b) == false
-    @test isequal(1, nv2b) == true
+@test isequal(1, nv1a) == true
+@test isequal(1, nv2a) == false
+@test isequal(1, nv1b) == false
+@test isequal(1, nv2b) == true
 
-    @test isequal(nv1a, 2) == false
-    @test isequal(nv2a, 2) == true
-    @test isequal(nv1b, 2) == true
-    @test isequal(nv2b, 2) == false
+@test isequal(nv1a, 2) == false
+@test isequal(nv2a, 2) == true
+@test isequal(nv1b, 2) == true
+@test isequal(nv2b, 2) == false
 
-    ov1a = CategoricalArrays.catvalue(1, opool1)
-    ov2a = CategoricalArrays.catvalue(1, opool2)
-    ov1b = CategoricalArrays.catvalue(2, opool1)
-    ov2b = CategoricalArrays.catvalue(2, opool2)
+ov1a = CategoricalArrays.catvalue(1, opool1)
+ov2a = CategoricalArrays.catvalue(1, opool2)
+ov1b = CategoricalArrays.catvalue(2, opool1)
+ov2b = CategoricalArrays.catvalue(2, opool2)
 
-    @test isequal(ov1a, ov1a) == true
-    @test isequal(ov1a, ov2a) == false
-    @test isequal(ov1a, ov1b) == false
-    @test isequal(ov1a, ov2b) == true
+@test isequal(ov1a, ov1a) == true
+@test isequal(ov1a, ov2a) == false
+@test isequal(ov1a, ov1b) == false
+@test isequal(ov1a, ov2b) == true
 
-    @test isequal(ov1b, ov1a) == false
-    @test isequal(ov1b, ov2a) == true
-    @test isequal(ov1b, ov1b) == true
-    @test isequal(ov1b, ov2b) == false
+@test isequal(ov1b, ov1a) == false
+@test isequal(ov1b, ov2a) == true
+@test isequal(ov1b, ov1b) == true
+@test isequal(ov1b, ov2b) == false
 
-    @test isequal(ov2a, ov1a) == false
-    @test isequal(ov2a, ov2a) == true
-    @test isequal(ov2a, ov1b) == true
-    @test isequal(ov2a, ov2b) == false
+@test isequal(ov2a, ov1a) == false
+@test isequal(ov2a, ov2a) == true
+@test isequal(ov2a, ov1b) == true
+@test isequal(ov2a, ov2b) == false
 
-    @test isequal(ov2b, ov1a) == true
-    @test isequal(ov2b, ov2a) == false
-    @test isequal(ov2b, ov1b) == false
-    @test isequal(ov2b, ov2b) == true
+@test isequal(ov2b, ov1a) == true
+@test isequal(ov2b, ov2a) == false
+@test isequal(ov2b, ov1b) == false
+@test isequal(ov2b, ov2b) == true
 
-    @test isequal(1, ov1a) == true
-    @test isequal(1, ov2a) == false
-    @test isequal(1, ov1b) == false
-    @test isequal(1, ov2b) == true
+@test isequal(1, ov1a) == true
+@test isequal(1, ov2a) == false
+@test isequal(1, ov1b) == false
+@test isequal(1, ov2b) == true
 
-    @test isequal(ov1a, 2) == false
-    @test isequal(ov2a, 2) == true
-    @test isequal(ov1b, 2) == true
-    @test isequal(ov2b, 2) == false
+@test isequal(ov1a, 2) == false
+@test isequal(ov2a, 2) == true
+@test isequal(ov1b, 2) == true
+@test isequal(ov2b, 2) == false
 
-    @test (ov1a == ov1a) == true
-    @test (ov1a == ov2a) == false
-    @test (ov1a == ov1b) == false
-    @test (ov1a == ov2b) == true
+@test (ov1a == ov1a) == true
+@test (ov1a == ov2a) == false
+@test (ov1a == ov1b) == false
+@test (ov1a == ov2b) == true
 
-    @test (ov1b == ov1a) == false
-    @test (ov1b == ov2a) == true
-    @test (ov1b == ov1b) == true
-    @test (ov1b == ov2b) == false
+@test (ov1b == ov1a) == false
+@test (ov1b == ov2a) == true
+@test (ov1b == ov1b) == true
+@test (ov1b == ov2b) == false
 
-    @test (ov2a == ov1a) == false
-    @test (ov2a == ov2a) == true
-    @test (ov2a == ov1b) == true
-    @test (ov2a == ov2b) == false
+@test (ov2a == ov1a) == false
+@test (ov2a == ov2a) == true
+@test (ov2a == ov1b) == true
+@test (ov2a == ov2b) == false
 
-    @test (ov2b == ov1a) == true
-    @test (ov2b == ov2a) == false
-    @test (ov2b == ov1b) == false
-    @test (ov2b == ov2b) == true
+@test (ov2b == ov1a) == true
+@test (ov2b == ov2a) == false
+@test (ov2b == ov1b) == false
+@test (ov2b == ov2b) == true
 
-    # Check that ordered and non-ordered values are equal
+@testset "ordered and non-ordered values are equal" begin
     @test (ov1a == nv1a) === true
     @test (ov1a == nv2a) === false
     @test (ov1a == nv1b) === false
@@ -142,8 +142,9 @@ module TestEquality
     @test (ov2b == nv2a) === false
     @test (ov2b == nv1b) === false
     @test (ov2b == nv2b) === true
+end
 
-    # Check non-equality with null
+@testset "non-equality with null" begin
     @test isnull(nv1a == null)
     @test isnull(ov1a == null)
     @test isnull(null == nv1a)
@@ -153,8 +154,9 @@ module TestEquality
     @test isequal(ov1a, null) == false
     @test isequal(null, nv1a) == false
     @test isequal(null, ov1a) == false
+end
 
-    # Check in()
+@testset "in()" begin
     pool = CategoricalPool([5, 1, 3])
     nv = CategoricalArrays.catvalue(2, pool)
 
@@ -162,4 +164,6 @@ module TestEquality
     @test (nv in [1, 2, 3]) === true
     @test (nv in 2:3) === false
     @test (nv in [2, 3]) === false
+end
+
 end

--- a/test/08_equality.jl
+++ b/test/08_equality.jl
@@ -2,127 +2,128 @@ module TestEquality
 using Base.Test
 using CategoricalArrays
 
-pool1 = CategoricalPool([1, 2, 3])
-pool2 = CategoricalPool([2.0, 1.0, 3.0])
+@testset "== and isequal() for CategoricalPool{Int} and CategoricalPool{Float64}" begin
+    pool1 = CategoricalPool([1, 2, 3])
+    pool2 = CategoricalPool([2.0, 1.0, 3.0])
 
-@test isequal(pool1, pool1) === true
-@test isequal(pool1, pool2) === false
-@test isequal(pool2, pool2) === true
+    @test isequal(pool1, pool1) === true
+    @test isequal(pool1, pool2) === false
+    @test isequal(pool2, pool2) === true
 
-@test (pool1 == pool1) === true
-@test (pool1 == pool2) === false
-@test (pool2 == pool2) === true
+    @test (pool1 == pool1) === true
+    @test (pool1 == pool2) === false
+    @test (pool2 == pool2) === true
 
-@test (pool1 === pool1) === true
-@test (pool1 === pool2) === false
-@test (pool2 === pool2) === true
+    @test (pool1 === pool1) === true
+    @test (pool1 === pool2) === false
+    @test (pool2 === pool2) === true
 
-opool1 = CategoricalPool([1, 2, 3], true)
-opool2 = CategoricalPool([2.0, 1.0, 3.0], true)
+    opool1 = CategoricalPool([1, 2, 3], true)
+    opool2 = CategoricalPool([2.0, 1.0, 3.0], true)
 
-@test isequal(opool1, opool1) === true
-@test isequal(opool1, opool2) === false
-@test isequal(opool2, opool2) === true
+    @test isequal(opool1, opool1) === true
+    @test isequal(opool1, opool2) === false
+    @test isequal(opool2, opool2) === true
 
-@test (opool1 == opool1) === true
-@test (opool1 == opool2) === false
-@test (opool2 == opool2) === true
+    @test (opool1 == opool1) === true
+    @test (opool1 == opool2) === false
+    @test (opool2 == opool2) === true
 
-@test (opool1 === opool1) === true
-@test (opool1 === opool2) === false
-@test (opool2 === opool2) === true
+    @test (opool1 === opool1) === true
+    @test (opool1 === opool2) === false
+    @test (opool2 === opool2) === true
 
-nv1a = CategoricalArrays.catvalue(1, pool1)
-nv2a = CategoricalArrays.catvalue(1, pool2)
-nv1b = CategoricalArrays.catvalue(2, pool1)
-nv2b = CategoricalArrays.catvalue(2, pool2)
+    nv1a = CategoricalArrays.catvalue(1, pool1)
+    nv2a = CategoricalArrays.catvalue(1, pool2)
+    nv1b = CategoricalArrays.catvalue(2, pool1)
+    nv2b = CategoricalArrays.catvalue(2, pool2)
 
-@test isequal(nv1a, nv1a) == true
-@test isequal(nv1a, nv2a) == false
-@test isequal(nv1a, nv1b) == false
-@test isequal(nv1a, nv2b) == true
+    @test isequal(nv1a, nv1a) == true
+    @test isequal(nv1a, nv2a) == false
+    @test isequal(nv1a, nv1b) == false
+    @test isequal(nv1a, nv2b) == true
 
-@test isequal(nv1b, nv1a) == false
-@test isequal(nv1b, nv2a) == true
-@test isequal(nv1b, nv1b) == true
-@test isequal(nv1b, nv2b) == false
+    @test isequal(nv1b, nv1a) == false
+    @test isequal(nv1b, nv2a) == true
+    @test isequal(nv1b, nv1b) == true
+    @test isequal(nv1b, nv2b) == false
 
-@test isequal(nv2a, nv1a) == false
-@test isequal(nv2a, nv2a) == true
-@test isequal(nv2a, nv1b) == true
-@test isequal(nv2a, nv2b) == false
+    @test isequal(nv2a, nv1a) == false
+    @test isequal(nv2a, nv2a) == true
+    @test isequal(nv2a, nv1b) == true
+    @test isequal(nv2a, nv2b) == false
 
-@test isequal(nv2b, nv1a) == true
-@test isequal(nv2b, nv2a) == false
-@test isequal(nv2b, nv1b) == false
-@test isequal(nv2b, nv2b) == true
+    @test isequal(nv2b, nv1a) == true
+    @test isequal(nv2b, nv2a) == false
+    @test isequal(nv2b, nv1b) == false
+    @test isequal(nv2b, nv2b) == true
 
-@test isequal(1, nv1a) == true
-@test isequal(1, nv2a) == false
-@test isequal(1, nv1b) == false
-@test isequal(1, nv2b) == true
+    @test isequal(1, nv1a) == true
+    @test isequal(1, nv2a) == false
+    @test isequal(1, nv1b) == false
+    @test isequal(1, nv2b) == true
 
-@test isequal(nv1a, 2) == false
-@test isequal(nv2a, 2) == true
-@test isequal(nv1b, 2) == true
-@test isequal(nv2b, 2) == false
+    @test isequal(nv1a, 2) == false
+    @test isequal(nv2a, 2) == true
+    @test isequal(nv1b, 2) == true
+    @test isequal(nv2b, 2) == false
 
-ov1a = CategoricalArrays.catvalue(1, opool1)
-ov2a = CategoricalArrays.catvalue(1, opool2)
-ov1b = CategoricalArrays.catvalue(2, opool1)
-ov2b = CategoricalArrays.catvalue(2, opool2)
+    ov1a = CategoricalArrays.catvalue(1, opool1)
+    ov2a = CategoricalArrays.catvalue(1, opool2)
+    ov1b = CategoricalArrays.catvalue(2, opool1)
+    ov2b = CategoricalArrays.catvalue(2, opool2)
 
-@test isequal(ov1a, ov1a) == true
-@test isequal(ov1a, ov2a) == false
-@test isequal(ov1a, ov1b) == false
-@test isequal(ov1a, ov2b) == true
+    @test isequal(ov1a, ov1a) == true
+    @test isequal(ov1a, ov2a) == false
+    @test isequal(ov1a, ov1b) == false
+    @test isequal(ov1a, ov2b) == true
 
-@test isequal(ov1b, ov1a) == false
-@test isequal(ov1b, ov2a) == true
-@test isequal(ov1b, ov1b) == true
-@test isequal(ov1b, ov2b) == false
+    @test isequal(ov1b, ov1a) == false
+    @test isequal(ov1b, ov2a) == true
+    @test isequal(ov1b, ov1b) == true
+    @test isequal(ov1b, ov2b) == false
 
-@test isequal(ov2a, ov1a) == false
-@test isequal(ov2a, ov2a) == true
-@test isequal(ov2a, ov1b) == true
-@test isequal(ov2a, ov2b) == false
+    @test isequal(ov2a, ov1a) == false
+    @test isequal(ov2a, ov2a) == true
+    @test isequal(ov2a, ov1b) == true
+    @test isequal(ov2a, ov2b) == false
 
-@test isequal(ov2b, ov1a) == true
-@test isequal(ov2b, ov2a) == false
-@test isequal(ov2b, ov1b) == false
-@test isequal(ov2b, ov2b) == true
+    @test isequal(ov2b, ov1a) == true
+    @test isequal(ov2b, ov2a) == false
+    @test isequal(ov2b, ov1b) == false
+    @test isequal(ov2b, ov2b) == true
 
-@test isequal(1, ov1a) == true
-@test isequal(1, ov2a) == false
-@test isequal(1, ov1b) == false
-@test isequal(1, ov2b) == true
+    @test isequal(1, ov1a) == true
+    @test isequal(1, ov2a) == false
+    @test isequal(1, ov1b) == false
+    @test isequal(1, ov2b) == true
 
-@test isequal(ov1a, 2) == false
-@test isequal(ov2a, 2) == true
-@test isequal(ov1b, 2) == true
-@test isequal(ov2b, 2) == false
+    @test isequal(ov1a, 2) == false
+    @test isequal(ov2a, 2) == true
+    @test isequal(ov1b, 2) == true
+    @test isequal(ov2b, 2) == false
 
-@test (ov1a == ov1a) == true
-@test (ov1a == ov2a) == false
-@test (ov1a == ov1b) == false
-@test (ov1a == ov2b) == true
+    @test (ov1a == ov1a) == true
+    @test (ov1a == ov2a) == false
+    @test (ov1a == ov1b) == false
+    @test (ov1a == ov2b) == true
 
-@test (ov1b == ov1a) == false
-@test (ov1b == ov2a) == true
-@test (ov1b == ov1b) == true
-@test (ov1b == ov2b) == false
+    @test (ov1b == ov1a) == false
+    @test (ov1b == ov2a) == true
+    @test (ov1b == ov1b) == true
+    @test (ov1b == ov2b) == false
 
-@test (ov2a == ov1a) == false
-@test (ov2a == ov2a) == true
-@test (ov2a == ov1b) == true
-@test (ov2a == ov2b) == false
+    @test (ov2a == ov1a) == false
+    @test (ov2a == ov2a) == true
+    @test (ov2a == ov1b) == true
+    @test (ov2a == ov2b) == false
 
-@test (ov2b == ov1a) == true
-@test (ov2b == ov2a) == false
-@test (ov2b == ov1b) == false
-@test (ov2b == ov2b) == true
+    @test (ov2b == ov1a) == true
+    @test (ov2b == ov2a) == false
+    @test (ov2b == ov1b) == false
+    @test (ov2b == ov2b) == true
 
-@testset "ordered and non-ordered values are equal" begin
+    @testset "ordered and non-ordered values are equal" begin
     @test (ov1a == nv1a) === true
     @test (ov1a == nv2a) === false
     @test (ov1a == nv1b) === false
@@ -142,9 +143,9 @@ ov2b = CategoricalArrays.catvalue(2, opool2)
     @test (ov2b == nv2a) === false
     @test (ov2b == nv1b) === false
     @test (ov2b == nv2b) === true
-end
+    end
 
-@testset "non-equality with null" begin
+    @testset "non-equality with null" begin
     @test isnull(nv1a == null)
     @test isnull(ov1a == null)
     @test isnull(null == nv1a)
@@ -154,6 +155,7 @@ end
     @test isequal(ov1a, null) == false
     @test isequal(null, nv1a) == false
     @test isequal(null, ov1a) == false
+    end
 end
 
 @testset "in()" begin

--- a/test/08_string.jl
+++ b/test/08_string.jl
@@ -2,224 +2,226 @@ module TestString
 using Base.Test
 using CategoricalArrays
 
-pool = CategoricalPool(["", "café"])
+@testset "AbstractString operations on values of CategoricalPool{String}" begin
+    pool = CategoricalPool(["", "café"])
 
-v1 = CategoricalArrays.catvalue(1, pool)
-v2 = CategoricalArrays.catvalue(2, pool)
+    v1 = CategoricalArrays.catvalue(1, pool)
+    v2 = CategoricalArrays.catvalue(2, pool)
 
-@test v1 isa AbstractString
-@test v2 isa AbstractString
+    @test v1 isa AbstractString
+    @test v2 isa AbstractString
 
-@test typeof(promote("a", v1)) == Tuple{String,String}
+    @test typeof(promote("a", v1)) == Tuple{String,String}
 
-@test String(v1)::String == ""
-@test String(v2)::String == "café"
+    @test String(v1)::String == ""
+    @test String(v2)::String == "café"
 
-@test Symbol(v1) === Symbol("")
-@test Symbol(v2) === :café
+    @test Symbol(v1) === Symbol("")
+    @test Symbol(v2) === :café
 
-@test v1 == ""
-@test v2 == "café"
-@test v2 != ""
+    @test v1 == ""
+    @test v2 == "café"
+    @test v2 != ""
 
-@test isequal(v1, "")
-@test isequal(v2, "café")
-@test !isequal(v2, "")
+    @test isequal(v1, "")
+    @test isequal(v2, "café")
+    @test !isequal(v2, "")
 
-@test isempty(v1)
-@test !isempty(v2)
+    @test isempty(v1)
+    @test !isempty(v2)
 
-@test length(v1) === 0
-@test length(v2) === 4
+    @test length(v1) === 0
+    @test length(v2) === 4
 
-@test sizeof(v1) === 0
-@test sizeof(v2) === 5
+    @test sizeof(v1) === 0
+    @test sizeof(v2) === 5
 
-@test nextind(v1, 1) === 2
-@test nextind(v2, 4) === 6
+    @test nextind(v1, 1) === 2
+    @test nextind(v2, 4) === 6
 
-@test prevind(v1, 1) === 0
-@test prevind(v2, 6) === 4
+    @test prevind(v1, 1) === 0
+    @test prevind(v2, 6) === 4
 
-@test endof(v1) === 0
-@test endof(v2) === 4
+    @test endof(v1) === 0
+    @test endof(v2) === 4
 
-@test collect(v1) == []
-@test collect(v2) == collect("café")
+    @test collect(v1) == []
+    @test collect(v2) == collect("café")
 
-@test v2[2] === 'a'
-@test v2[4] === 'é'
-@test_throws BoundsError v1[1]
-@test_throws UnicodeError v2[5]
+    @test v2[2] === 'a'
+    @test v2[4] === 'é'
+    @test_throws BoundsError v1[1]
+    @test_throws UnicodeError v2[5]
 
-@test codeunit(v2, 2) === 0x61
-@test codeunit(v2, 5) === 0xa9
-@test_throws BoundsError codeunit(v1, 1)
-@test_throws BoundsError codeunit(v2, 6)
+    @test codeunit(v2, 2) === 0x61
+    @test codeunit(v2, 5) === 0xa9
+    @test_throws BoundsError codeunit(v1, 1)
+    @test_throws BoundsError codeunit(v2, 6)
 
-@test ascii(v1)::String == ""
-@test_throws ArgumentError ascii(v2)
+    @test ascii(v1)::String == ""
+    @test_throws ArgumentError ascii(v2)
 
-@test normalize_string(v1) == ""
-@test normalize_string(v2) == "café"
-@test normalize_string(v2, :NFKD) == "café"
+    @test normalize_string(v1) == ""
+    @test normalize_string(v2) == "café"
+    @test normalize_string(v2, :NFKD) == "café"
 
-@test isempty(collect(graphemes(v1)))
-@test collect(graphemes(v2)) == collect(graphemes("café"))
+    @test isempty(collect(graphemes(v1)))
+    @test collect(graphemes(v2)) == collect(graphemes("café"))
 
-@test isvalid(v1)
-@test isvalid(v2)
-@test !isvalid(v1, 1)
-@test isvalid(v2, 4)
-@test !isvalid(v2, 5)
+    @test isvalid(v1)
+    @test isvalid(v2)
+    @test !isvalid(v1, 1)
+    @test isvalid(v2, 4)
+    @test !isvalid(v2, 5)
 
-@test_throws BoundsError ind2chr(v1, 0)
-@test ind2chr(v2, 4) === 4
+    @test_throws BoundsError ind2chr(v1, 0)
+    @test ind2chr(v2, 4) === 4
 
-@test_throws BoundsError chr2ind(v1, 1)
-@test chr2ind(v2, 2) === 2
+    @test_throws BoundsError chr2ind(v1, 1)
+    @test chr2ind(v2, 2) === 2
 
-@test string(v1) == ""
-@test string(v2) == "café"
-@test string(v1, "a") == "a"
-@test string(v1, "a", v2) == "acafé"
-@test string(v2, 1) == "café1"
+    @test string(v1) == ""
+    @test string(v2) == "café"
+    @test string(v1, "a") == "a"
+    @test string(v1, "a", v2) == "acafé"
+    @test string(v2, 1) == "café1"
 
-@test sprint(print, v1) == ""
-@test sprint(print, v2) == "café"
+    @test sprint(print, v1) == ""
+    @test sprint(print, v2) == "café"
 
-@test repr(v1) == "\"\""
-@test repr(v2) == "\"café\""
+    @test repr(v1) == "\"\""
+    @test repr(v2) == "\"café\""
 
-@test "a" * v1 == "a"
-@test "a" * v1 * "b" == "ab"
-@test "a" * v1 * v2 == "acafé"
+    @test "a" * v1 == "a"
+    @test "a" * v1 * "b" == "ab"
+    @test "a" * v1 * v2 == "acafé"
 
-@test v1^1 == ""
-@test v2^1 == "café"
-@test v1^2 == ""
-@test v2^2 == "cafécafé"
+    @test v1^1 == ""
+    @test v2^1 == "café"
+    @test v1^2 == ""
+    @test v2^2 == "cafécafé"
 
-@test repeat(v1, 10) == ""
-@test repeat(v2, 2) == "cafécafé"
+    @test repeat(v1, 10) == ""
+    @test repeat(v2, 2) == "cafécafé"
 
-@test !ismatch(r"fé", v1)
-@test ismatch(r"fé", v2)
+    @test !ismatch(r"fé", v1)
+    @test ismatch(r"fé", v2)
 
-@test isempty(collect(eachmatch(r"fé", v1)))
-@test first(eachmatch(r"fé", v2)).offset == 3
+    @test isempty(collect(eachmatch(r"fé", v1)))
+    @test first(eachmatch(r"fé", v2)).offset == 3
 
-@test match(r"fé", v1) === nothing
-@test match(r"fé", v2).offset === 3
-@test match(r"fé", v2, 2).offset === 3
-@test match(r"fé", v2, 2, UInt32(0)).offset === 3
+    @test match(r"fé", v1) === nothing
+    @test match(r"fé", v2).offset === 3
+    @test match(r"fé", v2, 2).offset === 3
+    @test match(r"fé", v2, 2, UInt32(0)).offset === 3
 
-@test matchall(r"fé", v1) == []
-@test matchall(r"fé", v2) == ["fé"]
-@test matchall(r"fé", v2, true) == ["fé"]
+    @test matchall(r"fé", v1) == []
+    @test matchall(r"fé", v2) == ["fé"]
+    @test matchall(r"fé", v2, true) == ["fé"]
 
-@test lpad(v1, 1) == " "
-@test lpad(v2, 1) == "café"
-@test lpad(v2, 5) == " café"
+    @test lpad(v1, 1) == " "
+    @test lpad(v2, 1) == "café"
+    @test lpad(v2, 5) == " café"
 
-@test rpad(v1, 1) == " "
-@test rpad(v2, 1) == "café"
-@test rpad(v2, 5) == "café "
+    @test rpad(v1, 1) == " "
+    @test rpad(v2, 1) == "café"
+    @test rpad(v2, 5) == "café "
 
-@test search(v1, "") === 1:0
-@test search(v2, "a") === 2:2
-@test search(v2, 'a') === 2
-@test search(v2, 'a', 3) === 0
+    @test search(v1, "") === 1:0
+    @test search(v2, "a") === 2:2
+    @test search(v2, 'a') === 2
+    @test search(v2, 'a', 3) === 0
 
-@test searchindex(v1, "") === 1
-@test searchindex(v2, "a") === 2
-@test searchindex(v2, 'a') === 2
-@test searchindex(v2, 'a', 3) === 0
+    @test searchindex(v1, "") === 1
+    @test searchindex(v2, "a") === 2
+    @test searchindex(v2, 'a') === 2
+    @test searchindex(v2, 'a', 3) === 0
 
-@test rsearch(v1, "a") === 0:-1
-@test rsearch(v2, "a") === 2:2
-@test rsearch(v2, 'a') === 2
-@test rsearch(v2, 'a', 1) === 0
+    @test rsearch(v1, "a") === 0:-1
+    @test rsearch(v2, "a") === 2:2
+    @test rsearch(v2, 'a') === 2
+    @test rsearch(v2, 'a', 1) === 0
 
-@test rsearchindex(v1, "a") === 0
-@test rsearchindex(v2, "a") === 2
-# Methods not defined even for String
-#@test rsearchindex(v2, 'a') === 2
-#@test rsearchindex(v2, 'a', 1) === 0
+    @test rsearchindex(v1, "a") === 0
+    @test rsearchindex(v2, "a") === 2
+    # Methods not defined even for String
+    #@test rsearchindex(v2, 'a') === 2
+    #@test rsearchindex(v2, 'a', 1) === 0
 
-@test !contains(v1, "a")
-@test contains(v1, "")
-@test contains(v2, "fé")
+    @test !contains(v1, "a")
+    @test contains(v1, "")
+    @test contains(v2, "fé")
 
-@test startswith(v1, "")
-@test !startswith(v1, "a")
-@test startswith(v2, "caf")
+    @test startswith(v1, "")
+    @test !startswith(v1, "a")
+    @test startswith(v2, "caf")
 
-@test endswith(v1, "")
-@test !endswith(v1, "a")
-@test endswith(v2, "fé")
+    @test endswith(v1, "")
+    @test !endswith(v1, "a")
+    @test endswith(v2, "fé")
 
-@test reverse(v1) == ""
-@test reverse(v2) == "éfac"
+    @test reverse(v1) == ""
+    @test reverse(v2) == "éfac"
 
-@test replace(v1, "a", "b") == ""
-@test replace(v2, 'a', 'b') == "cbfé"
-@test replace(v2, "ca", "b", 1) == "bfé"
+    @test replace(v1, "a", "b") == ""
+    @test replace(v2, 'a', 'b') == "cbfé"
+    @test replace(v2, "ca", "b", 1) == "bfé"
 
-@test isempty(split(v1))
-@test split(v1, "a") == [""]
-@test split(v2) == ["café"]
-@test split(v2, "f") == ["ca", "é"]
+    @test isempty(split(v1))
+    @test split(v1, "a") == [""]
+    @test split(v2) == ["café"]
+    @test split(v2, "f") == ["ca", "é"]
 
-@test rsplit(v1, "a") == [""]
-@test rsplit(v2, "f") == ["ca", "é"]
+    @test rsplit(v1, "a") == [""]
+    @test rsplit(v2, "f") == ["ca", "é"]
 
-@test strip(v1) == ""
-@test strip(v2) == v2
-@test strip(v2, 'é') == "caf"
+    @test strip(v1) == ""
+    @test strip(v2) == v2
+    @test strip(v2, 'é') == "caf"
 
-@test lstrip(v1) == ""
-@test lstrip(v2) == v2
-@test lstrip(v2, 'é') == "café"
+    @test lstrip(v1) == ""
+    @test lstrip(v2) == v2
+    @test lstrip(v2, 'é') == "café"
 
-@test rstrip(v1) == ""
-@test rstrip(v2) == v2
-@test rstrip(v2, 'é') == "caf"
+    @test rstrip(v1) == ""
+    @test rstrip(v2) == v2
+    @test rstrip(v2, 'é') == "caf"
 
-@test uppercase(v1) == ""
-@test uppercase(v2) == "CAFÉ"
+    @test uppercase(v1) == ""
+    @test uppercase(v2) == "CAFÉ"
 
-@test lowercase(v1) == ""
-@test lowercase(v2) == "café"
+    @test lowercase(v1) == ""
+    @test lowercase(v2) == "café"
 
-@test titlecase(v1) == ""
-@test titlecase(v2) == "Café"
+    @test titlecase(v1) == ""
+    @test titlecase(v2) == "Café"
 
-@test ucfirst(v1) == ""
-@test ucfirst(v2) == "Café"
+    @test ucfirst(v1) == ""
+    @test ucfirst(v2) == "Café"
 
-@test lcfirst(v1) == ""
-@test lcfirst(v2) == "café"
+    @test lcfirst(v1) == ""
+    @test lcfirst(v2) == "café"
 
-@test join([v1, "a"]) == "a"
-@test join([v1, "a"], v2) == "caféa"
+    @test join([v1, "a"]) == "a"
+    @test join([v1, "a"], v2) == "caféa"
 
-@test chop(v1) == ""
-@test chop(v2) == "caf"
+    @test chop(v1) == ""
+    @test chop(v2) == "caf"
 
-@test chomp(v1) == ""
-@test chomp(v2) == "café"
+    @test chomp(v1) == ""
+    @test chomp(v2) == "café"
 
-@test strwidth(v1) === 0
-@test strwidth(v2) === 4
+    @test strwidth(v1) === 0
+    @test strwidth(v2) === 4
 
-@test isascii(v1)
-@test !isascii(v2)
+    @test isascii(v1)
+    @test !isascii(v2)
 
-@test escape_string(v1) == ""
-@test escape_string(v2) == "café"
+    @test escape_string(v1) == ""
+    @test escape_string(v2) == "café"
 
-@test collect(v1) == Char[]
-@test collect(v2) == Char['c', 'a', 'f', 'é']
+    @test collect(v1) == Char[]
+    @test collect(v2) == Char['c', 'a', 'f', 'é']
+end
 
 end

--- a/test/08_string.jl
+++ b/test/08_string.jl
@@ -1,224 +1,225 @@
 module TestString
-    using Base.Test
-    using CategoricalArrays
+using Base.Test
+using CategoricalArrays
 
-    pool = CategoricalPool(["", "café"])
+pool = CategoricalPool(["", "café"])
 
-    v1 = CategoricalArrays.catvalue(1, pool)
-    v2 = CategoricalArrays.catvalue(2, pool)
+v1 = CategoricalArrays.catvalue(1, pool)
+v2 = CategoricalArrays.catvalue(2, pool)
 
-    @test v1 isa AbstractString
-    @test v2 isa AbstractString
+@test v1 isa AbstractString
+@test v2 isa AbstractString
 
-    @test typeof(promote("a", v1)) == Tuple{String,String}
+@test typeof(promote("a", v1)) == Tuple{String,String}
 
-    @test String(v1)::String == ""
-    @test String(v2)::String == "café"
+@test String(v1)::String == ""
+@test String(v2)::String == "café"
 
-    @test Symbol(v1) === Symbol("")
-    @test Symbol(v2) === :café
+@test Symbol(v1) === Symbol("")
+@test Symbol(v2) === :café
 
-    @test v1 == ""
-    @test v2 == "café"
-    @test v2 != ""
+@test v1 == ""
+@test v2 == "café"
+@test v2 != ""
 
-    @test isequal(v1, "")
-    @test isequal(v2, "café")
-    @test !isequal(v2, "")
+@test isequal(v1, "")
+@test isequal(v2, "café")
+@test !isequal(v2, "")
 
-    @test isempty(v1)
-    @test !isempty(v2)
+@test isempty(v1)
+@test !isempty(v2)
 
-    @test length(v1) === 0
-    @test length(v2) === 4
+@test length(v1) === 0
+@test length(v2) === 4
 
-    @test sizeof(v1) === 0
-    @test sizeof(v2) === 5
+@test sizeof(v1) === 0
+@test sizeof(v2) === 5
 
-    @test nextind(v1, 1) === 2
-    @test nextind(v2, 4) === 6
+@test nextind(v1, 1) === 2
+@test nextind(v2, 4) === 6
 
-    @test prevind(v1, 1) === 0
-    @test prevind(v2, 6) === 4
+@test prevind(v1, 1) === 0
+@test prevind(v2, 6) === 4
 
-    @test endof(v1) === 0
-    @test endof(v2) === 4
+@test endof(v1) === 0
+@test endof(v2) === 4
 
-    @test collect(v1) == []
-    @test collect(v2) == collect("café")
+@test collect(v1) == []
+@test collect(v2) == collect("café")
 
-    @test v2[2] === 'a'
-    @test v2[4] === 'é'
-    @test_throws BoundsError v1[1]
-    @test_throws UnicodeError v2[5]
+@test v2[2] === 'a'
+@test v2[4] === 'é'
+@test_throws BoundsError v1[1]
+@test_throws UnicodeError v2[5]
 
-    @test codeunit(v2, 2) === 0x61
-    @test codeunit(v2, 5) === 0xa9
-    @test_throws BoundsError codeunit(v1, 1)
-    @test_throws BoundsError codeunit(v2, 6)
+@test codeunit(v2, 2) === 0x61
+@test codeunit(v2, 5) === 0xa9
+@test_throws BoundsError codeunit(v1, 1)
+@test_throws BoundsError codeunit(v2, 6)
 
-    @test ascii(v1)::String == ""
-    @test_throws ArgumentError ascii(v2)
+@test ascii(v1)::String == ""
+@test_throws ArgumentError ascii(v2)
 
-    @test normalize_string(v1) == ""
-    @test normalize_string(v2) == "café"
-    @test normalize_string(v2, :NFKD) == "café"
+@test normalize_string(v1) == ""
+@test normalize_string(v2) == "café"
+@test normalize_string(v2, :NFKD) == "café"
 
-    @test isempty(collect(graphemes(v1)))
-    @test collect(graphemes(v2)) == collect(graphemes("café"))
+@test isempty(collect(graphemes(v1)))
+@test collect(graphemes(v2)) == collect(graphemes("café"))
 
-    @test isvalid(v1)
-    @test isvalid(v2)
-    @test !isvalid(v1, 1)
-    @test isvalid(v2, 4)
-    @test !isvalid(v2, 5)
+@test isvalid(v1)
+@test isvalid(v2)
+@test !isvalid(v1, 1)
+@test isvalid(v2, 4)
+@test !isvalid(v2, 5)
 
-    @test_throws BoundsError ind2chr(v1, 0)
-    @test ind2chr(v2, 4) === 4
+@test_throws BoundsError ind2chr(v1, 0)
+@test ind2chr(v2, 4) === 4
 
-    @test_throws BoundsError chr2ind(v1, 1)
-    @test chr2ind(v2, 2) === 2
+@test_throws BoundsError chr2ind(v1, 1)
+@test chr2ind(v2, 2) === 2
 
-    @test string(v1) == ""
-    @test string(v2) == "café"
-    @test string(v1, "a") == "a"
-    @test string(v1, "a", v2) == "acafé"
-    @test string(v2, 1) == "café1"
+@test string(v1) == ""
+@test string(v2) == "café"
+@test string(v1, "a") == "a"
+@test string(v1, "a", v2) == "acafé"
+@test string(v2, 1) == "café1"
 
-    @test sprint(print, v1) == ""
-    @test sprint(print, v2) == "café"
+@test sprint(print, v1) == ""
+@test sprint(print, v2) == "café"
 
-    @test repr(v1) == "\"\""
-    @test repr(v2) == "\"café\""
+@test repr(v1) == "\"\""
+@test repr(v2) == "\"café\""
 
-    @test "a" * v1 == "a"
-    @test "a" * v1 * "b" == "ab"
-    @test "a" * v1 * v2 == "acafé"
+@test "a" * v1 == "a"
+@test "a" * v1 * "b" == "ab"
+@test "a" * v1 * v2 == "acafé"
 
-    @test v1^1 == ""
-    @test v2^1 == "café"
-    @test v1^2 == ""
-    @test v2^2 == "cafécafé"
+@test v1^1 == ""
+@test v2^1 == "café"
+@test v1^2 == ""
+@test v2^2 == "cafécafé"
 
-    @test repeat(v1, 10) == ""
-    @test repeat(v2, 2) == "cafécafé"
+@test repeat(v1, 10) == ""
+@test repeat(v2, 2) == "cafécafé"
 
-    @test !ismatch(r"fé", v1)
-    @test ismatch(r"fé", v2)
+@test !ismatch(r"fé", v1)
+@test ismatch(r"fé", v2)
 
-    @test isempty(collect(eachmatch(r"fé", v1)))
-    @test first(eachmatch(r"fé", v2)).offset == 3
+@test isempty(collect(eachmatch(r"fé", v1)))
+@test first(eachmatch(r"fé", v2)).offset == 3
 
-    @test match(r"fé", v1) === nothing
-    @test match(r"fé", v2).offset === 3
-    @test match(r"fé", v2, 2).offset === 3
-    @test match(r"fé", v2, 2, UInt32(0)).offset === 3
+@test match(r"fé", v1) === nothing
+@test match(r"fé", v2).offset === 3
+@test match(r"fé", v2, 2).offset === 3
+@test match(r"fé", v2, 2, UInt32(0)).offset === 3
 
-    @test matchall(r"fé", v1) == []
-    @test matchall(r"fé", v2) == ["fé"]
-    @test matchall(r"fé", v2, true) == ["fé"]
+@test matchall(r"fé", v1) == []
+@test matchall(r"fé", v2) == ["fé"]
+@test matchall(r"fé", v2, true) == ["fé"]
 
-    @test lpad(v1, 1) == " "
-    @test lpad(v2, 1) == "café"
-    @test lpad(v2, 5) == " café"
+@test lpad(v1, 1) == " "
+@test lpad(v2, 1) == "café"
+@test lpad(v2, 5) == " café"
 
-    @test rpad(v1, 1) == " "
-    @test rpad(v2, 1) == "café"
-    @test rpad(v2, 5) == "café "
+@test rpad(v1, 1) == " "
+@test rpad(v2, 1) == "café"
+@test rpad(v2, 5) == "café "
 
-    @test search(v1, "") === 1:0
-    @test search(v2, "a") === 2:2
-    @test search(v2, 'a') === 2
-    @test search(v2, 'a', 3) === 0
+@test search(v1, "") === 1:0
+@test search(v2, "a") === 2:2
+@test search(v2, 'a') === 2
+@test search(v2, 'a', 3) === 0
 
-    @test searchindex(v1, "") === 1
-    @test searchindex(v2, "a") === 2
-    @test searchindex(v2, 'a') === 2
-    @test searchindex(v2, 'a', 3) === 0
+@test searchindex(v1, "") === 1
+@test searchindex(v2, "a") === 2
+@test searchindex(v2, 'a') === 2
+@test searchindex(v2, 'a', 3) === 0
 
-    @test rsearch(v1, "a") === 0:-1
-    @test rsearch(v2, "a") === 2:2
-    @test rsearch(v2, 'a') === 2
-    @test rsearch(v2, 'a', 1) === 0
+@test rsearch(v1, "a") === 0:-1
+@test rsearch(v2, "a") === 2:2
+@test rsearch(v2, 'a') === 2
+@test rsearch(v2, 'a', 1) === 0
 
-    @test rsearchindex(v1, "a") === 0
-    @test rsearchindex(v2, "a") === 2
-    # Methods not defined even for String
-    #@test rsearchindex(v2, 'a') === 2
-    #@test rsearchindex(v2, 'a', 1) === 0
+@test rsearchindex(v1, "a") === 0
+@test rsearchindex(v2, "a") === 2
+# Methods not defined even for String
+#@test rsearchindex(v2, 'a') === 2
+#@test rsearchindex(v2, 'a', 1) === 0
 
-    @test !contains(v1, "a")
-    @test contains(v1, "")
-    @test contains(v2, "fé")
+@test !contains(v1, "a")
+@test contains(v1, "")
+@test contains(v2, "fé")
 
-    @test startswith(v1, "")
-    @test !startswith(v1, "a")
-    @test startswith(v2, "caf")
+@test startswith(v1, "")
+@test !startswith(v1, "a")
+@test startswith(v2, "caf")
 
-    @test endswith(v1, "")
-    @test !endswith(v1, "a")
-    @test endswith(v2, "fé")
+@test endswith(v1, "")
+@test !endswith(v1, "a")
+@test endswith(v2, "fé")
 
-    @test reverse(v1) == ""
-    @test reverse(v2) == "éfac"
+@test reverse(v1) == ""
+@test reverse(v2) == "éfac"
 
-    @test replace(v1, "a", "b") == ""
-    @test replace(v2, 'a', 'b') == "cbfé"
-    @test replace(v2, "ca", "b", 1) == "bfé"
+@test replace(v1, "a", "b") == ""
+@test replace(v2, 'a', 'b') == "cbfé"
+@test replace(v2, "ca", "b", 1) == "bfé"
 
-    @test isempty(split(v1))
-    @test split(v1, "a") == [""]
-    @test split(v2) == ["café"]
-    @test split(v2, "f") == ["ca", "é"]
+@test isempty(split(v1))
+@test split(v1, "a") == [""]
+@test split(v2) == ["café"]
+@test split(v2, "f") == ["ca", "é"]
 
-    @test rsplit(v1, "a") == [""]
-    @test rsplit(v2, "f") == ["ca", "é"]
+@test rsplit(v1, "a") == [""]
+@test rsplit(v2, "f") == ["ca", "é"]
 
-    @test strip(v1) == ""
-    @test strip(v2) == v2
-    @test strip(v2, 'é') == "caf"
+@test strip(v1) == ""
+@test strip(v2) == v2
+@test strip(v2, 'é') == "caf"
 
-    @test lstrip(v1) == ""
-    @test lstrip(v2) == v2
-    @test lstrip(v2, 'é') == "café"
+@test lstrip(v1) == ""
+@test lstrip(v2) == v2
+@test lstrip(v2, 'é') == "café"
 
-    @test rstrip(v1) == ""
-    @test rstrip(v2) == v2
-    @test rstrip(v2, 'é') == "caf"
+@test rstrip(v1) == ""
+@test rstrip(v2) == v2
+@test rstrip(v2, 'é') == "caf"
 
-    @test uppercase(v1) == ""
-    @test uppercase(v2) == "CAFÉ"
+@test uppercase(v1) == ""
+@test uppercase(v2) == "CAFÉ"
 
-    @test lowercase(v1) == ""
-    @test lowercase(v2) == "café"
+@test lowercase(v1) == ""
+@test lowercase(v2) == "café"
 
-    @test titlecase(v1) == ""
-    @test titlecase(v2) == "Café"
+@test titlecase(v1) == ""
+@test titlecase(v2) == "Café"
 
-    @test ucfirst(v1) == ""
-    @test ucfirst(v2) == "Café"
+@test ucfirst(v1) == ""
+@test ucfirst(v2) == "Café"
 
-    @test lcfirst(v1) == ""
-    @test lcfirst(v2) == "café"
+@test lcfirst(v1) == ""
+@test lcfirst(v2) == "café"
 
-    @test join([v1, "a"]) == "a"
-    @test join([v1, "a"], v2) == "caféa"
+@test join([v1, "a"]) == "a"
+@test join([v1, "a"], v2) == "caféa"
 
-    @test chop(v1) == ""
-    @test chop(v2) == "caf"
+@test chop(v1) == ""
+@test chop(v2) == "caf"
 
-    @test chomp(v1) == ""
-    @test chomp(v2) == "café"
+@test chomp(v1) == ""
+@test chomp(v2) == "café"
 
-    @test strwidth(v1) === 0
-    @test strwidth(v2) === 4
+@test strwidth(v1) === 0
+@test strwidth(v2) === 4
 
-    @test isascii(v1)
-    @test !isascii(v2)
+@test isascii(v1)
+@test !isascii(v2)
 
-    @test escape_string(v1) == ""
-    @test escape_string(v2) == "café"
+@test escape_string(v1) == ""
+@test escape_string(v2) == "café"
 
-    @test collect(v1) == Char[]
-    @test collect(v2) == Char['c', 'a', 'f', 'é']
+@test collect(v1) == Char[]
+@test collect(v2) == Char['c', 'a', 'f', 'é']
+
 end

--- a/test/09_hash.jl
+++ b/test/09_hash.jl
@@ -1,72 +1,72 @@
 module TestHash
-    using Base.Test
-    using CategoricalArrays
+using Base.Test
+using CategoricalArrays
 
-    pool1 = CategoricalPool([1, 2, 3])
-    pool2 = CategoricalPool([2.0, 1.0, 3.0])
+pool1 = CategoricalPool([1, 2, 3])
+pool2 = CategoricalPool([2.0, 1.0, 3.0])
 
-    @test (hash(pool1) == hash(pool1)) === true
-    @test (hash(pool1) == hash(pool2)) === false
-    @test (hash(pool2) == hash(pool2)) === true
+@test (hash(pool1) == hash(pool1)) === true
+@test (hash(pool1) == hash(pool2)) === false
+@test (hash(pool2) == hash(pool2)) === true
 
-    opool1 = CategoricalPool([1, 2, 3], true)
-    opool2 = CategoricalPool([2.0, 1.0, 3.0], true)
+opool1 = CategoricalPool([1, 2, 3], true)
+opool2 = CategoricalPool([2.0, 1.0, 3.0], true)
 
-    @test (hash(opool1) == hash(opool1)) === true
-    @test (hash(opool1) == hash(opool2)) === false
-    @test (hash(opool2) == hash(opool2)) === true
+@test (hash(opool1) == hash(opool1)) === true
+@test (hash(opool1) == hash(opool2)) === false
+@test (hash(opool2) == hash(opool2)) === true
 
-    nv1a = CategoricalArrays.catvalue(1, pool1)
-    nv2a = CategoricalArrays.catvalue(1, pool2)
-    nv1b = CategoricalArrays.catvalue(2, pool1)
-    nv2b = CategoricalArrays.catvalue(2, pool2)
+nv1a = CategoricalArrays.catvalue(1, pool1)
+nv2a = CategoricalArrays.catvalue(1, pool2)
+nv1b = CategoricalArrays.catvalue(2, pool1)
+nv2b = CategoricalArrays.catvalue(2, pool2)
 
-    @test (hash(nv1a) == hash(nv1a)) === true
-    @test (hash(nv1a) == hash(nv2a)) === false
-    @test (hash(nv1a) == hash(nv1b)) === false
-    @test (hash(nv1a) == hash(nv2b)) === true
+@test (hash(nv1a) == hash(nv1a)) === true
+@test (hash(nv1a) == hash(nv2a)) === false
+@test (hash(nv1a) == hash(nv1b)) === false
+@test (hash(nv1a) == hash(nv2b)) === true
 
-    @test (hash(nv1b) == hash(nv1a)) === false
-    @test (hash(nv1b) == hash(nv2a)) === true
-    @test (hash(nv1b) == hash(nv1b)) === true
-    @test (hash(nv1b) == hash(nv2b)) === false
+@test (hash(nv1b) == hash(nv1a)) === false
+@test (hash(nv1b) == hash(nv2a)) === true
+@test (hash(nv1b) == hash(nv1b)) === true
+@test (hash(nv1b) == hash(nv2b)) === false
 
-    @test (hash(nv2a) == hash(nv1a)) === false
-    @test (hash(nv2a) == hash(nv2a)) === true
-    @test (hash(nv2a) == hash(nv1b)) === true
-    @test (hash(nv2a) == hash(nv2b)) === false
+@test (hash(nv2a) == hash(nv1a)) === false
+@test (hash(nv2a) == hash(nv2a)) === true
+@test (hash(nv2a) == hash(nv1b)) === true
+@test (hash(nv2a) == hash(nv2b)) === false
 
-    @test (hash(nv2b) == hash(nv1a)) === true
-    @test (hash(nv2b) == hash(nv2a)) === false
-    @test (hash(nv2b) == hash(nv1b)) === false
-    @test (hash(nv2b) == hash(nv2b)) === true
+@test (hash(nv2b) == hash(nv1a)) === true
+@test (hash(nv2b) == hash(nv2a)) === false
+@test (hash(nv2b) == hash(nv1b)) === false
+@test (hash(nv2b) == hash(nv2b)) === true
 
-    ov1a = CategoricalArrays.catvalue(1, opool1)
-    ov2a = CategoricalArrays.catvalue(1, opool2)
-    ov1b = CategoricalArrays.catvalue(2, opool1)
-    ov2b = CategoricalArrays.catvalue(2, opool2)
+ov1a = CategoricalArrays.catvalue(1, opool1)
+ov2a = CategoricalArrays.catvalue(1, opool2)
+ov1b = CategoricalArrays.catvalue(2, opool1)
+ov2b = CategoricalArrays.catvalue(2, opool2)
 
-    @test (hash(ov1a) == hash(ov1a)) === true
-    @test (hash(ov1a) == hash(ov2a)) === false
-    @test (hash(ov1a) == hash(ov1b)) === false
-    @test (hash(ov1a) == hash(ov2b)) === true
+@test (hash(ov1a) == hash(ov1a)) === true
+@test (hash(ov1a) == hash(ov2a)) === false
+@test (hash(ov1a) == hash(ov1b)) === false
+@test (hash(ov1a) == hash(ov2b)) === true
 
-    @test (hash(ov1b) == hash(ov1a)) === false
-    @test (hash(ov1b) == hash(ov2a)) === true
-    @test (hash(ov1b) == hash(ov1b)) === true
-    @test (hash(ov1b) == hash(ov2b)) === false
+@test (hash(ov1b) == hash(ov1a)) === false
+@test (hash(ov1b) == hash(ov2a)) === true
+@test (hash(ov1b) == hash(ov1b)) === true
+@test (hash(ov1b) == hash(ov2b)) === false
 
-    @test (hash(ov2a) == hash(ov1a)) === false
-    @test (hash(ov2a) == hash(ov2a)) === true
-    @test (hash(ov2a) == hash(ov1b)) === true
-    @test (hash(ov2a) == hash(ov2b)) === false
+@test (hash(ov2a) == hash(ov1a)) === false
+@test (hash(ov2a) == hash(ov2a)) === true
+@test (hash(ov2a) == hash(ov1b)) === true
+@test (hash(ov2a) == hash(ov2b)) === false
 
-    @test (hash(ov2b) == hash(ov1a)) === true
-    @test (hash(ov2b) == hash(ov2a)) === false
-    @test (hash(ov2b) == hash(ov1b)) === false
-    @test (hash(ov2b) == hash(ov2b)) === true
+@test (hash(ov2b) == hash(ov1a)) === true
+@test (hash(ov2b) == hash(ov2a)) === false
+@test (hash(ov2b) == hash(ov1b)) === false
+@test (hash(ov2b) == hash(ov2b)) === true
 
-    # Check that ordered and non-ordered values hash equal
+@testset "ordered and non-ordered values hash equal" begin
     @test (hash(ov1a) == hash(nv1a)) === true
     @test (hash(ov1a) == hash(nv2a)) === false
     @test (hash(ov1a) == hash(nv1b)) === false
@@ -86,4 +86,6 @@ module TestHash
     @test (hash(ov2b) == hash(nv2a)) === false
     @test (hash(ov2b) == hash(nv1b)) === false
     @test (hash(ov2b) == hash(nv2b)) === true
+end
+
 end

--- a/test/09_hash.jl
+++ b/test/09_hash.jl
@@ -2,71 +2,72 @@ module TestHash
 using Base.Test
 using CategoricalArrays
 
-pool1 = CategoricalPool([1, 2, 3])
-pool2 = CategoricalPool([2.0, 1.0, 3.0])
+@testset "hash() for CategoricalPool{Int} and CategoricalPool{Float64} and its values" begin
+    pool1 = CategoricalPool([1, 2, 3])
+    pool2 = CategoricalPool([2.0, 1.0, 3.0])
 
-@test (hash(pool1) == hash(pool1)) === true
-@test (hash(pool1) == hash(pool2)) === false
-@test (hash(pool2) == hash(pool2)) === true
+    @test (hash(pool1) == hash(pool1)) === true
+    @test (hash(pool1) == hash(pool2)) === false
+    @test (hash(pool2) == hash(pool2)) === true
 
-opool1 = CategoricalPool([1, 2, 3], true)
-opool2 = CategoricalPool([2.0, 1.0, 3.0], true)
+    opool1 = CategoricalPool([1, 2, 3], true)
+    opool2 = CategoricalPool([2.0, 1.0, 3.0], true)
 
-@test (hash(opool1) == hash(opool1)) === true
-@test (hash(opool1) == hash(opool2)) === false
-@test (hash(opool2) == hash(opool2)) === true
+    @test (hash(opool1) == hash(opool1)) === true
+    @test (hash(opool1) == hash(opool2)) === false
+    @test (hash(opool2) == hash(opool2)) === true
 
-nv1a = CategoricalArrays.catvalue(1, pool1)
-nv2a = CategoricalArrays.catvalue(1, pool2)
-nv1b = CategoricalArrays.catvalue(2, pool1)
-nv2b = CategoricalArrays.catvalue(2, pool2)
+    nv1a = CategoricalArrays.catvalue(1, pool1)
+    nv2a = CategoricalArrays.catvalue(1, pool2)
+    nv1b = CategoricalArrays.catvalue(2, pool1)
+    nv2b = CategoricalArrays.catvalue(2, pool2)
 
-@test (hash(nv1a) == hash(nv1a)) === true
-@test (hash(nv1a) == hash(nv2a)) === false
-@test (hash(nv1a) == hash(nv1b)) === false
-@test (hash(nv1a) == hash(nv2b)) === true
+    @test (hash(nv1a) == hash(nv1a)) === true
+    @test (hash(nv1a) == hash(nv2a)) === false
+    @test (hash(nv1a) == hash(nv1b)) === false
+    @test (hash(nv1a) == hash(nv2b)) === true
 
-@test (hash(nv1b) == hash(nv1a)) === false
-@test (hash(nv1b) == hash(nv2a)) === true
-@test (hash(nv1b) == hash(nv1b)) === true
-@test (hash(nv1b) == hash(nv2b)) === false
+    @test (hash(nv1b) == hash(nv1a)) === false
+    @test (hash(nv1b) == hash(nv2a)) === true
+    @test (hash(nv1b) == hash(nv1b)) === true
+    @test (hash(nv1b) == hash(nv2b)) === false
 
-@test (hash(nv2a) == hash(nv1a)) === false
-@test (hash(nv2a) == hash(nv2a)) === true
-@test (hash(nv2a) == hash(nv1b)) === true
-@test (hash(nv2a) == hash(nv2b)) === false
+    @test (hash(nv2a) == hash(nv1a)) === false
+    @test (hash(nv2a) == hash(nv2a)) === true
+    @test (hash(nv2a) == hash(nv1b)) === true
+    @test (hash(nv2a) == hash(nv2b)) === false
 
-@test (hash(nv2b) == hash(nv1a)) === true
-@test (hash(nv2b) == hash(nv2a)) === false
-@test (hash(nv2b) == hash(nv1b)) === false
-@test (hash(nv2b) == hash(nv2b)) === true
+    @test (hash(nv2b) == hash(nv1a)) === true
+    @test (hash(nv2b) == hash(nv2a)) === false
+    @test (hash(nv2b) == hash(nv1b)) === false
+    @test (hash(nv2b) == hash(nv2b)) === true
 
-ov1a = CategoricalArrays.catvalue(1, opool1)
-ov2a = CategoricalArrays.catvalue(1, opool2)
-ov1b = CategoricalArrays.catvalue(2, opool1)
-ov2b = CategoricalArrays.catvalue(2, opool2)
+    ov1a = CategoricalArrays.catvalue(1, opool1)
+    ov2a = CategoricalArrays.catvalue(1, opool2)
+    ov1b = CategoricalArrays.catvalue(2, opool1)
+    ov2b = CategoricalArrays.catvalue(2, opool2)
 
-@test (hash(ov1a) == hash(ov1a)) === true
-@test (hash(ov1a) == hash(ov2a)) === false
-@test (hash(ov1a) == hash(ov1b)) === false
-@test (hash(ov1a) == hash(ov2b)) === true
+    @test (hash(ov1a) == hash(ov1a)) === true
+    @test (hash(ov1a) == hash(ov2a)) === false
+    @test (hash(ov1a) == hash(ov1b)) === false
+    @test (hash(ov1a) == hash(ov2b)) === true
 
-@test (hash(ov1b) == hash(ov1a)) === false
-@test (hash(ov1b) == hash(ov2a)) === true
-@test (hash(ov1b) == hash(ov1b)) === true
-@test (hash(ov1b) == hash(ov2b)) === false
+    @test (hash(ov1b) == hash(ov1a)) === false
+    @test (hash(ov1b) == hash(ov2a)) === true
+    @test (hash(ov1b) == hash(ov1b)) === true
+    @test (hash(ov1b) == hash(ov2b)) === false
 
-@test (hash(ov2a) == hash(ov1a)) === false
-@test (hash(ov2a) == hash(ov2a)) === true
-@test (hash(ov2a) == hash(ov1b)) === true
-@test (hash(ov2a) == hash(ov2b)) === false
+    @test (hash(ov2a) == hash(ov1a)) === false
+    @test (hash(ov2a) == hash(ov2a)) === true
+    @test (hash(ov2a) == hash(ov1b)) === true
+    @test (hash(ov2a) == hash(ov2b)) === false
 
-@test (hash(ov2b) == hash(ov1a)) === true
-@test (hash(ov2b) == hash(ov2a)) === false
-@test (hash(ov2b) == hash(ov1b)) === false
-@test (hash(ov2b) == hash(ov2b)) === true
+    @test (hash(ov2b) == hash(ov1a)) === true
+    @test (hash(ov2b) == hash(ov2a)) === false
+    @test (hash(ov2b) == hash(ov1b)) === false
+    @test (hash(ov2b) == hash(ov2b)) === true
 
-@testset "ordered and non-ordered values hash equal" begin
+    @testset "ordered and non-ordered values hash equal" begin
     @test (hash(ov1a) == hash(nv1a)) === true
     @test (hash(ov1a) == hash(nv2a)) === false
     @test (hash(ov1a) == hash(nv1b)) === false
@@ -86,6 +87,7 @@ ov2b = CategoricalArrays.catvalue(2, opool2)
     @test (hash(ov2b) == hash(nv2a)) === false
     @test (hash(ov2b) == hash(nv1b)) === false
     @test (hash(ov2b) == hash(nv2b)) === true
+    end
 end
 
 end

--- a/test/10_isless.jl
+++ b/test/10_isless.jl
@@ -60,16 +60,16 @@ v3 = CategoricalArrays.catvalue(3, pool)
     @test isless(v3, v3) === false
 
     @testset "comparison with null" begin
-        @test isless(v1, null)
-        @test !isless(null, v1)
-        @test isnull(v1 < null)
-        @test isnull(v1 <= null)
-        @test isnull(v1 > null)
-        @test isnull(v1 >= null)
-        @test isnull(null < v1)
-        @test isnull(null <= v1)
-        @test isnull(null > v1)
-        @test isnull(null >= v1)
+    @test isless(v1, null)
+    @test !isless(null, v1)
+    @test isnull(v1 < null)
+    @test isnull(v1 <= null)
+    @test isnull(v1 > null)
+    @test isnull(v1 >= null)
+    @test isnull(null < v1)
+    @test isnull(null <= v1)
+    @test isnull(null > v1)
+    @test isnull(null >= v1)
     end
 end
 

--- a/test/10_isless.jl
+++ b/test/10_isless.jl
@@ -248,8 +248,8 @@ end
     @test isless(v3, v3) === false
 end
 
-@testset "ordering comparisons" begin
-    # check that ordering comparisons also fail for CategoricalValue{String}
+@testset "comparisons for CategoricalString" begin
+    # check that ordering comparisons also fail for CategoricalString
     # (since the AbstractString fallback could break this)
     pool = CategoricalPool(["a", "b", "c"])
 

--- a/test/10_isless.jl
+++ b/test/10_isless.jl
@@ -1,13 +1,14 @@
 module TestIsLess
-    using Base.Test
-    using CategoricalArrays
+using Base.Test
+using CategoricalArrays
 
-    pool = CategoricalPool([1, 2, 3])
+pool = CategoricalPool([1, 2, 3])
 
-    v1 = CategoricalArrays.catvalue(1, pool)
-    v2 = CategoricalArrays.catvalue(2, pool)
-    v3 = CategoricalArrays.catvalue(3, pool)
+v1 = CategoricalArrays.catvalue(1, pool)
+v2 = CategoricalArrays.catvalue(2, pool)
+v3 = CategoricalArrays.catvalue(3, pool)
 
+@testset "values from unordered CategoricalPool" begin
     @test_throws ArgumentError v1 < v1
     @test_throws ArgumentError v1 < v2
     @test_throws ArgumentError v1 < v3
@@ -58,18 +59,21 @@ module TestIsLess
     @test isless(v3, v2) === false
     @test isless(v3, v3) === false
 
-    # Check comparison with null
-    @test isless(v1, null)
-    @test !isless(null, v1)
-    @test isnull(v1 < null)
-    @test isnull(v1 <= null)
-    @test isnull(v1 > null)
-    @test isnull(v1 >= null)
-    @test isnull(null < v1)
-    @test isnull(null <= v1)
-    @test isnull(null > v1)
-    @test isnull(null >= v1)
+    @testset "comparison with null" begin
+        @test isless(v1, null)
+        @test !isless(null, v1)
+        @test isnull(v1 < null)
+        @test isnull(v1 <= null)
+        @test isnull(v1 > null)
+        @test isnull(v1 >= null)
+        @test isnull(null < v1)
+        @test isnull(null <= v1)
+        @test isnull(null > v1)
+        @test isnull(null >= v1)
+    end
+end
 
+@testset "values from ordered CategoricalPool" begin
     @test ordered!(pool, true) === pool
     @test isordered(pool) === true
 
@@ -134,7 +138,9 @@ module TestIsLess
     @test isnull(null <= v1)
     @test isnull(null > v1)
     @test isnull(null >= v1)
+end
 
+@testset "comparisons with reordered levels" begin
     @test CategoricalArrays.levels!(pool, [2, 3, 1]) === pool
     @test levels(pool) == [2, 3, 1]
 
@@ -240,9 +246,10 @@ module TestIsLess
     @test isless(v3, v1) === true
     @test isless(v3, v2) === false
     @test isless(v3, v3) === false
+end
 
-
-    # Test that ordering comparisons also fail for CategoricalValue{String}
+@testset "ordering comparisons" begin
+    # check that ordering comparisons also fail for CategoricalValue{String}
     # (since the AbstractString fallback could break this)
     pool = CategoricalPool(["a", "b", "c"])
 
@@ -299,8 +306,9 @@ module TestIsLess
     @test isless(v3, v1) === false
     @test isless(v3, v2) === false
     @test isless(v3, v3) === false
+end
 
-    # Test that ordering comparisons between pools fail
+@testset "ordering comparisons between pools fail" begin
     ordered!(pool, true)
     pool2 = CategoricalPool([1, 2, 3])
     ordered!(pool2, true)
@@ -312,4 +320,6 @@ module TestIsLess
     @test_throws ArgumentError v > v1
     @test_throws ArgumentError v >= v1
     @test_throws ArgumentError isless(v, v1)
+end
+
 end

--- a/test/10_isless.jl
+++ b/test/10_isless.jl
@@ -60,16 +60,16 @@ v3 = CategoricalArrays.catvalue(3, pool)
     @test isless(v3, v3) === false
 
     @testset "comparison with null" begin
-    @test isless(v1, null)
-    @test !isless(null, v1)
-    @test isnull(v1 < null)
-    @test isnull(v1 <= null)
-    @test isnull(v1 > null)
-    @test isnull(v1 >= null)
-    @test isnull(null < v1)
-    @test isnull(null <= v1)
-    @test isnull(null > v1)
-    @test isnull(null >= v1)
+        @test isless(v1, null)
+        @test !isless(null, v1)
+        @test isnull(v1 < null)
+        @test isnull(v1 <= null)
+        @test isnull(v1 > null)
+        @test isnull(v1 >= null)
+        @test isnull(null < v1)
+        @test isnull(null <= v1)
+        @test isnull(null > v1)
+        @test isnull(null >= v1)
     end
 end
 
@@ -127,17 +127,18 @@ end
     @test isless(v3, v2) === false
     @test isless(v3, v3) === false
 
-    # Check comparison with null
-    @test isless(v1, null)
-    @test !isless(null, v1)
-    @test isnull(v1 < null)
-    @test isnull(v1 <= null)
-    @test isnull(v1 > null)
-    @test isnull(v1 >= null)
-    @test isnull(null < v1)
-    @test isnull(null <= v1)
-    @test isnull(null > v1)
-    @test isnull(null >= v1)
+    @testset "comparison with null" begin
+        @test isless(v1, null)
+        @test !isless(null, v1)
+        @test isnull(v1 < null)
+        @test isnull(v1 <= null)
+        @test isnull(v1 > null)
+        @test isnull(v1 >= null)
+        @test isnull(null < v1)
+        @test isnull(null <= v1)
+        @test isnull(null > v1)
+        @test isnull(null >= v1)
+    end
 end
 
 @testset "comparisons with reordered levels" begin

--- a/test/11_array.jl
+++ b/test/11_array.jl
@@ -1,635 +1,639 @@
 module TestArray
-
 using Base.Test
 using CategoricalArrays
 using CategoricalArrays: DefaultRefType, catvaluetype, leveltype
 
-for ordered in (false, true)
-    for R in (CategoricalArrays.DefaultRefType, UInt8, UInt, Int8, Int)
-        # Vector
-        a = ["b", "a", "b"]
-        x = CategoricalVector{String, R}(a, ordered=ordered)
+@testset "conversion ordered=$ordered reftype=$R" for ordered in (false, true),
+    R in (CategoricalArrays.DefaultRefType, UInt8, UInt, Int8, Int)
+    # Vector
+    a = ["b", "a", "b"]
+    x = CategoricalVector{String, R}(a, ordered=ordered)
 
-        @test x == a
-        @test leveltype(typeof(x)) === String
-        @test leveltype(x) === String
-        @test catvaluetype(typeof(x)) === CategoricalArrays.CategoricalString{R}
-        @test catvaluetype(x) === CategoricalArrays.CategoricalString{R}
+    @test x == a
+    @test leveltype(typeof(x)) === String
+    @test leveltype(x) === String
+    @test catvaluetype(typeof(x)) === CategoricalArrays.CategoricalString{R}
+    @test catvaluetype(x) === CategoricalArrays.CategoricalString{R}
+    @test isordered(x) === ordered
+    @test levels(x) == sort(unique(a))
+    @test size(x) === (3,)
+    @test length(x) === 3
+
+    @test convert(CategoricalArray, x) === x
+    @test convert(CategoricalArray{String}, x) === x
+    @test convert(CategoricalArray{String, 1}, x) === x
+    @test convert(CategoricalArray{String, 1, R}, x) === x
+    @test convert(CategoricalArray{String, 1, DefaultRefType}, x) == x
+    @test convert(CategoricalArray{String, 1, UInt8}, x) == x
+
+    @test convert(CategoricalVector, x) === x
+    @test convert(CategoricalVector{String}, x) === x
+    @test convert(CategoricalVector{String, R}, x) === x
+    @test convert(CategoricalVector{String, DefaultRefType}, x) == x
+    @test convert(CategoricalVector{String, UInt8}, x) == x
+
+    @test convert(CategoricalArray, a) == x
+    @test convert(CategoricalArray{String}, a) == x
+    @test convert(CategoricalArray{String, 1}, a) == x
+    @test convert(CategoricalArray{String, 1, R}, a) == x
+    @test convert(CategoricalArray{String, 1, DefaultRefType}, a) == x
+    @test convert(CategoricalArray{String, 1, UInt8}, a) == x
+
+    @test convert(CategoricalVector, a) == x
+    @test convert(CategoricalVector{String}, a) == x
+    @test convert(CategoricalVector{String, R}, a) == x
+    @test convert(CategoricalVector{String, DefaultRefType}, a) == x
+    @test convert(CategoricalVector{String, UInt8}, a) == x
+
+    @test CategoricalArray{String}(a, ordered=ordered) == x
+    @test CategoricalArray{String, 1}(a, ordered=ordered) == x
+    @test CategoricalArray{String, 1, R}(a, ordered=ordered) == x
+    @test CategoricalArray{String, 1, DefaultRefType}(a, ordered=ordered) == x
+    @test CategoricalArray{String, 1, UInt8}(a, ordered=ordered) == x
+
+    @test CategoricalVector(a, ordered=ordered) == x
+    @test CategoricalVector{String}(a, ordered=ordered) == x
+    @test CategoricalVector{String, R}(a, ordered=ordered) == x
+    @test CategoricalVector{String, DefaultRefType}(a, ordered=ordered) == x
+    @test CategoricalVector{String, UInt8}(a, ordered=ordered) == x
+
+    @testset "categorical($(typeof(y)), compress=$comp) R1=$R1 R2=$R2" for (y, R1, R2, comp) in
+        ((a, DefaultRefType, UInt8, true),
+         (a, DefaultRefType, DefaultRefType, false),
+         (x, R, UInt8, true),
+         (x, R, R, false))
+
+        x2 = categorical(y, ordered=ordered)
+        @test x2 == x
+        @test isa(x2, CategoricalVector{String, R1})
+        @test isordered(x2) === ordered
+        @test leveltype(x2) === String
+        @test catvaluetype(x2) === CategoricalArrays.CategoricalString{R1}
+
+        x2 = categorical(y, comp, ordered=ordered)
+        @test x2 == x
+        @test isa(x2, CategoricalVector{String, R2})
+        @test isordered(x2) === ordered
+        @test leveltype(x2) === String
+        @test catvaluetype(x2) === CategoricalArrays.CategoricalString{R2}
+    end
+
+    x2 = compress(x)
+    @test x2 == x
+    @test isa(x2, CategoricalVector{String, UInt8})
+    @test isordered(x2) === isordered(x)
+    @test levels(x2) == levels(x)
+
+    x2 = copy(x)
+    @test x2 == x
+    @test typeof(x2) === typeof(x)
+    @test isordered(x2) === isordered(x)
+    @test levels(x2) == levels(x)
+
+    if !isordered(x)
+        @test ordered!(x, true) === x
+        @test isordered(x) === true
+    end
+    @test x[1] > x[2]
+    @test x[3] > x[2]
+
+    @test ordered!(x, false) === x
+    @test isordered(x) === false
+    @test_throws Exception x[1] > x[2]
+    @test_throws Exception x[3] > x[2]
+
+    @test x[1] === x.pool.valindex[1]
+    @test x[2] === x.pool.valindex[2]
+    @test x[3] === x.pool.valindex[1]
+    @test_throws BoundsError x[4]
+
+    x2 = x[:]
+    @test typeof(x2) === typeof(x)
+    @test x2 == x
+    @test x2 !== x
+    @test levels(x2) == levels(x)
+    @test levels(x2) !== levels(x)
+    @test isordered(x2) == isordered(x)
+
+    x2 = x[1:2]
+    @test typeof(x2) === typeof(x)
+    @test x2 == ["b", "a"]
+    @test levels(x2) == levels(x)
+    @test levels(x2) !== levels(x)
+    @test isordered(x2) == isordered(x)
+
+    x2 = x[1:1]
+    @test typeof(x2) === typeof(x)
+    @test x2 == ["b"]
+    @test levels(x2) == levels(x)
+    @test levels(x2) !== levels(x)
+    @test isordered(x2) == isordered(x)
+
+    x2 = x[2:1]
+    @test typeof(x2) === typeof(x)
+    @test isempty(x2)
+    @test levels(x2) == levels(x)
+    @test levels(x2) !== levels(x)
+    @test isordered(x2) == isordered(x)
+
+    x[1] = x[2]
+    @test x[1] === x.pool.valindex[2]
+    @test x[2] === x.pool.valindex[2]
+    @test x[3] === x.pool.valindex[1]
+
+    x[3] = "c"
+    @test x[1] === x.pool.valindex[2]
+    @test x[2] === x.pool.valindex[2]
+    @test x[3] === x.pool.valindex[3]
+    @test levels(x) == ["a", "b", "c"]
+
+    x[2:3] = "b"
+    @test x[1] === x.pool.valindex[2]
+    @test x[2] === x.pool.valindex[1]
+    @test x[3] === x.pool.valindex[1]
+    @test levels(x) == ["a", "b", "c"]
+
+    @test droplevels!(x) === x
+    @test levels(x) == ["a", "b"]
+    @test x[1] === x.pool.valindex[1]
+    @test x[2] === x.pool.valindex[2]
+    @test x[3] === x.pool.valindex[2]
+    @test levels(x) == ["a", "b"]
+
+    @test levels!(x, ["b", "a"]) === x
+    @test levels(x) == ["b", "a"]
+    @test x[1] === x.pool.valindex[1]
+    @test x[2] === x.pool.valindex[2]
+    @test x[3] === x.pool.valindex[2]
+    @test levels(x) == ["b", "a"]
+
+    @test_throws ArgumentError levels!(x, ["a"])
+    @test_throws ArgumentError levels!(x, ["e", "b"])
+    @test_throws ArgumentError levels!(x, ["e", "a", "b", "a"])
+
+    @test levels!(x, ["e", "a", "b"]) === x
+    @test levels(x) == ["e", "a", "b"]
+    @test x[1] === x.pool.valindex[1]
+    @test x[2] === x.pool.valindex[2]
+    @test x[3] === x.pool.valindex[2]
+    @test levels(x) == ["e", "a", "b"]
+
+    x[1] = "c"
+    @test x[1] === x.pool.valindex[4]
+    @test x[2] === x.pool.valindex[2]
+    @test x[3] === x.pool.valindex[2]
+    @test levels(x) == ["e", "a", "b", "c"]
+
+    push!(x, "a")
+    @test length(x) == 4
+    @test x[end] == "a"
+    @test levels(x) == ["e", "a", "b", "c"]
+
+    push!(x, "zz")
+    @test length(x) == 5
+    @test x[end] == "zz"
+    @test levels(x) == ["e", "a", "b", "c", "zz"]
+
+    push!(x, x[1])
+    @test length(x) == 6
+    @test x[1] == x[end]
+    @test levels(x) == ["e", "a", "b", "c", "zz"]
+
+    append!(x, x)
+    @test length(x) == 12
+    @test x == ["c", "b", "b", "a", "zz", "c", "c", "b", "b", "a", "zz", "c"]
+    @test isordered(x) === false
+    @test levels(x) == ["e", "a", "b", "c", "zz"]
+
+    b = ["z","y","x"]
+    y = CategoricalVector{String, R}(b)
+    append!(x, y)
+    @test length(x) == 15
+    @test x == ["c", "b", "b", "a", "zz", "c", "c", "b", "b", "a", "zz", "c", "z", "y", "x"]
+    @test levels(x) == ["e", "a", "b", "c", "zz", "x", "y", "z"]
+
+    empty!(x)
+    @test length(x) == 0
+    @test levels(x) == ["e", "a", "b", "c", "zz", "x", "y", "z"]
+
+    # Vector created from range (i.e. non-Array AbstractArray),
+    # direct conversion to a vector with different eltype
+    a = 0.0:0.5:1.5
+    x = CategoricalVector{Float64, R}(a, ordered=ordered)
+
+    @test x == collect(a)
+    @test isordered(x) === ordered
+    @test levels(x) == unique(a)
+    @test size(x) === (4,)
+    @test length(x) === 4
+    @test leveltype(x) === Float64
+    @test catvaluetype(x) <: CategoricalArrays.CategoricalValue{Float64}
+
+    @test convert(CategoricalArray, x) === x
+    @test convert(CategoricalArray{Float64}, x) === x
+    @test convert(CategoricalArray{Float64, 1}, x) === x
+    @test convert(CategoricalArray{Float64, 1, R}, x) === x
+    @test convert(CategoricalArray{Float64, 1, DefaultRefType}, x) == x
+    @test convert(CategoricalArray{Float64, 1, UInt8}, x) == x
+
+    @test convert(CategoricalVector, x) === x
+    @test convert(CategoricalVector{Float64}, x) === x
+    @test convert(CategoricalVector{Float64, R}, x) === x
+    @test convert(CategoricalVector{Float64, DefaultRefType}, x) == x
+    @test convert(CategoricalVector{Float64, UInt8}, x) == x
+
+    @test convert(CategoricalArray, a) == x
+    @test convert(CategoricalArray{Float64}, a) == x
+    @test convert(CategoricalArray{Float32}, a) == x
+    @test convert(CategoricalArray{Float64, 1}, a) == x
+    @test convert(CategoricalArray{Float32, 1}, a) == x
+    @test convert(CategoricalArray{Float64, 1, R}, a) == x
+    @test convert(CategoricalArray{Float32, 1, R}, a) == x
+    @test convert(CategoricalArray{Float64, 1, DefaultRefType}, a) == x
+    @test convert(CategoricalArray{Float32, 1, DefaultRefType}, a) == x
+    @test convert(CategoricalArray{Float64, 1, UInt8}, a) == x
+    @test convert(CategoricalArray{Float32, 1, UInt8}, a) == x
+
+    @test convert(CategoricalVector, a) == x
+    @test convert(CategoricalVector{Float64}, a) == x
+    @test convert(CategoricalVector{Float32}, a) == x
+    @test convert(CategoricalVector{Float64, R}, a) == x
+    @test convert(CategoricalVector{Float32, R}, a) == x
+    @test convert(CategoricalVector{Float64, DefaultRefType}, a) == x
+    @test convert(CategoricalVector{Float32, DefaultRefType}, a) == x
+    @test convert(CategoricalVector{Float64, UInt8}, a) == x
+    @test convert(CategoricalVector{Float32, UInt8}, a) == x
+
+    @test CategoricalArray{Float64}(a, ordered=ordered) == x
+    @test CategoricalArray{Float32}(a, ordered=ordered) == x
+    @test CategoricalArray{Float64, 1}(a, ordered=ordered) == x
+    @test CategoricalArray{Float32, 1}(a, ordered=ordered) == x
+    @test CategoricalArray{Float64, 1, R}(a, ordered=ordered) == x
+    @test CategoricalArray{Float32, 1, R}(a, ordered=ordered) == x
+    @test CategoricalArray{Float64, 1, DefaultRefType}(a, ordered=ordered) == x
+    @test CategoricalArray{Float32, 1, DefaultRefType}(a, ordered=ordered) == x
+
+    @test CategoricalVector(a, ordered=ordered) == x
+    @test CategoricalVector{Float64}(a, ordered=ordered) == x
+    @test CategoricalVector{Float32}(a, ordered=ordered) == x
+    @test CategoricalVector{Float64, R}(a, ordered=ordered) == x
+    @test CategoricalVector{Float32, R}(a, ordered=ordered) == x
+    @test CategoricalVector{Float64, DefaultRefType}(a, ordered=ordered) == x
+    @test CategoricalVector{Float32, DefaultRefType}(a, ordered=ordered) == x
+
+    @testset "categorical($(typeof(y)), compress=$comp) R1=$R1 R2=$R2" for (y, R1, R2, comp) in
+        ((a, DefaultRefType, UInt8, true),
+         (a, DefaultRefType, DefaultRefType, false),
+         (x, R, UInt8, true),
+         (x, R, R, false))
+
+        x2 = categorical(y, ordered=ordered)
+        @test x2 == x
+        @test isa(x2, CategoricalVector{Float64, R1})
+        @test isordered(x2) === ordered
+        @test leveltype(x2) === Float64
+        @test catvaluetype(x2) === CategoricalArrays.CategoricalValue{Float64, R1}
+
+        x2 = categorical(y, comp, ordered=ordered)
+        @test x2 == x
+        @test isa(x2, CategoricalVector{Float64, R2})
+        @test isordered(x2) === ordered
+        @test leveltype(x2) === Float64
+        @test catvaluetype(x2) === CategoricalArrays.CategoricalValue{Float64, R2}
+    end
+
+    x2 = copy(x)
+    @test x2 == x
+    @test typeof(x2) === typeof(x)
+    @test isordered(x2) === isordered(x)
+    @test levels(x2) == levels(x)
+
+    @test x[1] === x.pool.valindex[1]
+    @test x[2] === x.pool.valindex[2]
+    @test x[3] === x.pool.valindex[3]
+    @test x[4] === x.pool.valindex[4]
+    @test_throws BoundsError x[5]
+
+    x2 = x[:]
+    @test typeof(x2) === typeof(x)
+    @test x2 == x
+    @test levels(x2) == levels(x)
+    @test levels(x2) !== levels(x)
+    @test isordered(x2) == isordered(x)
+
+    x2 = x[1:2]
+    @test typeof(x2) === typeof(x)
+    @test x2 == [0.0, 0.5]
+    @test levels(x2) == levels(x)
+    @test levels(x2) !== levels(x)
+    @test isordered(x2) == isordered(x)
+
+    x2 = x[1:1]
+    @test typeof(x2) === typeof(x)
+    @test x2 == [0.0]
+    @test levels(x2) == levels(x)
+    @test levels(x2) !== levels(x)
+    @test isordered(x2) == isordered(x)
+
+    x2 = x[2:1]
+    @test typeof(x2) === typeof(x)
+    @test isempty(x2)
+    @test levels(x2) == levels(x)
+    @test levels(x2) !== levels(x)
+    @test isordered(x2) == isordered(x)
+
+    x[2] = 1
+    @test x[1] === x.pool.valindex[1]
+    @test x[2] === x.pool.valindex[3]
+    @test x[3] === x.pool.valindex[3]
+    @test x[4] === x.pool.valindex[4]
+    @test levels(x) == unique(a)
+
+    x[1:2] = -1
+    @test x[1] === x.pool.valindex[5]
+    @test x[2] === x.pool.valindex[5]
+    @test x[3] === x.pool.valindex[3]
+    @test x[4] === x.pool.valindex[4]
+    @test levels(x) == vcat(unique(a), -1)
+
+    push!(x, 2.0)
+    @test length(x) == 5
+    @test x[end] == 2.0
+    @test isordered(x) === ordered
+    @test levels(x) == [0.0,  0.5,  1.0,  1.5, -1.0,  2.0]
+
+    push!(x, x[1])
+    @test length(x) == 6
+    @test x[1] == x[end]
+    @test isordered(x) === ordered
+    @test levels(x) == [0.0,  0.5,  1.0,  1.5, -1.0,  2.0]
+
+    append!(x, x)
+    @test length(x) == 12
+    @test x == [-1.0, -1.0, 1.0, 1.5, 2.0, -1.0, -1.0, -1.0, 1.0, 1.5, 2.0, -1.0]
+    @test isordered(x) === ordered
+    @test levels(x) == [0.0,  0.5,  1.0,  1.5, -1.0,  2.0]
+
+    b = [2.5, 3.0, -3.5]
+    y = CategoricalVector{Float64, R}(b, ordered=ordered)
+    append!(x, y)
+    @test length(x) == 15
+    @test x == [-1.0, -1.0, 1.0, 1.5, 2.0, -1.0, -1.0, -1.0, 1.0, 1.5, 2.0, -1.0, 2.5, 3.0, -3.5]
+    @test isordered(x) === ordered
+    @test levels(x) == [0.0, 0.5, 1.0, 1.5, -1.0, 2.0, -3.5, 2.5, 3.0]
+
+    empty!(x)
+    @test length(x) == 0
+    @test isordered(x) === ordered
+    @test levels(x) == [0.0, 0.5, 1.0, 1.5, -1.0, 2.0, -3.5, 2.5, 3.0]
+
+    # Matrix
+    a = ["a" "b" "c"; "b" "a" "c"]
+    x = CategoricalMatrix{String, R}(a, ordered=ordered)
+
+    @test x == a
+    @test isordered(x) === ordered
+    @test levels(x) == unique(a)
+    @test size(x) === (2, 3)
+    @test length(x) === 6
+
+    @test convert(CategoricalArray, x) === x
+    @test convert(CategoricalArray{String}, x) === x
+    @test convert(CategoricalArray{String, 2}, x) === x
+    @test convert(CategoricalArray{String, 2, R}, x) === x
+    @test convert(CategoricalArray{String, 2, DefaultRefType}, x) == x
+    @test convert(CategoricalArray{String, 2, UInt8}, x) == x
+
+    @test convert(CategoricalMatrix, x) === x
+    @test convert(CategoricalMatrix{String}, x) === x
+    @test convert(CategoricalMatrix{String, R}, x) === x
+    @test convert(CategoricalMatrix{String, DefaultRefType}, x) == x
+    @test convert(CategoricalMatrix{String, UInt8}, x) == x
+
+    @test convert(CategoricalArray, a) == x
+    @test convert(CategoricalArray{String}, a) == x
+    @test convert(CategoricalArray{String, 2, R}, a) == x
+    @test convert(CategoricalArray{String, 2, DefaultRefType}, a) == x
+    @test convert(CategoricalArray{String, 2, UInt8}, a) == x
+
+    @test convert(CategoricalMatrix, a) == x
+    @test convert(CategoricalMatrix{String}, a) == x
+    @test convert(CategoricalMatrix{String, R}, a) == x
+    @test convert(CategoricalMatrix{String, DefaultRefType}, a) == x
+    @test convert(CategoricalMatrix{String, UInt8}, a) == x
+
+    @test CategoricalArray{String}(a, ordered=ordered) == x
+    @test CategoricalArray{String, 2}(a, ordered=ordered) == x
+    @test CategoricalArray{String, 2}(a, ordered=ordered) == x
+    @test CategoricalArray{String, 2, R}(a, ordered=ordered) == x
+    @test CategoricalArray{String, 2, DefaultRefType}(a, ordered=ordered) == x
+    @test CategoricalArray{String, 2, UInt8}(a, ordered=ordered) == x
+
+    @test CategoricalMatrix(a, ordered=ordered) == x
+    @test CategoricalMatrix{String}(a, ordered=ordered) == x
+    @test CategoricalMatrix{String, R}(a, ordered=ordered) == x
+    @test CategoricalMatrix{String, DefaultRefType}(a, ordered=ordered) == x
+    @test CategoricalMatrix{String, UInt8}(a, ordered=ordered) == x
+
+    @testset "categorical($(typeof(y)), compress=$comp) R1=$R1 R2=$R2" for (y, R1, R2, comp) in
+        ((a, DefaultRefType, UInt8, true),
+         (a, DefaultRefType, DefaultRefType, false),
+         (x, R, UInt8, true),
+         (x, R, R, false))
+
+        x2 = categorical(y, ordered=ordered)
+        @test x2 == x
+        @test isa(x2, CategoricalMatrix{String, R1})
+        @test isordered(x2) === ordered
+
+        x2 = categorical(y, comp, ordered=ordered)
+        @test x2 == x
+        @test isa(x2, CategoricalMatrix{String, R2})
+        @test isordered(x2) === ordered
+    end
+
+    x2 = compress(x)
+    @test x2 == x
+    @test isa(x2, CategoricalMatrix{String, UInt8})
+    @test isordered(x2) === isordered(x)
+    @test levels(x2) == levels(x)
+
+    x2 = copy(x)
+    @test x2 == x
+    @test typeof(x2) === typeof(x)
+    @test isordered(x2) === isordered(x)
+    @test levels(x2) == levels(x)
+
+    @test x[1] === x.pool.valindex[1]
+    @test x[2] === x.pool.valindex[2]
+    @test x[3] === x.pool.valindex[2]
+    @test x[4] === x.pool.valindex[1]
+    @test x[5] === x.pool.valindex[3]
+    @test x[6] === x.pool.valindex[3]
+    @test_throws BoundsError x[7]
+
+    @test x[1,1] === x.pool.valindex[1]
+    @test x[2,1] === x.pool.valindex[2]
+    @test x[1,2] === x.pool.valindex[2]
+    @test x[2,2] === x.pool.valindex[1]
+    @test x[1,3] === x.pool.valindex[3]
+    @test x[2,3] === x.pool.valindex[3]
+    @test_throws BoundsError x[1,4]
+    @test_throws BoundsError x[4,1]
+    @test_throws BoundsError x[4,4]
+
+    x2 = x[1:2,:]
+    @test typeof(x2) === typeof(x)
+    @test x2 == x
+    @test levels(x2) == levels(x)
+    @test levels(x2) !== levels(x)
+    @test isordered(x2) == isordered(x)
+
+    x2 = x[:,[1, 3]]
+    @test typeof(x2) === typeof(x)
+    @test x2 == ["a" "c"; "b" "c"]
+    @test levels(x2) == levels(x)
+    @test levels(x2) !== levels(x)
+    @test isordered(x2) == isordered(x)
+
+    x2 = x[1:1,2]
+    @test isa(x2, CategoricalVector{String, R})
+    @test x2 == ["b"]
+    @test levels(x2) == levels(x)
+    @test levels(x2) !== levels(x)
+    @test isordered(x2) == isordered(x)
+
+    x2 = x[1:0,:]
+    @test typeof(x2) === typeof(x)
+    @test size(x2) == (0,3)
+    @test levels(x2) == levels(x)
+    @test levels(x2) !== levels(x)
+    @test isordered(x2) == isordered(x)
+
+    @test_throws BoundsError x[1:4, :]
+    @test_throws BoundsError x[1:1, -1:1]
+    @test_throws BoundsError x[4, :]
+
+    x[1] = "z"
+    @test x[1] === x.pool.valindex[4]
+    @test x[2] === x.pool.valindex[2]
+    @test x[3] === x.pool.valindex[2]
+    @test x[4] === x.pool.valindex[1]
+    @test x[5] === x.pool.valindex[3]
+    @test x[6] === x.pool.valindex[3]
+    @test levels(x) == ["a", "b", "c", "z"]
+
+    x[1,:] = "a"
+    @test x[1] === x.pool.valindex[1]
+    @test x[2] === x.pool.valindex[2]
+    @test x[3] === x.pool.valindex[1]
+    @test x[4] === x.pool.valindex[1]
+    @test x[5] === x.pool.valindex[1]
+    @test x[6] === x.pool.valindex[3]
+    @test levels(x) == ["a", "b", "c", "z"]
+
+    x[1,1:2] = "z"
+    @test x[1] === x.pool.valindex[4]
+    @test x[2] === x.pool.valindex[2]
+    @test x[3] === x.pool.valindex[4]
+    @test x[4] === x.pool.valindex[1]
+    @test x[5] === x.pool.valindex[1]
+    @test x[6] === x.pool.valindex[3]
+    @test levels(x) == ["a", "b", "c", "z"]
+
+    x[1,2] = "b"
+    @test x[1] === x.pool.valindex[4]
+    @test x[2] === x.pool.valindex[2]
+    @test x[3] === x.pool.valindex[2]
+    @test x[4] === x.pool.valindex[1]
+    @test x[5] === x.pool.valindex[1]
+    @test x[6] === x.pool.valindex[3]
+    @test levels(x) == ["a", "b", "c", "z"]
+
+
+    # Uninitialized array
+    v = Any[CategoricalArray(2, ordered=ordered),
+            CategoricalArray{String}(2, ordered=ordered),
+            CategoricalArray{String, 1}(2, ordered=ordered),
+            CategoricalArray{String, 1, R}(2, ordered=ordered),
+            CategoricalVector(2, ordered=ordered),
+            CategoricalVector{String}(2, ordered=ordered),
+            CategoricalVector{String, R}(2, ordered=ordered),
+            CategoricalArray(2, 3, ordered=ordered),
+            CategoricalArray{String}(2, 3, ordered=ordered),
+            CategoricalArray{String, 2}(2, 3, ordered=ordered),
+            CategoricalArray{String, 2, R}(2, 3, ordered=ordered),
+            CategoricalMatrix(2, 3, ordered=ordered),
+            CategoricalMatrix{String}(2, 3, ordered=ordered),
+            CategoricalMatrix{String, R}(2, 3, ordered=ordered)]
+
+    @testset "compress($(typeof(x))) and setindex!()" for x in v
+        @test !isassigned(x, 1) && isdefined(x, 1)
+        @test !isassigned(x, 2) && isdefined(x, 2)
+        @test_throws UndefRefError x[1]
+        @test_throws UndefRefError x[2]
         @test isordered(x) === ordered
-        @test levels(x) == sort(unique(a))
-        @test size(x) === (3,)
-        @test length(x) === 3
-
-        @test convert(CategoricalArray, x) === x
-        @test convert(CategoricalArray{String}, x) === x
-        @test convert(CategoricalArray{String, 1}, x) === x
-        @test convert(CategoricalArray{String, 1, R}, x) === x
-        @test convert(CategoricalArray{String, 1, DefaultRefType}, x) == x
-        @test convert(CategoricalArray{String, 1, UInt8}, x) == x
-
-        @test convert(CategoricalVector, x) === x
-        @test convert(CategoricalVector{String}, x) === x
-        @test convert(CategoricalVector{String, R}, x) === x
-        @test convert(CategoricalVector{String, DefaultRefType}, x) == x
-        @test convert(CategoricalVector{String, UInt8}, x) == x
-
-        @test convert(CategoricalArray, a) == x
-        @test convert(CategoricalArray{String}, a) == x
-        @test convert(CategoricalArray{String, 1}, a) == x
-        @test convert(CategoricalArray{String, 1, R}, a) == x
-        @test convert(CategoricalArray{String, 1, DefaultRefType}, a) == x
-        @test convert(CategoricalArray{String, 1, UInt8}, a) == x
-
-        @test convert(CategoricalVector, a) == x
-        @test convert(CategoricalVector{String}, a) == x
-        @test convert(CategoricalVector{String, R}, a) == x
-        @test convert(CategoricalVector{String, DefaultRefType}, a) == x
-        @test convert(CategoricalVector{String, UInt8}, a) == x
-
-        @test CategoricalArray{String}(a, ordered=ordered) == x
-        @test CategoricalArray{String, 1}(a, ordered=ordered) == x
-        @test CategoricalArray{String, 1, R}(a, ordered=ordered) == x
-        @test CategoricalArray{String, 1, DefaultRefType}(a, ordered=ordered) == x
-        @test CategoricalArray{String, 1, UInt8}(a, ordered=ordered) == x
-
-        @test CategoricalVector(a, ordered=ordered) == x
-        @test CategoricalVector{String}(a, ordered=ordered) == x
-        @test CategoricalVector{String, R}(a, ordered=ordered) == x
-        @test CategoricalVector{String, DefaultRefType}(a, ordered=ordered) == x
-        @test CategoricalVector{String, UInt8}(a, ordered=ordered) == x
-
-        for (y, R1, R2, comp) in ((a, DefaultRefType, UInt8, true),
-                                  (a, DefaultRefType, DefaultRefType, false),
-                                  (x, R, UInt8, true),
-                                  (x, R, R, false))
-            x2 = categorical(y, ordered=ordered)
-            @test x2 == x
-            @test isa(x2, CategoricalVector{String, R1})
-            @test isordered(x2) === ordered
-            @test leveltype(x2) === String
-            @test catvaluetype(x2) === CategoricalArrays.CategoricalString{R1}
-
-            x2 = categorical(y, comp, ordered=ordered)
-            @test x2 == x
-            @test isa(x2, CategoricalVector{String, R2})
-            @test isordered(x2) === ordered
-            @test leveltype(x2) === String
-            @test catvaluetype(x2) === CategoricalArrays.CategoricalString{R2}
-        end
+        @test levels(x) == []
 
         x2 = compress(x)
-        @test x2 == x
-        @test isa(x2, CategoricalVector{String, UInt8})
-        @test isordered(x2) === isordered(x)
-        @test levels(x2) == levels(x)
-
-        x2 = copy(x)
-        @test x2 == x
-        @test typeof(x2) === typeof(x)
-        @test isordered(x2) === isordered(x)
-        @test levels(x2) == levels(x)
-
-        if !isordered(x)
-            @test ordered!(x, true) === x
-            @test isordered(x) === true
-        end
-        @test x[1] > x[2]
-        @test x[3] > x[2]
-
-        @test ordered!(x, false) === x
-        @test isordered(x) === false
-        @test_throws Exception x[1] > x[2]
-        @test_throws Exception x[3] > x[2]
-
-        @test x[1] === x.pool.valindex[1]
-        @test x[2] === x.pool.valindex[2]
-        @test x[3] === x.pool.valindex[1]
-        @test_throws BoundsError x[4]
-
-        x2 = x[:]
-        @test typeof(x2) === typeof(x)
-        @test x2 == x
-        @test x2 !== x
-        @test levels(x2) == levels(x)
-        @test levels(x2) !== levels(x)
-        @test isordered(x2) == isordered(x)
-
-        x2 = x[1:2]
-        @test typeof(x2) === typeof(x)
-        @test x2 == ["b", "a"]
-        @test levels(x2) == levels(x)
-        @test levels(x2) !== levels(x)
-        @test isordered(x2) == isordered(x)
-
-        x2 = x[1:1]
-        @test typeof(x2) === typeof(x)
-        @test x2 == ["b"]
-        @test levels(x2) == levels(x)
-        @test levels(x2) !== levels(x)
-        @test isordered(x2) == isordered(x)
-
-        x2 = x[2:1]
-        @test typeof(x2) === typeof(x)
-        @test isempty(x2)
-        @test levels(x2) == levels(x)
-        @test levels(x2) !== levels(x)
-        @test isordered(x2) == isordered(x)
-
-        x[1] = x[2]
-        @test x[1] === x.pool.valindex[2]
-        @test x[2] === x.pool.valindex[2]
-        @test x[3] === x.pool.valindex[1]
-
-        x[3] = "c"
-        @test x[1] === x.pool.valindex[2]
-        @test x[2] === x.pool.valindex[2]
-        @test x[3] === x.pool.valindex[3]
-        @test levels(x) == ["a", "b", "c"]
-
-        x[2:3] = "b"
-        @test x[1] === x.pool.valindex[2]
-        @test x[2] === x.pool.valindex[1]
-        @test x[3] === x.pool.valindex[1]
-        @test levels(x) == ["a", "b", "c"]
-
-        @test droplevels!(x) === x
-        @test levels(x) == ["a", "b"]
-        @test x[1] === x.pool.valindex[1]
-        @test x[2] === x.pool.valindex[2]
-        @test x[3] === x.pool.valindex[2]
-        @test levels(x) == ["a", "b"]
-
-        @test levels!(x, ["b", "a"]) === x
-        @test levels(x) == ["b", "a"]
-        @test x[1] === x.pool.valindex[1]
-        @test x[2] === x.pool.valindex[2]
-        @test x[3] === x.pool.valindex[2]
-        @test levels(x) == ["b", "a"]
-
-        @test_throws ArgumentError levels!(x, ["a"])
-        @test_throws ArgumentError levels!(x, ["e", "b"])
-        @test_throws ArgumentError levels!(x, ["e", "a", "b", "a"])
-
-        @test levels!(x, ["e", "a", "b"]) === x
-        @test levels(x) == ["e", "a", "b"]
-        @test x[1] === x.pool.valindex[1]
-        @test x[2] === x.pool.valindex[2]
-        @test x[3] === x.pool.valindex[2]
-        @test levels(x) == ["e", "a", "b"]
+        @test isa(x2, CategoricalArray{leveltype(x), ndims(x), UInt8})
+        @test !isassigned(x2, 1) && isdefined(x2, 1)
+        @test !isassigned(x2, 2) && isdefined(x2, 2)
+        @test_throws UndefRefError x2[1]
+        @test_throws UndefRefError x2[2]
+        @test levels(x2) == []
 
         x[1] = "c"
-        @test x[1] === x.pool.valindex[4]
-        @test x[2] === x.pool.valindex[2]
-        @test x[3] === x.pool.valindex[2]
-        @test levels(x) == ["e", "a", "b", "c"]
-
-        push!(x, "a")
-        @test length(x) == 4
-        @test x[end] == "a"
-        @test levels(x) == ["e", "a", "b", "c"]
-
-        push!(x, "zz")
-        @test length(x) == 5
-        @test x[end] == "zz"
-        @test levels(x) == ["e", "a", "b", "c", "zz"]
-
-        push!(x, x[1])
-        @test length(x) == 6
-        @test x[1] == x[end]
-        @test levels(x) == ["e", "a", "b", "c", "zz"]
-
-        append!(x, x)
-        @test length(x) == 12
-        @test x == ["c", "b", "b", "a", "zz", "c", "c", "b", "b", "a", "zz", "c"]
-        @test isordered(x) === false
-        @test levels(x) == ["e", "a", "b", "c", "zz"]
-
-        b = ["z","y","x"]
-        y = CategoricalVector{String, R}(b)
-        append!(x, y)
-        @test length(x) == 15
-        @test x == ["c", "b", "b", "a", "zz", "c", "c", "b", "b", "a", "zz", "c", "z", "y", "x"]
-        @test levels(x) == ["e", "a", "b", "c", "zz", "x", "y", "z"]
-
-        empty!(x)
-        @test length(x) == 0
-        @test levels(x) == ["e", "a", "b", "c", "zz", "x", "y", "z"]
-
-        # Vector created from range (i.e. non-Array AbstractArray),
-        # direct conversion to a vector with different eltype
-        a = 0.0:0.5:1.5
-        x = CategoricalVector{Float64, R}(a, ordered=ordered)
-
-        @test x == collect(a)
-        @test isordered(x) === ordered
-        @test levels(x) == unique(a)
-        @test size(x) === (4,)
-        @test length(x) === 4
-        @test leveltype(x) === Float64
-        @test catvaluetype(x) <: CategoricalArrays.CategoricalValue{Float64}
-
-        @test convert(CategoricalArray, x) === x
-        @test convert(CategoricalArray{Float64}, x) === x
-        @test convert(CategoricalArray{Float64, 1}, x) === x
-        @test convert(CategoricalArray{Float64, 1, R}, x) === x
-        @test convert(CategoricalArray{Float64, 1, DefaultRefType}, x) == x
-        @test convert(CategoricalArray{Float64, 1, UInt8}, x) == x
-
-        @test convert(CategoricalVector, x) === x
-        @test convert(CategoricalVector{Float64}, x) === x
-        @test convert(CategoricalVector{Float64, R}, x) === x
-        @test convert(CategoricalVector{Float64, DefaultRefType}, x) == x
-        @test convert(CategoricalVector{Float64, UInt8}, x) == x
-
-        @test convert(CategoricalArray, a) == x
-        @test convert(CategoricalArray{Float64}, a) == x
-        @test convert(CategoricalArray{Float32}, a) == x
-        @test convert(CategoricalArray{Float64, 1}, a) == x
-        @test convert(CategoricalArray{Float32, 1}, a) == x
-        @test convert(CategoricalArray{Float64, 1, R}, a) == x
-        @test convert(CategoricalArray{Float32, 1, R}, a) == x
-        @test convert(CategoricalArray{Float64, 1, DefaultRefType}, a) == x
-        @test convert(CategoricalArray{Float32, 1, DefaultRefType}, a) == x
-        @test convert(CategoricalArray{Float64, 1, UInt8}, a) == x
-        @test convert(CategoricalArray{Float32, 1, UInt8}, a) == x
-
-        @test convert(CategoricalVector, a) == x
-        @test convert(CategoricalVector{Float64}, a) == x
-        @test convert(CategoricalVector{Float32}, a) == x
-        @test convert(CategoricalVector{Float64, R}, a) == x
-        @test convert(CategoricalVector{Float32, R}, a) == x
-        @test convert(CategoricalVector{Float64, DefaultRefType}, a) == x
-        @test convert(CategoricalVector{Float32, DefaultRefType}, a) == x
-        @test convert(CategoricalVector{Float64, UInt8}, a) == x
-        @test convert(CategoricalVector{Float32, UInt8}, a) == x
-
-        @test CategoricalArray{Float64}(a, ordered=ordered) == x
-        @test CategoricalArray{Float32}(a, ordered=ordered) == x
-        @test CategoricalArray{Float64, 1}(a, ordered=ordered) == x
-        @test CategoricalArray{Float32, 1}(a, ordered=ordered) == x
-        @test CategoricalArray{Float64, 1, R}(a, ordered=ordered) == x
-        @test CategoricalArray{Float32, 1, R}(a, ordered=ordered) == x
-        @test CategoricalArray{Float64, 1, DefaultRefType}(a, ordered=ordered) == x
-        @test CategoricalArray{Float32, 1, DefaultRefType}(a, ordered=ordered) == x
-
-        @test CategoricalVector(a, ordered=ordered) == x
-        @test CategoricalVector{Float64}(a, ordered=ordered) == x
-        @test CategoricalVector{Float32}(a, ordered=ordered) == x
-        @test CategoricalVector{Float64, R}(a, ordered=ordered) == x
-        @test CategoricalVector{Float32, R}(a, ordered=ordered) == x
-        @test CategoricalVector{Float64, DefaultRefType}(a, ordered=ordered) == x
-        @test CategoricalVector{Float32, DefaultRefType}(a, ordered=ordered) == x
-
-        for (y, R1, R2, comp) in ((a, DefaultRefType, UInt8, true),
-                                  (a, DefaultRefType, DefaultRefType, false),
-                                  (x, R, UInt8, true),
-                                  (x, R, R, false))
-            x2 = categorical(y, ordered=ordered)
-            @test x2 == x
-            @test isa(x2, CategoricalVector{Float64, R1})
-            @test isordered(x2) === ordered
-            @test leveltype(x2) === Float64
-            @test catvaluetype(x2) === CategoricalArrays.CategoricalValue{Float64, R1}
-
-            x2 = categorical(y, comp, ordered=ordered)
-            @test x2 == x
-            @test isa(x2, CategoricalVector{Float64, R2})
-            @test isordered(x2) === ordered
-            @test leveltype(x2) === Float64
-            @test catvaluetype(x2) === CategoricalArrays.CategoricalValue{Float64, R2}
-        end
-
-        x2 = copy(x)
-        @test x2 == x
-        @test typeof(x2) === typeof(x)
-        @test isordered(x2) === isordered(x)
-        @test levels(x2) == levels(x)
-
         @test x[1] === x.pool.valindex[1]
-        @test x[2] === x.pool.valindex[2]
-        @test x[3] === x.pool.valindex[3]
-        @test x[4] === x.pool.valindex[4]
-        @test_throws BoundsError x[5]
+        @test !isassigned(x, 2) && isdefined(x, 2)
+        @test_throws UndefRefError x[2]
+        @test levels(x) == ["c"]
 
-        x2 = x[:]
-        @test typeof(x2) === typeof(x)
-        @test x2 == x
-        @test levels(x2) == levels(x)
-        @test levels(x2) !== levels(x)
-        @test isordered(x2) == isordered(x)
-
-        x2 = x[1:2]
-        @test typeof(x2) === typeof(x)
-        @test x2 == [0.0, 0.5]
-        @test levels(x2) == levels(x)
-        @test levels(x2) !== levels(x)
-        @test isordered(x2) == isordered(x)
-
-        x2 = x[1:1]
-        @test typeof(x2) === typeof(x)
-        @test x2 == [0.0]
-        @test levels(x2) == levels(x)
-        @test levels(x2) !== levels(x)
-        @test isordered(x2) == isordered(x)
-
-        x2 = x[2:1]
-        @test typeof(x2) === typeof(x)
-        @test isempty(x2)
-        @test levels(x2) == levels(x)
-        @test levels(x2) !== levels(x)
-        @test isordered(x2) == isordered(x)
-
-        x[2] = 1
-        @test x[1] === x.pool.valindex[1]
-        @test x[2] === x.pool.valindex[3]
-        @test x[3] === x.pool.valindex[3]
-        @test x[4] === x.pool.valindex[4]
-        @test levels(x) == unique(a)
-
-        x[1:2] = -1
-        @test x[1] === x.pool.valindex[5]
-        @test x[2] === x.pool.valindex[5]
-        @test x[3] === x.pool.valindex[3]
-        @test x[4] === x.pool.valindex[4]
-        @test levels(x) == vcat(unique(a), -1)
-
-        push!(x, 2.0)
-        @test length(x) == 5
-        @test x[end] == 2.0
+        x[1] = "a"
+        @test x[1] === x.pool.valindex[2]
+        @test !isassigned(x, 2) && isdefined(x, 2)
+        @test_throws UndefRefError x[2]
         @test isordered(x) === ordered
-        @test levels(x) == [0.0,  0.5,  1.0,  1.5, -1.0,  2.0]
+        @test levels(x) == ["c", "a"]
 
-        push!(x, x[1])
-        @test length(x) == 6
-        @test x[1] == x[end]
-        @test isordered(x) === ordered
-        @test levels(x) == [0.0,  0.5,  1.0,  1.5, -1.0,  2.0]
+        x[2] = "c"
+        @test x[1] === x.pool.valindex[2]
+        @test x[2] === x.pool.valindex[1]
+        @test levels(x) == ["c", "a"]
 
-        append!(x, x)
-        @test length(x) == 12
-        @test x == [-1.0, -1.0, 1.0, 1.5, 2.0, -1.0, -1.0, -1.0, 1.0, 1.5, 2.0, -1.0]
-        @test isordered(x) === ordered
-        @test levels(x) == [0.0,  0.5,  1.0,  1.5, -1.0,  2.0]
-
-        b = [2.5, 3.0, -3.5]
-        y = CategoricalVector{Float64, R}(b, ordered=ordered)
-        append!(x, y)
-        @test length(x) == 15
-        @test x == [-1.0, -1.0, 1.0, 1.5, 2.0, -1.0, -1.0, -1.0, 1.0, 1.5, 2.0, -1.0, 2.5, 3.0, -3.5]
-        @test isordered(x) === ordered
-        @test levels(x) == [0.0, 0.5, 1.0, 1.5, -1.0, 2.0, -3.5, 2.5, 3.0]
-
-        empty!(x)
-        @test length(x) == 0
-        @test isordered(x) === ordered
-        @test levels(x) == [0.0, 0.5, 1.0, 1.5, -1.0, 2.0, -3.5, 2.5, 3.0]
-
-        # Matrix
-        a = ["a" "b" "c"; "b" "a" "c"]
-        x = CategoricalMatrix{String, R}(a, ordered=ordered)
-
-        @test x == a
-        @test isordered(x) === ordered
-        @test levels(x) == unique(a)
-        @test size(x) === (2, 3)
-        @test length(x) === 6
-
-        @test convert(CategoricalArray, x) === x
-        @test convert(CategoricalArray{String}, x) === x
-        @test convert(CategoricalArray{String, 2}, x) === x
-        @test convert(CategoricalArray{String, 2, R}, x) === x
-        @test convert(CategoricalArray{String, 2, DefaultRefType}, x) == x
-        @test convert(CategoricalArray{String, 2, UInt8}, x) == x
-
-        @test convert(CategoricalMatrix, x) === x
-        @test convert(CategoricalMatrix{String}, x) === x
-        @test convert(CategoricalMatrix{String, R}, x) === x
-        @test convert(CategoricalMatrix{String, DefaultRefType}, x) == x
-        @test convert(CategoricalMatrix{String, UInt8}, x) == x
-
-        @test convert(CategoricalArray, a) == x
-        @test convert(CategoricalArray{String}, a) == x
-        @test convert(CategoricalArray{String, 2, R}, a) == x
-        @test convert(CategoricalArray{String, 2, DefaultRefType}, a) == x
-        @test convert(CategoricalArray{String, 2, UInt8}, a) == x
-
-        @test convert(CategoricalMatrix, a) == x
-        @test convert(CategoricalMatrix{String}, a) == x
-        @test convert(CategoricalMatrix{String, R}, a) == x
-        @test convert(CategoricalMatrix{String, DefaultRefType}, a) == x
-        @test convert(CategoricalMatrix{String, UInt8}, a) == x
-
-        @test CategoricalArray{String}(a, ordered=ordered) == x
-        @test CategoricalArray{String, 2}(a, ordered=ordered) == x
-        @test CategoricalArray{String, 2}(a, ordered=ordered) == x
-        @test CategoricalArray{String, 2, R}(a, ordered=ordered) == x
-        @test CategoricalArray{String, 2, DefaultRefType}(a, ordered=ordered) == x
-        @test CategoricalArray{String, 2, UInt8}(a, ordered=ordered) == x
-
-        @test CategoricalMatrix(a, ordered=ordered) == x
-        @test CategoricalMatrix{String}(a, ordered=ordered) == x
-        @test CategoricalMatrix{String, R}(a, ordered=ordered) == x
-        @test CategoricalMatrix{String, DefaultRefType}(a, ordered=ordered) == x
-        @test CategoricalMatrix{String, UInt8}(a, ordered=ordered) == x
-
-        for (y, R1, R2, comp) in ((a, DefaultRefType, UInt8, true),
-                                  (a, DefaultRefType, DefaultRefType, false),
-                                  (x, R, UInt8, true),
-                                  (x, R, R, false))
-            x2 = categorical(y, ordered=ordered)
-            @test x2 == x
-            @test isa(x2, CategoricalMatrix{String, R1})
-            @test isordered(x2) === ordered
-
-            x2 = categorical(y, comp, ordered=ordered)
-            @test x2 == x
-            @test isa(x2, CategoricalMatrix{String, R2})
-            @test isordered(x2) === ordered
-        end
-
-        x2 = compress(x)
-        @test x2 == x
-        @test isa(x2, CategoricalMatrix{String, UInt8})
-        @test isordered(x2) === isordered(x)
-        @test levels(x2) == levels(x)
-
-        x2 = copy(x)
-        @test x2 == x
-        @test typeof(x2) === typeof(x)
-        @test isordered(x2) === isordered(x)
-        @test levels(x2) == levels(x)
-
-        @test x[1] === x.pool.valindex[1]
-        @test x[2] === x.pool.valindex[2]
-        @test x[3] === x.pool.valindex[2]
-        @test x[4] === x.pool.valindex[1]
-        @test x[5] === x.pool.valindex[3]
-        @test x[6] === x.pool.valindex[3]
-        @test_throws BoundsError x[7]
-
-        @test x[1,1] === x.pool.valindex[1]
-        @test x[2,1] === x.pool.valindex[2]
-        @test x[1,2] === x.pool.valindex[2]
-        @test x[2,2] === x.pool.valindex[1]
-        @test x[1,3] === x.pool.valindex[3]
-        @test x[2,3] === x.pool.valindex[3]
-        @test_throws BoundsError x[1,4]
-        @test_throws BoundsError x[4,1]
-        @test_throws BoundsError x[4,4]
-
-        x2 = x[1:2,:]
-        @test typeof(x2) === typeof(x)
-        @test x2 == x
-        @test levels(x2) == levels(x)
-        @test levels(x2) !== levels(x)
-        @test isordered(x2) == isordered(x)
-
-        x2 = x[:,[1, 3]]
-        @test typeof(x2) === typeof(x)
-        @test x2 == ["a" "c"; "b" "c"]
-        @test levels(x2) == levels(x)
-        @test levels(x2) !== levels(x)
-        @test isordered(x2) == isordered(x)
-
-        x2 = x[1:1,2]
-        @test isa(x2, CategoricalVector{String, R})
-        @test x2 == ["b"]
-        @test levels(x2) == levels(x)
-        @test levels(x2) !== levels(x)
-        @test isordered(x2) == isordered(x)
-
-        x2 = x[1:0,:]
-        @test typeof(x2) === typeof(x)
-        @test size(x2) == (0,3)
-        @test levels(x2) == levels(x)
-        @test levels(x2) !== levels(x)
-        @test isordered(x2) == isordered(x)
-
-        @test_throws BoundsError x[1:4, :]
-        @test_throws BoundsError x[1:1, -1:1]
-        @test_throws BoundsError x[4, :]
-
-        x[1] = "z"
-        @test x[1] === x.pool.valindex[4]
-        @test x[2] === x.pool.valindex[2]
-        @test x[3] === x.pool.valindex[2]
-        @test x[4] === x.pool.valindex[1]
-        @test x[5] === x.pool.valindex[3]
-        @test x[6] === x.pool.valindex[3]
-        @test levels(x) == ["a", "b", "c", "z"]
-
-        x[1,:] = "a"
-        @test x[1] === x.pool.valindex[1]
-        @test x[2] === x.pool.valindex[2]
-        @test x[3] === x.pool.valindex[1]
-        @test x[4] === x.pool.valindex[1]
-        @test x[5] === x.pool.valindex[1]
-        @test x[6] === x.pool.valindex[3]
-        @test levels(x) == ["a", "b", "c", "z"]
-
-        x[1,1:2] = "z"
-        @test x[1] === x.pool.valindex[4]
-        @test x[2] === x.pool.valindex[2]
-        @test x[3] === x.pool.valindex[4]
-        @test x[4] === x.pool.valindex[1]
-        @test x[5] === x.pool.valindex[1]
-        @test x[6] === x.pool.valindex[3]
-        @test levels(x) == ["a", "b", "c", "z"]
-
-        x[1,2] = "b"
-        @test x[1] === x.pool.valindex[4]
-        @test x[2] === x.pool.valindex[2]
-        @test x[3] === x.pool.valindex[2]
-        @test x[4] === x.pool.valindex[1]
-        @test x[5] === x.pool.valindex[1]
-        @test x[6] === x.pool.valindex[3]
-        @test levels(x) == ["a", "b", "c", "z"]
-
-
-        # Uninitialized array
-        v = Any[CategoricalArray(2, ordered=ordered),
-                CategoricalArray{String}(2, ordered=ordered),
-                CategoricalArray{String, 1}(2, ordered=ordered),
-                CategoricalArray{String, 1, R}(2, ordered=ordered),
-                CategoricalVector(2, ordered=ordered),
-                CategoricalVector{String}(2, ordered=ordered),
-                CategoricalVector{String, R}(2, ordered=ordered),
-                CategoricalArray(2, 3, ordered=ordered),
-                CategoricalArray{String}(2, 3, ordered=ordered),
-                CategoricalArray{String, 2}(2, 3, ordered=ordered),
-                CategoricalArray{String, 2, R}(2, 3, ordered=ordered),
-                CategoricalMatrix(2, 3, ordered=ordered),
-                CategoricalMatrix{String}(2, 3, ordered=ordered),
-                CategoricalMatrix{String, R}(2, 3, ordered=ordered)]
-
-        for x in v
-            @test !isassigned(x, 1) && isdefined(x, 1)
-            @test !isassigned(x, 2) && isdefined(x, 2)
-            @test_throws UndefRefError x[1]
-            @test_throws UndefRefError x[2]
-            @test isordered(x) === ordered
-            @test levels(x) == []
-
-            x2 = compress(x)
-            @test isa(x2, CategoricalArray{leveltype(x), ndims(x), UInt8})
-            @test !isassigned(x2, 1) && isdefined(x2, 1)
-            @test !isassigned(x2, 2) && isdefined(x2, 2)
-            @test_throws UndefRefError x2[1]
-            @test_throws UndefRefError x2[2]
-            @test levels(x2) == []
-
-            x[1] = "c"
-            @test x[1] === x.pool.valindex[1]
-            @test !isassigned(x, 2) && isdefined(x, 2)
-            @test_throws UndefRefError x[2]
-            @test levels(x) == ["c"]
-
-            x[1] = "a"
-            @test x[1] === x.pool.valindex[2]
-            @test !isassigned(x, 2) && isdefined(x, 2)
-            @test_throws UndefRefError x[2]
-            @test isordered(x) === ordered
-            @test levels(x) == ["c", "a"]
-
-            x[2] = "c"
-            @test x[1] === x.pool.valindex[2]
-            @test x[2] === x.pool.valindex[1]
-            @test levels(x) == ["c", "a"]
-
-            x[1] = "b"
-            @test x[1] === x.pool.valindex[3]
-            @test x[2] === x.pool.valindex[1]
-            @test levels(x) == ["c", "a", "b"]
-        end
+        x[1] = "b"
+        @test x[1] === x.pool.valindex[3]
+        @test x[2] === x.pool.valindex[1]
+        @test levels(x) == ["c", "a", "b"]
     end
 end
 
-# Test unique() and levels()
+@testset "unique() and levels()" begin
+    x = CategoricalArray(["Old", "Young", "Middle", "Young"])
+    @test levels!(x, ["Young", "Middle", "Old"]) === x
+    @test levels(x) == ["Young", "Middle", "Old"]
+    @test unique(x) == levels(x) == ["Young", "Middle", "Old"]
+    @test levels!(x, ["Young", "Middle", "Old", "Unused"]) === x
+    @test levels(x) == ["Young", "Middle", "Old", "Unused"]
+    @test unique(x) == ["Young", "Middle", "Old"]
+    @test levels!(x, ["Unused1", "Young", "Middle", "Old", "Unused2"]) === x
+    @test levels(x) == ["Unused1", "Young", "Middle", "Old", "Unused2"]
+    @test unique(x) == ["Young", "Middle", "Old"]
 
-x = CategoricalArray(["Old", "Young", "Middle", "Young"])
-@test levels!(x, ["Young", "Middle", "Old"]) === x
-@test levels(x) == ["Young", "Middle", "Old"]
-@test unique(x) == levels(x) == ["Young", "Middle", "Old"]
-@test levels!(x, ["Young", "Middle", "Old", "Unused"]) === x
-@test levels(x) == ["Young", "Middle", "Old", "Unused"]
-@test unique(x) == ["Young", "Middle", "Old"]
-@test levels!(x, ["Unused1", "Young", "Middle", "Old", "Unused2"]) === x
-@test levels(x) == ["Unused1", "Young", "Middle", "Old", "Unused2"]
-@test unique(x) == ["Young", "Middle", "Old"]
+    x = CategoricalArray(String[])
+    @test isa(levels(x), Vector{String}) && isempty(levels(x))
+    @test isa(unique(x), Vector{String}) && isempty(unique(x))
+    @test levels!(x, ["Young", "Middle", "Old"]) === x
+    @test levels(x) == ["Young", "Middle", "Old"]
+    @test isa(unique(x), Vector{String}) && isempty(unique(x))
 
-x = CategoricalArray(String[])
-@test isa(levels(x), Vector{String}) && isempty(levels(x))
-@test isa(unique(x), Vector{String}) && isempty(unique(x))
-@test levels!(x, ["Young", "Middle", "Old"]) === x
-@test levels(x) == ["Young", "Middle", "Old"]
-@test isa(unique(x), Vector{String}) && isempty(unique(x))
-
-# To test short-circuit after 1000 elements
-x = CategoricalArray(repeat(1:1500, inner=10))
-@test levels(x) == collect(1:1500)
-@test unique(x) == collect(1:1500)
-@test levels!(x, [1600:-1:1; 2000]) === x
-@test levels(x) == [1600:-1:1; 2000]
-@test unique(x) == collect(1500:-1:1)
+    # To test short-circuit after 1000 elements
+    x = CategoricalArray(repeat(1:1500, inner=10))
+    @test levels(x) == collect(1:1500)
+    @test unique(x) == collect(1:1500)
+    @test levels!(x, [1600:-1:1; 2000]) === x
+    @test levels(x) == [1600:-1:1; 2000]
+    @test unique(x) == collect(1500:-1:1)
+end
 
 end

--- a/test/11_array.jl
+++ b/test/11_array.jl
@@ -216,340 +216,342 @@ using CategoricalArrays: DefaultRefType, catvaluetype, leveltype
     @test length(x) == 0
     @test levels(x) == ["e", "a", "b", "c", "zz", "x", "y", "z"]
 
-    # Vector created from range (i.e. non-Array AbstractArray),
-    # direct conversion to a vector with different eltype
-    a = 0.0:0.5:1.5
-    x = CategoricalVector{Float64, R}(a, ordered=ordered)
+    @testset "Vector created from range" begin
+        # (i.e. non-Array AbstractArray),
+        # direct conversion to a vector with different eltype
+        a = 0.0:0.5:1.5
+        x = CategoricalVector{Float64, R}(a, ordered=ordered)
 
-    @test x == collect(a)
-    @test isordered(x) === ordered
-    @test levels(x) == unique(a)
-    @test size(x) === (4,)
-    @test length(x) === 4
-    @test leveltype(x) === Float64
-    @test catvaluetype(x) <: CategoricalArrays.CategoricalValue{Float64}
+        @test x == collect(a)
+        @test isordered(x) === ordered
+        @test levels(x) == unique(a)
+        @test size(x) === (4,)
+        @test length(x) === 4
+        @test leveltype(x) === Float64
+        @test catvaluetype(x) <: CategoricalArrays.CategoricalValue{Float64}
 
-    @test convert(CategoricalArray, x) === x
-    @test convert(CategoricalArray{Float64}, x) === x
-    @test convert(CategoricalArray{Float64, 1}, x) === x
-    @test convert(CategoricalArray{Float64, 1, R}, x) === x
-    @test convert(CategoricalArray{Float64, 1, DefaultRefType}, x) == x
-    @test convert(CategoricalArray{Float64, 1, UInt8}, x) == x
+        @test convert(CategoricalArray, x) === x
+        @test convert(CategoricalArray{Float64}, x) === x
+        @test convert(CategoricalArray{Float64, 1}, x) === x
+        @test convert(CategoricalArray{Float64, 1, R}, x) === x
+        @test convert(CategoricalArray{Float64, 1, DefaultRefType}, x) == x
+        @test convert(CategoricalArray{Float64, 1, UInt8}, x) == x
 
-    @test convert(CategoricalVector, x) === x
-    @test convert(CategoricalVector{Float64}, x) === x
-    @test convert(CategoricalVector{Float64, R}, x) === x
-    @test convert(CategoricalVector{Float64, DefaultRefType}, x) == x
-    @test convert(CategoricalVector{Float64, UInt8}, x) == x
+        @test convert(CategoricalVector, x) === x
+        @test convert(CategoricalVector{Float64}, x) === x
+        @test convert(CategoricalVector{Float64, R}, x) === x
+        @test convert(CategoricalVector{Float64, DefaultRefType}, x) == x
+        @test convert(CategoricalVector{Float64, UInt8}, x) == x
 
-    @test convert(CategoricalArray, a) == x
-    @test convert(CategoricalArray{Float64}, a) == x
-    @test convert(CategoricalArray{Float32}, a) == x
-    @test convert(CategoricalArray{Float64, 1}, a) == x
-    @test convert(CategoricalArray{Float32, 1}, a) == x
-    @test convert(CategoricalArray{Float64, 1, R}, a) == x
-    @test convert(CategoricalArray{Float32, 1, R}, a) == x
-    @test convert(CategoricalArray{Float64, 1, DefaultRefType}, a) == x
-    @test convert(CategoricalArray{Float32, 1, DefaultRefType}, a) == x
-    @test convert(CategoricalArray{Float64, 1, UInt8}, a) == x
-    @test convert(CategoricalArray{Float32, 1, UInt8}, a) == x
+        @test convert(CategoricalArray, a) == x
+        @test convert(CategoricalArray{Float64}, a) == x
+        @test convert(CategoricalArray{Float32}, a) == x
+        @test convert(CategoricalArray{Float64, 1}, a) == x
+        @test convert(CategoricalArray{Float32, 1}, a) == x
+        @test convert(CategoricalArray{Float64, 1, R}, a) == x
+        @test convert(CategoricalArray{Float32, 1, R}, a) == x
+        @test convert(CategoricalArray{Float64, 1, DefaultRefType}, a) == x
+        @test convert(CategoricalArray{Float32, 1, DefaultRefType}, a) == x
+        @test convert(CategoricalArray{Float64, 1, UInt8}, a) == x
+        @test convert(CategoricalArray{Float32, 1, UInt8}, a) == x
 
-    @test convert(CategoricalVector, a) == x
-    @test convert(CategoricalVector{Float64}, a) == x
-    @test convert(CategoricalVector{Float32}, a) == x
-    @test convert(CategoricalVector{Float64, R}, a) == x
-    @test convert(CategoricalVector{Float32, R}, a) == x
-    @test convert(CategoricalVector{Float64, DefaultRefType}, a) == x
-    @test convert(CategoricalVector{Float32, DefaultRefType}, a) == x
-    @test convert(CategoricalVector{Float64, UInt8}, a) == x
-    @test convert(CategoricalVector{Float32, UInt8}, a) == x
+        @test convert(CategoricalVector, a) == x
+        @test convert(CategoricalVector{Float64}, a) == x
+        @test convert(CategoricalVector{Float32}, a) == x
+        @test convert(CategoricalVector{Float64, R}, a) == x
+        @test convert(CategoricalVector{Float32, R}, a) == x
+        @test convert(CategoricalVector{Float64, DefaultRefType}, a) == x
+        @test convert(CategoricalVector{Float32, DefaultRefType}, a) == x
+        @test convert(CategoricalVector{Float64, UInt8}, a) == x
+        @test convert(CategoricalVector{Float32, UInt8}, a) == x
 
-    @test CategoricalArray{Float64}(a, ordered=ordered) == x
-    @test CategoricalArray{Float32}(a, ordered=ordered) == x
-    @test CategoricalArray{Float64, 1}(a, ordered=ordered) == x
-    @test CategoricalArray{Float32, 1}(a, ordered=ordered) == x
-    @test CategoricalArray{Float64, 1, R}(a, ordered=ordered) == x
-    @test CategoricalArray{Float32, 1, R}(a, ordered=ordered) == x
-    @test CategoricalArray{Float64, 1, DefaultRefType}(a, ordered=ordered) == x
-    @test CategoricalArray{Float32, 1, DefaultRefType}(a, ordered=ordered) == x
+        @test CategoricalArray{Float64}(a, ordered=ordered) == x
+        @test CategoricalArray{Float32}(a, ordered=ordered) == x
+        @test CategoricalArray{Float64, 1}(a, ordered=ordered) == x
+        @test CategoricalArray{Float32, 1}(a, ordered=ordered) == x
+        @test CategoricalArray{Float64, 1, R}(a, ordered=ordered) == x
+        @test CategoricalArray{Float32, 1, R}(a, ordered=ordered) == x
+        @test CategoricalArray{Float64, 1, DefaultRefType}(a, ordered=ordered) == x
+        @test CategoricalArray{Float32, 1, DefaultRefType}(a, ordered=ordered) == x
 
-    @test CategoricalVector(a, ordered=ordered) == x
-    @test CategoricalVector{Float64}(a, ordered=ordered) == x
-    @test CategoricalVector{Float32}(a, ordered=ordered) == x
-    @test CategoricalVector{Float64, R}(a, ordered=ordered) == x
-    @test CategoricalVector{Float32, R}(a, ordered=ordered) == x
-    @test CategoricalVector{Float64, DefaultRefType}(a, ordered=ordered) == x
-    @test CategoricalVector{Float32, DefaultRefType}(a, ordered=ordered) == x
+        @test CategoricalVector(a, ordered=ordered) == x
+        @test CategoricalVector{Float64}(a, ordered=ordered) == x
+        @test CategoricalVector{Float32}(a, ordered=ordered) == x
+        @test CategoricalVector{Float64, R}(a, ordered=ordered) == x
+        @test CategoricalVector{Float32, R}(a, ordered=ordered) == x
+        @test CategoricalVector{Float64, DefaultRefType}(a, ordered=ordered) == x
+        @test CategoricalVector{Float32, DefaultRefType}(a, ordered=ordered) == x
 
-    @testset "categorical($(typeof(y)), compress=$comp) R1=$R1 R2=$R2" for (y, R1, R2, comp) in
-        ((a, DefaultRefType, UInt8, true),
-         (a, DefaultRefType, DefaultRefType, false),
-         (x, R, UInt8, true),
-         (x, R, R, false))
+        @testset "categorical($(typeof(y)), compress=$comp) R1=$R1 R2=$R2" for (y, R1, R2, comp) in
+            ((a, DefaultRefType, UInt8, true),
+             (a, DefaultRefType, DefaultRefType, false),
+             (x, R, UInt8, true),
+             (x, R, R, false))
 
-        x2 = categorical(y, ordered=ordered)
+            x2 = categorical(y, ordered=ordered)
+            @test x2 == x
+            @test isa(x2, CategoricalVector{Float64, R1})
+            @test isordered(x2) === ordered
+            @test leveltype(x2) === Float64
+            @test catvaluetype(x2) === CategoricalArrays.CategoricalValue{Float64, R1}
+
+            x2 = categorical(y, comp, ordered=ordered)
+            @test x2 == x
+            @test isa(x2, CategoricalVector{Float64, R2})
+            @test isordered(x2) === ordered
+            @test leveltype(x2) === Float64
+            @test catvaluetype(x2) === CategoricalArrays.CategoricalValue{Float64, R2}
+        end
+
+        x2 = copy(x)
         @test x2 == x
-        @test isa(x2, CategoricalVector{Float64, R1})
-        @test isordered(x2) === ordered
-        @test leveltype(x2) === Float64
-        @test catvaluetype(x2) === CategoricalArrays.CategoricalValue{Float64, R1}
+        @test typeof(x2) === typeof(x)
+        @test isordered(x2) === isordered(x)
+        @test levels(x2) == levels(x)
 
-        x2 = categorical(y, comp, ordered=ordered)
+        @test x[1] === x.pool.valindex[1]
+        @test x[2] === x.pool.valindex[2]
+        @test x[3] === x.pool.valindex[3]
+        @test x[4] === x.pool.valindex[4]
+        @test_throws BoundsError x[5]
+
+        x2 = x[:]
+        @test typeof(x2) === typeof(x)
         @test x2 == x
-        @test isa(x2, CategoricalVector{Float64, R2})
-        @test isordered(x2) === ordered
-        @test leveltype(x2) === Float64
-        @test catvaluetype(x2) === CategoricalArrays.CategoricalValue{Float64, R2}
+        @test levels(x2) == levels(x)
+        @test levels(x2) !== levels(x)
+        @test isordered(x2) == isordered(x)
+
+        x2 = x[1:2]
+        @test typeof(x2) === typeof(x)
+        @test x2 == [0.0, 0.5]
+        @test levels(x2) == levels(x)
+        @test levels(x2) !== levels(x)
+        @test isordered(x2) == isordered(x)
+
+        x2 = x[1:1]
+        @test typeof(x2) === typeof(x)
+        @test x2 == [0.0]
+        @test levels(x2) == levels(x)
+        @test levels(x2) !== levels(x)
+        @test isordered(x2) == isordered(x)
+
+        x2 = x[2:1]
+        @test typeof(x2) === typeof(x)
+        @test isempty(x2)
+        @test levels(x2) == levels(x)
+        @test levels(x2) !== levels(x)
+        @test isordered(x2) == isordered(x)
+
+        x[2] = 1
+        @test x[1] === x.pool.valindex[1]
+        @test x[2] === x.pool.valindex[3]
+        @test x[3] === x.pool.valindex[3]
+        @test x[4] === x.pool.valindex[4]
+        @test levels(x) == unique(a)
+
+        x[1:2] = -1
+        @test x[1] === x.pool.valindex[5]
+        @test x[2] === x.pool.valindex[5]
+        @test x[3] === x.pool.valindex[3]
+        @test x[4] === x.pool.valindex[4]
+        @test levels(x) == vcat(unique(a), -1)
+
+        push!(x, 2.0)
+        @test length(x) == 5
+        @test x[end] == 2.0
+        @test isordered(x) === ordered
+        @test levels(x) == [0.0,  0.5,  1.0,  1.5, -1.0,  2.0]
+
+        push!(x, x[1])
+        @test length(x) == 6
+        @test x[1] == x[end]
+        @test isordered(x) === ordered
+        @test levels(x) == [0.0,  0.5,  1.0,  1.5, -1.0,  2.0]
+
+        append!(x, x)
+        @test length(x) == 12
+        @test x == [-1.0, -1.0, 1.0, 1.5, 2.0, -1.0, -1.0, -1.0, 1.0, 1.5, 2.0, -1.0]
+        @test isordered(x) === ordered
+        @test levels(x) == [0.0,  0.5,  1.0,  1.5, -1.0,  2.0]
+
+        b = [2.5, 3.0, -3.5]
+        y = CategoricalVector{Float64, R}(b, ordered=ordered)
+        append!(x, y)
+        @test length(x) == 15
+        @test x == [-1.0, -1.0, 1.0, 1.5, 2.0, -1.0, -1.0, -1.0, 1.0, 1.5, 2.0, -1.0, 2.5, 3.0, -3.5]
+        @test isordered(x) === ordered
+        @test levels(x) == [0.0, 0.5, 1.0, 1.5, -1.0, 2.0, -3.5, 2.5, 3.0]
+
+        empty!(x)
+        @test length(x) == 0
+        @test isordered(x) === ordered
+        @test levels(x) == [0.0, 0.5, 1.0, 1.5, -1.0, 2.0, -3.5, 2.5, 3.0]
     end
 
-    x2 = copy(x)
-    @test x2 == x
-    @test typeof(x2) === typeof(x)
-    @test isordered(x2) === isordered(x)
-    @test levels(x2) == levels(x)
+    @testset "Matrix"
+        a = ["a" "b" "c"; "b" "a" "c"]
+        x = CategoricalMatrix{String, R}(a, ordered=ordered)
 
-    @test x[1] === x.pool.valindex[1]
-    @test x[2] === x.pool.valindex[2]
-    @test x[3] === x.pool.valindex[3]
-    @test x[4] === x.pool.valindex[4]
-    @test_throws BoundsError x[5]
+        @test x == a
+        @test isordered(x) === ordered
+        @test levels(x) == unique(a)
+        @test size(x) === (2, 3)
+        @test length(x) === 6
 
-    x2 = x[:]
-    @test typeof(x2) === typeof(x)
-    @test x2 == x
-    @test levels(x2) == levels(x)
-    @test levels(x2) !== levels(x)
-    @test isordered(x2) == isordered(x)
+        @test convert(CategoricalArray, x) === x
+        @test convert(CategoricalArray{String}, x) === x
+        @test convert(CategoricalArray{String, 2}, x) === x
+        @test convert(CategoricalArray{String, 2, R}, x) === x
+        @test convert(CategoricalArray{String, 2, DefaultRefType}, x) == x
+        @test convert(CategoricalArray{String, 2, UInt8}, x) == x
 
-    x2 = x[1:2]
-    @test typeof(x2) === typeof(x)
-    @test x2 == [0.0, 0.5]
-    @test levels(x2) == levels(x)
-    @test levels(x2) !== levels(x)
-    @test isordered(x2) == isordered(x)
+        @test convert(CategoricalMatrix, x) === x
+        @test convert(CategoricalMatrix{String}, x) === x
+        @test convert(CategoricalMatrix{String, R}, x) === x
+        @test convert(CategoricalMatrix{String, DefaultRefType}, x) == x
+        @test convert(CategoricalMatrix{String, UInt8}, x) == x
 
-    x2 = x[1:1]
-    @test typeof(x2) === typeof(x)
-    @test x2 == [0.0]
-    @test levels(x2) == levels(x)
-    @test levels(x2) !== levels(x)
-    @test isordered(x2) == isordered(x)
+        @test convert(CategoricalArray, a) == x
+        @test convert(CategoricalArray{String}, a) == x
+        @test convert(CategoricalArray{String, 2, R}, a) == x
+        @test convert(CategoricalArray{String, 2, DefaultRefType}, a) == x
+        @test convert(CategoricalArray{String, 2, UInt8}, a) == x
 
-    x2 = x[2:1]
-    @test typeof(x2) === typeof(x)
-    @test isempty(x2)
-    @test levels(x2) == levels(x)
-    @test levels(x2) !== levels(x)
-    @test isordered(x2) == isordered(x)
+        @test convert(CategoricalMatrix, a) == x
+        @test convert(CategoricalMatrix{String}, a) == x
+        @test convert(CategoricalMatrix{String, R}, a) == x
+        @test convert(CategoricalMatrix{String, DefaultRefType}, a) == x
+        @test convert(CategoricalMatrix{String, UInt8}, a) == x
 
-    x[2] = 1
-    @test x[1] === x.pool.valindex[1]
-    @test x[2] === x.pool.valindex[3]
-    @test x[3] === x.pool.valindex[3]
-    @test x[4] === x.pool.valindex[4]
-    @test levels(x) == unique(a)
+        @test CategoricalArray{String}(a, ordered=ordered) == x
+        @test CategoricalArray{String, 2}(a, ordered=ordered) == x
+        @test CategoricalArray{String, 2}(a, ordered=ordered) == x
+        @test CategoricalArray{String, 2, R}(a, ordered=ordered) == x
+        @test CategoricalArray{String, 2, DefaultRefType}(a, ordered=ordered) == x
+        @test CategoricalArray{String, 2, UInt8}(a, ordered=ordered) == x
 
-    x[1:2] = -1
-    @test x[1] === x.pool.valindex[5]
-    @test x[2] === x.pool.valindex[5]
-    @test x[3] === x.pool.valindex[3]
-    @test x[4] === x.pool.valindex[4]
-    @test levels(x) == vcat(unique(a), -1)
+        @test CategoricalMatrix(a, ordered=ordered) == x
+        @test CategoricalMatrix{String}(a, ordered=ordered) == x
+        @test CategoricalMatrix{String, R}(a, ordered=ordered) == x
+        @test CategoricalMatrix{String, DefaultRefType}(a, ordered=ordered) == x
+        @test CategoricalMatrix{String, UInt8}(a, ordered=ordered) == x
 
-    push!(x, 2.0)
-    @test length(x) == 5
-    @test x[end] == 2.0
-    @test isordered(x) === ordered
-    @test levels(x) == [0.0,  0.5,  1.0,  1.5, -1.0,  2.0]
+        @testset "categorical($(typeof(y)), compress=$comp) R1=$R1 R2=$R2" for (y, R1, R2, comp) in
+            ((a, DefaultRefType, UInt8, true),
+             (a, DefaultRefType, DefaultRefType, false),
+             (x, R, UInt8, true),
+             (x, R, R, false))
 
-    push!(x, x[1])
-    @test length(x) == 6
-    @test x[1] == x[end]
-    @test isordered(x) === ordered
-    @test levels(x) == [0.0,  0.5,  1.0,  1.5, -1.0,  2.0]
+            x2 = categorical(y, ordered=ordered)
+            @test x2 == x
+            @test isa(x2, CategoricalMatrix{String, R1})
+            @test isordered(x2) === ordered
 
-    append!(x, x)
-    @test length(x) == 12
-    @test x == [-1.0, -1.0, 1.0, 1.5, 2.0, -1.0, -1.0, -1.0, 1.0, 1.5, 2.0, -1.0]
-    @test isordered(x) === ordered
-    @test levels(x) == [0.0,  0.5,  1.0,  1.5, -1.0,  2.0]
+            x2 = categorical(y, comp, ordered=ordered)
+            @test x2 == x
+            @test isa(x2, CategoricalMatrix{String, R2})
+            @test isordered(x2) === ordered
+        end
 
-    b = [2.5, 3.0, -3.5]
-    y = CategoricalVector{Float64, R}(b, ordered=ordered)
-    append!(x, y)
-    @test length(x) == 15
-    @test x == [-1.0, -1.0, 1.0, 1.5, 2.0, -1.0, -1.0, -1.0, 1.0, 1.5, 2.0, -1.0, 2.5, 3.0, -3.5]
-    @test isordered(x) === ordered
-    @test levels(x) == [0.0, 0.5, 1.0, 1.5, -1.0, 2.0, -3.5, 2.5, 3.0]
-
-    empty!(x)
-    @test length(x) == 0
-    @test isordered(x) === ordered
-    @test levels(x) == [0.0, 0.5, 1.0, 1.5, -1.0, 2.0, -3.5, 2.5, 3.0]
-
-    # Matrix
-    a = ["a" "b" "c"; "b" "a" "c"]
-    x = CategoricalMatrix{String, R}(a, ordered=ordered)
-
-    @test x == a
-    @test isordered(x) === ordered
-    @test levels(x) == unique(a)
-    @test size(x) === (2, 3)
-    @test length(x) === 6
-
-    @test convert(CategoricalArray, x) === x
-    @test convert(CategoricalArray{String}, x) === x
-    @test convert(CategoricalArray{String, 2}, x) === x
-    @test convert(CategoricalArray{String, 2, R}, x) === x
-    @test convert(CategoricalArray{String, 2, DefaultRefType}, x) == x
-    @test convert(CategoricalArray{String, 2, UInt8}, x) == x
-
-    @test convert(CategoricalMatrix, x) === x
-    @test convert(CategoricalMatrix{String}, x) === x
-    @test convert(CategoricalMatrix{String, R}, x) === x
-    @test convert(CategoricalMatrix{String, DefaultRefType}, x) == x
-    @test convert(CategoricalMatrix{String, UInt8}, x) == x
-
-    @test convert(CategoricalArray, a) == x
-    @test convert(CategoricalArray{String}, a) == x
-    @test convert(CategoricalArray{String, 2, R}, a) == x
-    @test convert(CategoricalArray{String, 2, DefaultRefType}, a) == x
-    @test convert(CategoricalArray{String, 2, UInt8}, a) == x
-
-    @test convert(CategoricalMatrix, a) == x
-    @test convert(CategoricalMatrix{String}, a) == x
-    @test convert(CategoricalMatrix{String, R}, a) == x
-    @test convert(CategoricalMatrix{String, DefaultRefType}, a) == x
-    @test convert(CategoricalMatrix{String, UInt8}, a) == x
-
-    @test CategoricalArray{String}(a, ordered=ordered) == x
-    @test CategoricalArray{String, 2}(a, ordered=ordered) == x
-    @test CategoricalArray{String, 2}(a, ordered=ordered) == x
-    @test CategoricalArray{String, 2, R}(a, ordered=ordered) == x
-    @test CategoricalArray{String, 2, DefaultRefType}(a, ordered=ordered) == x
-    @test CategoricalArray{String, 2, UInt8}(a, ordered=ordered) == x
-
-    @test CategoricalMatrix(a, ordered=ordered) == x
-    @test CategoricalMatrix{String}(a, ordered=ordered) == x
-    @test CategoricalMatrix{String, R}(a, ordered=ordered) == x
-    @test CategoricalMatrix{String, DefaultRefType}(a, ordered=ordered) == x
-    @test CategoricalMatrix{String, UInt8}(a, ordered=ordered) == x
-
-    @testset "categorical($(typeof(y)), compress=$comp) R1=$R1 R2=$R2" for (y, R1, R2, comp) in
-        ((a, DefaultRefType, UInt8, true),
-         (a, DefaultRefType, DefaultRefType, false),
-         (x, R, UInt8, true),
-         (x, R, R, false))
-
-        x2 = categorical(y, ordered=ordered)
+        x2 = compress(x)
         @test x2 == x
-        @test isa(x2, CategoricalMatrix{String, R1})
-        @test isordered(x2) === ordered
+        @test isa(x2, CategoricalMatrix{String, UInt8})
+        @test isordered(x2) === isordered(x)
+        @test levels(x2) == levels(x)
 
-        x2 = categorical(y, comp, ordered=ordered)
+        x2 = copy(x)
         @test x2 == x
-        @test isa(x2, CategoricalMatrix{String, R2})
-        @test isordered(x2) === ordered
+        @test typeof(x2) === typeof(x)
+        @test isordered(x2) === isordered(x)
+        @test levels(x2) == levels(x)
+
+        @test x[1] === x.pool.valindex[1]
+        @test x[2] === x.pool.valindex[2]
+        @test x[3] === x.pool.valindex[2]
+        @test x[4] === x.pool.valindex[1]
+        @test x[5] === x.pool.valindex[3]
+        @test x[6] === x.pool.valindex[3]
+        @test_throws BoundsError x[7]
+
+        @test x[1,1] === x.pool.valindex[1]
+        @test x[2,1] === x.pool.valindex[2]
+        @test x[1,2] === x.pool.valindex[2]
+        @test x[2,2] === x.pool.valindex[1]
+        @test x[1,3] === x.pool.valindex[3]
+        @test x[2,3] === x.pool.valindex[3]
+        @test_throws BoundsError x[1,4]
+        @test_throws BoundsError x[4,1]
+        @test_throws BoundsError x[4,4]
+
+        x2 = x[1:2,:]
+        @test typeof(x2) === typeof(x)
+        @test x2 == x
+        @test levels(x2) == levels(x)
+        @test levels(x2) !== levels(x)
+        @test isordered(x2) == isordered(x)
+
+        x2 = x[:,[1, 3]]
+        @test typeof(x2) === typeof(x)
+        @test x2 == ["a" "c"; "b" "c"]
+        @test levels(x2) == levels(x)
+        @test levels(x2) !== levels(x)
+        @test isordered(x2) == isordered(x)
+
+        x2 = x[1:1,2]
+        @test isa(x2, CategoricalVector{String, R})
+        @test x2 == ["b"]
+        @test levels(x2) == levels(x)
+        @test levels(x2) !== levels(x)
+        @test isordered(x2) == isordered(x)
+
+        x2 = x[1:0,:]
+        @test typeof(x2) === typeof(x)
+        @test size(x2) == (0,3)
+        @test levels(x2) == levels(x)
+        @test levels(x2) !== levels(x)
+        @test isordered(x2) == isordered(x)
+
+        @test_throws BoundsError x[1:4, :]
+        @test_throws BoundsError x[1:1, -1:1]
+        @test_throws BoundsError x[4, :]
+
+        x[1] = "z"
+        @test x[1] === x.pool.valindex[4]
+        @test x[2] === x.pool.valindex[2]
+        @test x[3] === x.pool.valindex[2]
+        @test x[4] === x.pool.valindex[1]
+        @test x[5] === x.pool.valindex[3]
+        @test x[6] === x.pool.valindex[3]
+        @test levels(x) == ["a", "b", "c", "z"]
+
+        x[1,:] = "a"
+        @test x[1] === x.pool.valindex[1]
+        @test x[2] === x.pool.valindex[2]
+        @test x[3] === x.pool.valindex[1]
+        @test x[4] === x.pool.valindex[1]
+        @test x[5] === x.pool.valindex[1]
+        @test x[6] === x.pool.valindex[3]
+        @test levels(x) == ["a", "b", "c", "z"]
+
+        x[1,1:2] = "z"
+        @test x[1] === x.pool.valindex[4]
+        @test x[2] === x.pool.valindex[2]
+        @test x[3] === x.pool.valindex[4]
+        @test x[4] === x.pool.valindex[1]
+        @test x[5] === x.pool.valindex[1]
+        @test x[6] === x.pool.valindex[3]
+        @test levels(x) == ["a", "b", "c", "z"]
+
+        x[1,2] = "b"
+        @test x[1] === x.pool.valindex[4]
+        @test x[2] === x.pool.valindex[2]
+        @test x[3] === x.pool.valindex[2]
+        @test x[4] === x.pool.valindex[1]
+        @test x[5] === x.pool.valindex[1]
+        @test x[6] === x.pool.valindex[3]
+        @test levels(x) == ["a", "b", "c", "z"]
     end
-
-    x2 = compress(x)
-    @test x2 == x
-    @test isa(x2, CategoricalMatrix{String, UInt8})
-    @test isordered(x2) === isordered(x)
-    @test levels(x2) == levels(x)
-
-    x2 = copy(x)
-    @test x2 == x
-    @test typeof(x2) === typeof(x)
-    @test isordered(x2) === isordered(x)
-    @test levels(x2) == levels(x)
-
-    @test x[1] === x.pool.valindex[1]
-    @test x[2] === x.pool.valindex[2]
-    @test x[3] === x.pool.valindex[2]
-    @test x[4] === x.pool.valindex[1]
-    @test x[5] === x.pool.valindex[3]
-    @test x[6] === x.pool.valindex[3]
-    @test_throws BoundsError x[7]
-
-    @test x[1,1] === x.pool.valindex[1]
-    @test x[2,1] === x.pool.valindex[2]
-    @test x[1,2] === x.pool.valindex[2]
-    @test x[2,2] === x.pool.valindex[1]
-    @test x[1,3] === x.pool.valindex[3]
-    @test x[2,3] === x.pool.valindex[3]
-    @test_throws BoundsError x[1,4]
-    @test_throws BoundsError x[4,1]
-    @test_throws BoundsError x[4,4]
-
-    x2 = x[1:2,:]
-    @test typeof(x2) === typeof(x)
-    @test x2 == x
-    @test levels(x2) == levels(x)
-    @test levels(x2) !== levels(x)
-    @test isordered(x2) == isordered(x)
-
-    x2 = x[:,[1, 3]]
-    @test typeof(x2) === typeof(x)
-    @test x2 == ["a" "c"; "b" "c"]
-    @test levels(x2) == levels(x)
-    @test levels(x2) !== levels(x)
-    @test isordered(x2) == isordered(x)
-
-    x2 = x[1:1,2]
-    @test isa(x2, CategoricalVector{String, R})
-    @test x2 == ["b"]
-    @test levels(x2) == levels(x)
-    @test levels(x2) !== levels(x)
-    @test isordered(x2) == isordered(x)
-
-    x2 = x[1:0,:]
-    @test typeof(x2) === typeof(x)
-    @test size(x2) == (0,3)
-    @test levels(x2) == levels(x)
-    @test levels(x2) !== levels(x)
-    @test isordered(x2) == isordered(x)
-
-    @test_throws BoundsError x[1:4, :]
-    @test_throws BoundsError x[1:1, -1:1]
-    @test_throws BoundsError x[4, :]
-
-    x[1] = "z"
-    @test x[1] === x.pool.valindex[4]
-    @test x[2] === x.pool.valindex[2]
-    @test x[3] === x.pool.valindex[2]
-    @test x[4] === x.pool.valindex[1]
-    @test x[5] === x.pool.valindex[3]
-    @test x[6] === x.pool.valindex[3]
-    @test levels(x) == ["a", "b", "c", "z"]
-
-    x[1,:] = "a"
-    @test x[1] === x.pool.valindex[1]
-    @test x[2] === x.pool.valindex[2]
-    @test x[3] === x.pool.valindex[1]
-    @test x[4] === x.pool.valindex[1]
-    @test x[5] === x.pool.valindex[1]
-    @test x[6] === x.pool.valindex[3]
-    @test levels(x) == ["a", "b", "c", "z"]
-
-    x[1,1:2] = "z"
-    @test x[1] === x.pool.valindex[4]
-    @test x[2] === x.pool.valindex[2]
-    @test x[3] === x.pool.valindex[4]
-    @test x[4] === x.pool.valindex[1]
-    @test x[5] === x.pool.valindex[1]
-    @test x[6] === x.pool.valindex[3]
-    @test levels(x) == ["a", "b", "c", "z"]
-
-    x[1,2] = "b"
-    @test x[1] === x.pool.valindex[4]
-    @test x[2] === x.pool.valindex[2]
-    @test x[3] === x.pool.valindex[2]
-    @test x[4] === x.pool.valindex[1]
-    @test x[5] === x.pool.valindex[1]
-    @test x[6] === x.pool.valindex[3]
-    @test levels(x) == ["a", "b", "c", "z"]
-
 
     # Uninitialized array
     v = Any[CategoricalArray(2, ordered=ordered),

--- a/test/11_array.jl
+++ b/test/11_array.jl
@@ -389,7 +389,7 @@ using CategoricalArrays: DefaultRefType, catvaluetype, leveltype
         @test levels(x) == [0.0, 0.5, 1.0, 1.5, -1.0, 2.0, -3.5, 2.5, 3.0]
     end
 
-    @testset "Matrix"
+    @testset "Matrix" begin
         a = ["a" "b" "c"; "b" "a" "c"]
         x = CategoricalMatrix{String, R}(a, ordered=ordered)
 

--- a/test/12_nullablearray.jl
+++ b/test/12_nullablearray.jl
@@ -8,237 +8,239 @@ const ≅ = isequal
 @testset "conversion ordered=$ordered" for ordered in (false, true)
     @testset "conversion reftype=$R" for R in (CategoricalArrays.DefaultRefType, UInt8, UInt, Int8, Int)
         @testset "conversion of $(typeof(a))" for a in (["b", "a", "b"], Union{String, Null}["b", "a", "b"])
-            x = CategoricalVector{Union{String, Null}, R}(a, ordered=ordered)
+            @testset "Vector with no null values" begin
+                x = CategoricalVector{Union{String, Null}, R}(a, ordered=ordered)
 
-            @test x == a
-            @test leveltype(typeof(x)) === String
-            @test leveltype(x) === String
-            @test catvaluetype(typeof(x)) === CategoricalArrays.CategoricalString{R}
-            @test catvaluetype(x) === CategoricalArrays.CategoricalString{R}
-            @test isordered(x) === ordered
-            @test levels(x) == sort(unique(a))
-            @test size(x) === (3,)
-            @test length(x) === 3
+                @test x == a
+                @test leveltype(typeof(x)) === String
+                @test leveltype(x) === String
+                @test catvaluetype(typeof(x)) === CategoricalArrays.CategoricalString{R}
+                @test catvaluetype(x) === CategoricalArrays.CategoricalString{R}
+                @test isordered(x) === ordered
+                @test levels(x) == sort(unique(a))
+                @test size(x) === (3,)
+                @test length(x) === 3
 
-            @test convert(CategoricalArray, x) === x
-            @test convert(CategoricalArray{Union{String, Null}}, x) === x
-            @test convert(CategoricalArray{Union{String, Null}, 1}, x) === x
-            @test convert(CategoricalArray{Union{String, Null}, 1, R}, x) === x
-            @test convert(CategoricalArray{Union{String, Null}, 1, DefaultRefType}, x) == x
-            @test convert(CategoricalArray{Union{String, Null}, 1, UInt8}, x) == x
+                @test convert(CategoricalArray, x) === x
+                @test convert(CategoricalArray{Union{String, Null}}, x) === x
+                @test convert(CategoricalArray{Union{String, Null}, 1}, x) === x
+                @test convert(CategoricalArray{Union{String, Null}, 1, R}, x) === x
+                @test convert(CategoricalArray{Union{String, Null}, 1, DefaultRefType}, x) == x
+                @test convert(CategoricalArray{Union{String, Null}, 1, UInt8}, x) == x
 
-            @test convert(CategoricalVector, x) === x
-            @test convert(CategoricalVector{Union{String, Null}}, x) === x
-            @test convert(CategoricalVector{Union{String, Null}, R}, x) === x
-            @test convert(CategoricalVector{Union{String, Null}, DefaultRefType}, x) == x
-            @test convert(CategoricalVector{Union{String, Null}, UInt8}, x) == x
+                @test convert(CategoricalVector, x) === x
+                @test convert(CategoricalVector{Union{String, Null}}, x) === x
+                @test convert(CategoricalVector{Union{String, Null}, R}, x) === x
+                @test convert(CategoricalVector{Union{String, Null}, DefaultRefType}, x) == x
+                @test convert(CategoricalVector{Union{String, Null}, UInt8}, x) == x
 
-            @test convert(CategoricalArray, a) == x
-            @test convert(CategoricalArray{Union{String, Null}}, a) == x
-            @test convert(CategoricalArray{Union{String, Null}, 1}, a) == x
-            @test convert(CategoricalArray{Union{String, Null}, 1, R}, a) == x
-            @test convert(CategoricalArray{Union{String, Null}, 1, DefaultRefType}, a) == x
-            @test convert(CategoricalArray{Union{String, Null}, 1, UInt8}, a) == x
+                @test convert(CategoricalArray, a) == x
+                @test convert(CategoricalArray{Union{String, Null}}, a) == x
+                @test convert(CategoricalArray{Union{String, Null}, 1}, a) == x
+                @test convert(CategoricalArray{Union{String, Null}, 1, R}, a) == x
+                @test convert(CategoricalArray{Union{String, Null}, 1, DefaultRefType}, a) == x
+                @test convert(CategoricalArray{Union{String, Null}, 1, UInt8}, a) == x
 
-            @test convert(CategoricalVector, a) == x
-            @test convert(CategoricalVector{Union{String, Null}}, a) == x
-            @test convert(CategoricalVector{Union{String, Null}, R}, a) == x
-            @test convert(CategoricalVector{Union{String, Null}, DefaultRefType}, a) == x
-            @test convert(CategoricalVector{Union{String, Null}, UInt8}, a) == x
+                @test convert(CategoricalVector, a) == x
+                @test convert(CategoricalVector{Union{String, Null}}, a) == x
+                @test convert(CategoricalVector{Union{String, Null}, R}, a) == x
+                @test convert(CategoricalVector{Union{String, Null}, DefaultRefType}, a) == x
+                @test convert(CategoricalVector{Union{String, Null}, UInt8}, a) == x
 
-            @test CategoricalArray{Union{String, Null}}(a, ordered=ordered) == x
-            @test CategoricalArray{Union{String, Null}, 1}(a, ordered=ordered) == x
-            @test CategoricalArray{Union{String, Null}, 1, R}(a, ordered=ordered) == x
-            @test CategoricalArray{Union{String, Null}, 1, DefaultRefType}(a, ordered=ordered) == x
-            @test CategoricalArray{Union{String, Null}, 1, UInt8}(a, ordered=ordered) == x
+                @test CategoricalArray{Union{String, Null}}(a, ordered=ordered) == x
+                @test CategoricalArray{Union{String, Null}, 1}(a, ordered=ordered) == x
+                @test CategoricalArray{Union{String, Null}, 1, R}(a, ordered=ordered) == x
+                @test CategoricalArray{Union{String, Null}, 1, DefaultRefType}(a, ordered=ordered) == x
+                @test CategoricalArray{Union{String, Null}, 1, UInt8}(a, ordered=ordered) == x
 
-            @test CategoricalVector(a, ordered=ordered) == x
-            @test CategoricalVector{Union{String, Null}}(a, ordered=ordered) == x
-            @test CategoricalVector{Union{String, Null}, R}(a, ordered=ordered) == x
-            @test CategoricalVector{Union{String, Null}, DefaultRefType}(a, ordered=ordered) == x
-            @test CategoricalVector{Union{String, Null}, UInt8}(a, ordered=ordered) == x
+                @test CategoricalVector(a, ordered=ordered) == x
+                @test CategoricalVector{Union{String, Null}}(a, ordered=ordered) == x
+                @test CategoricalVector{Union{String, Null}, R}(a, ordered=ordered) == x
+                @test CategoricalVector{Union{String, Null}, DefaultRefType}(a, ordered=ordered) == x
+                @test CategoricalVector{Union{String, Null}, UInt8}(a, ordered=ordered) == x
 
-            @testset "categorical($(typeof(y)), compress=$comp) R1=$R1 R2=$R2" for (y, R1, R2, comp) in
-                ((a, DefaultRefType, UInt8, true),
-                 (a, DefaultRefType, DefaultRefType, false),
-                 (x, R, UInt8, true),
-                 (x, R, R, false))
+                @testset "categorical($(typeof(y)), compress=$comp) R1=$R1 R2=$R2" for (y, R1, R2, comp) in
+                    ((a, DefaultRefType, UInt8, true),
+                     (a, DefaultRefType, DefaultRefType, false),
+                     (x, R, UInt8, true),
+                     (x, R, R, false))
 
-                x2 = categorical(y, ordered=ordered)
-                @test leveltype(x2) === String
-                @test catvaluetype(x2) === CategoricalArrays.CategoricalString{R1}
-                @test x2 == y
-                if eltype(y) >: Null
-                    @test isa(x2, CategoricalVector{Union{String, Null}, R1})
-                else
-                    @test isa(x2, CategoricalVector{String, R1})
+                    x2 = categorical(y, ordered=ordered)
+                    @test leveltype(x2) === String
+                    @test catvaluetype(x2) === CategoricalArrays.CategoricalString{R1}
+                    @test x2 == y
+                    if eltype(y) >: Null
+                        @test isa(x2, CategoricalVector{Union{String, Null}, R1})
+                    else
+                        @test isa(x2, CategoricalVector{String, R1})
+                    end
+                    @test isordered(x2) === ordered
+
+                    x2 = categorical(y, comp, ordered=ordered)
+                    @test x2 == y
+                    @test leveltype(x2) === String
+                    @test catvaluetype(x2) === CategoricalArrays.CategoricalString{R2}
+                    if eltype(y) >: Null
+                        @test isa(x2, CategoricalVector{Union{String, Null}, R2})
+                    else
+                        @test isa(x2, CategoricalVector{String, R2})
+                    end
+                    @test isordered(x2) === ordered
                 end
-                @test isordered(x2) === ordered
 
-                x2 = categorical(y, comp, ordered=ordered)
-                @test x2 == y
-                @test leveltype(x2) === String
-                @test catvaluetype(x2) === CategoricalArrays.CategoricalString{R2}
-                if eltype(y) >: Null
-                    @test isa(x2, CategoricalVector{Union{String, Null}, R2})
-                else
-                    @test isa(x2, CategoricalVector{String, R2})
+                x2 = compress(x)
+                @test x2 == x
+                @test isa(x2, CategoricalVector{Union{String, Null}, UInt8})
+                @test isordered(x2) === isordered(x)
+                @test levels(x2) == levels(x)
+
+                x2 = copy(x)
+                @test x2 == x
+                @test isordered(x2) === isordered(x)
+                @test typeof(x2) === typeof(x)
+                @test levels(x2) == levels(x)
+
+                if !isordered(x)
+                    @test ordered!(x, true) === x
+                    @test isordered(x) === true
                 end
-                @test isordered(x2) === ordered
+                @test x[1] > x[2]
+                @test x[3] > x[2]
+
+                @test ordered!(x, false) === x
+                @test isordered(x) === false
+                @test_throws Exception x[1] > x[2]
+                @test_throws Exception x[3] > x[2]
+
+                @test x[1] === x.pool.valindex[1]
+                @test x[2] === x.pool.valindex[2]
+                @test x[3] === x.pool.valindex[1]
+                @test_throws BoundsError x[4]
+
+                x2 = x[:]
+                @test typeof(x2) === typeof(x)
+                @test x2 == x
+                @test x2 !== x
+                @test levels(x2) == levels(x)
+                @test levels(x2) !== levels(x)
+                @test isordered(x2) == isordered(x)
+
+                x2 = x[2:3]
+                @test typeof(x2) === typeof(x)
+                @test x2 == ["a", "b"]
+                @test levels(x2) == levels(x)
+                @test levels(x2) !== levels(x)
+                @test isordered(x2) == isordered(x)
+
+                x2 = x[1:1]
+                @test typeof(x2) === typeof(x)
+                @test x2 == ["b"]
+                @test levels(x2) == levels(x)
+                @test levels(x2) !== levels(x)
+                @test isordered(x2) == isordered(x)
+
+                x2 = x[2:1]
+                @test typeof(x2) === typeof(x)
+                @test isempty(x2)
+                @test levels(x2) == levels(x)
+                @test levels(x2) !== levels(x)
+                @test isordered(x2) == isordered(x)
+
+                x[1] = x[2]
+                @test x[1] === x.pool.valindex[2]
+                @test x[2] === x.pool.valindex[2]
+                @test x[3] === x.pool.valindex[1]
+
+                x[3] = "c"
+                @test x[1] === x.pool.valindex[2]
+                @test x[2] === x.pool.valindex[2]
+                @test x[3] === x.pool.valindex[3]
+                @test levels(x) == ["a", "b", "c"]
+
+                x[2:3] = "b"
+                @test x[1] === x.pool.valindex[2]
+                @test x[2] === x.pool.valindex[1]
+                @test x[3] === x.pool.valindex[1]
+                @test levels(x) == ["a", "b", "c"]
+
+                @test droplevels!(x) === x
+                @test levels(x) == ["a", "b"]
+                @test x[1] === x.pool.valindex[1]
+                @test x[2] === x.pool.valindex[2]
+                @test x[3] === x.pool.valindex[2]
+                @test levels(x) == ["a", "b"]
+
+                @test levels!(x, ["b", "a"]) === x
+                @test levels(x) == ["b", "a"]
+                @test x[1] === x.pool.valindex[1]
+                @test x[2] === x.pool.valindex[2]
+                @test x[3] === x.pool.valindex[2]
+                @test levels(x) == ["b", "a"]
+
+                @test_throws ArgumentError levels!(x, ["a"])
+                @test_throws ArgumentError levels!(x, ["e", "b"])
+                @test_throws ArgumentError levels!(x, ["e", "a", "b", "a"])
+
+                @test levels!(x, ["e", "a", "b"]) === x
+                @test levels(x) == ["e", "a", "b"]
+                @test x[1] === x.pool.valindex[1]
+                @test x[2] === x.pool.valindex[2]
+                @test x[3] === x.pool.valindex[2]
+                @test levels(x) == ["e", "a", "b"]
+
+                x[1] = "c"
+                @test x[1] === x.pool.valindex[4]
+                @test x[2] === x.pool.valindex[2]
+                @test x[3] === x.pool.valindex[2]
+                @test levels(x) == ["e", "a", "b", "c"]
+
+                @test_throws ArgumentError levels!(x, ["e", "c"])
+                @test levels!(x, ["e", "c"], nullok=true) === x
+                @test levels(x) == ["e", "c"]
+                @test x[1] === x.pool.valindex[2]
+                @test x[2] === null
+                @test x[3] === null
+                @test levels(x) == ["e", "c"]
+
+                push!(x, "e")
+                @test length(x) == 4
+                @test x ≅ ["c", null, null, "e"]
+                @test levels(x) == ["e", "c"]
+
+                push!(x, "zz")
+                @test length(x) == 5
+                @test x ≅ ["c", null, null, "e", "zz"]
+                @test levels(x) == ["e", "c", "zz"]
+
+                push!(x, x[1])
+                @test length(x) == 6
+                @test x ≅ ["c", null, null, "e", "zz", "c"]
+                @test levels(x) == ["e", "c", "zz"]
+
+                push!(x, null)
+                @test length(x) == 7
+                @test x ≅ ["c", null, null, "e", "zz", "c", null]
+                @test levels(x) == ["e", "c", "zz"]
+
+                append!(x, x)
+                @test x ≅ ["c", null, null, "e", "zz", "c", null, "c", null, null, "e", "zz", "c", null]
+                @test levels(x) == ["e", "c", "zz"]
+                @test isordered(x) === false
+                @test length(x) == 14
+
+                b = ["z","y","x"]
+                y = CategoricalVector{Union{String, Null}, R}(b)
+                append!(x, y)
+                @test length(x) == 17
+                @test isordered(x) === false
+                @test levels(x) == ["e", "c", "zz", "x", "y", "z"]
+                @test x ≅ ["c", null, null, "e", "zz", "c", null, "c", null, null, "e", "zz", "c", null, "z", "y", "x"]
+
+                empty!(x)
+                @test isordered(x) === false
+                @test length(x) == 0
+                @test levels(x) == ["e", "c", "zz", "x", "y", "z"]
             end
-
-            x2 = compress(x)
-            @test x2 == x
-            @test isa(x2, CategoricalVector{Union{String, Null}, UInt8})
-            @test isordered(x2) === isordered(x)
-            @test levels(x2) == levels(x)
-
-            x2 = copy(x)
-            @test x2 == x
-            @test isordered(x2) === isordered(x)
-            @test typeof(x2) === typeof(x)
-            @test levels(x2) == levels(x)
-
-            if !isordered(x)
-                @test ordered!(x, true) === x
-                @test isordered(x) === true
-            end
-            @test x[1] > x[2]
-            @test x[3] > x[2]
-
-            @test ordered!(x, false) === x
-            @test isordered(x) === false
-            @test_throws Exception x[1] > x[2]
-            @test_throws Exception x[3] > x[2]
-
-            @test x[1] === x.pool.valindex[1]
-            @test x[2] === x.pool.valindex[2]
-            @test x[3] === x.pool.valindex[1]
-            @test_throws BoundsError x[4]
-
-            x2 = x[:]
-            @test typeof(x2) === typeof(x)
-            @test x2 == x
-            @test x2 !== x
-            @test levels(x2) == levels(x)
-            @test levels(x2) !== levels(x)
-            @test isordered(x2) == isordered(x)
-
-            x2 = x[2:3]
-            @test typeof(x2) === typeof(x)
-            @test x2 == ["a", "b"]
-            @test levels(x2) == levels(x)
-            @test levels(x2) !== levels(x)
-            @test isordered(x2) == isordered(x)
-
-            x2 = x[1:1]
-            @test typeof(x2) === typeof(x)
-            @test x2 == ["b"]
-            @test levels(x2) == levels(x)
-            @test levels(x2) !== levels(x)
-            @test isordered(x2) == isordered(x)
-
-            x2 = x[2:1]
-            @test typeof(x2) === typeof(x)
-            @test isempty(x2)
-            @test levels(x2) == levels(x)
-            @test levels(x2) !== levels(x)
-            @test isordered(x2) == isordered(x)
-
-            x[1] = x[2]
-            @test x[1] === x.pool.valindex[2]
-            @test x[2] === x.pool.valindex[2]
-            @test x[3] === x.pool.valindex[1]
-
-            x[3] = "c"
-            @test x[1] === x.pool.valindex[2]
-            @test x[2] === x.pool.valindex[2]
-            @test x[3] === x.pool.valindex[3]
-            @test levels(x) == ["a", "b", "c"]
-
-            x[2:3] = "b"
-            @test x[1] === x.pool.valindex[2]
-            @test x[2] === x.pool.valindex[1]
-            @test x[3] === x.pool.valindex[1]
-            @test levels(x) == ["a", "b", "c"]
-
-            @test droplevels!(x) === x
-            @test levels(x) == ["a", "b"]
-            @test x[1] === x.pool.valindex[1]
-            @test x[2] === x.pool.valindex[2]
-            @test x[3] === x.pool.valindex[2]
-            @test levels(x) == ["a", "b"]
-
-            @test levels!(x, ["b", "a"]) === x
-            @test levels(x) == ["b", "a"]
-            @test x[1] === x.pool.valindex[1]
-            @test x[2] === x.pool.valindex[2]
-            @test x[3] === x.pool.valindex[2]
-            @test levels(x) == ["b", "a"]
-
-            @test_throws ArgumentError levels!(x, ["a"])
-            @test_throws ArgumentError levels!(x, ["e", "b"])
-            @test_throws ArgumentError levels!(x, ["e", "a", "b", "a"])
-
-            @test levels!(x, ["e", "a", "b"]) === x
-            @test levels(x) == ["e", "a", "b"]
-            @test x[1] === x.pool.valindex[1]
-            @test x[2] === x.pool.valindex[2]
-            @test x[3] === x.pool.valindex[2]
-            @test levels(x) == ["e", "a", "b"]
-
-            x[1] = "c"
-            @test x[1] === x.pool.valindex[4]
-            @test x[2] === x.pool.valindex[2]
-            @test x[3] === x.pool.valindex[2]
-            @test levels(x) == ["e", "a", "b", "c"]
-
-            @test_throws ArgumentError levels!(x, ["e", "c"])
-            @test levels!(x, ["e", "c"], nullok=true) === x
-            @test levels(x) == ["e", "c"]
-            @test x[1] === x.pool.valindex[2]
-            @test x[2] === null
-            @test x[3] === null
-            @test levels(x) == ["e", "c"]
-
-            push!(x, "e")
-            @test length(x) == 4
-            @test x ≅ ["c", null, null, "e"]
-            @test levels(x) == ["e", "c"]
-
-            push!(x, "zz")
-            @test length(x) == 5
-            @test x ≅ ["c", null, null, "e", "zz"]
-            @test levels(x) == ["e", "c", "zz"]
-
-            push!(x, x[1])
-            @test length(x) == 6
-            @test x ≅ ["c", null, null, "e", "zz", "c"]
-            @test levels(x) == ["e", "c", "zz"]
-
-            push!(x, null)
-            @test length(x) == 7
-            @test x ≅ ["c", null, null, "e", "zz", "c", null]
-            @test levels(x) == ["e", "c", "zz"]
-
-            append!(x, x)
-            @test x ≅ ["c", null, null, "e", "zz", "c", null, "c", null, null, "e", "zz", "c", null]
-            @test levels(x) == ["e", "c", "zz"]
-            @test isordered(x) === false
-            @test length(x) == 14
-
-            b = ["z","y","x"]
-            y = CategoricalVector{Union{String, Null}, R}(b)
-            append!(x, y)
-            @test length(x) == 17
-            @test isordered(x) === false
-            @test levels(x) == ["e", "c", "zz", "x", "y", "z"]
-            @test x ≅ ["c", null, null, "e", "zz", "c", null, "c", null, null, "e", "zz", "c", null, "z", "y", "x"]
-
-            empty!(x)
-            @test isordered(x) === false
-            @test length(x) == 0
-            @test levels(x) == ["e", "c", "zz", "x", "y", "z"]
         end
 
         @testset "Vector with null values" begin

--- a/test/12_nullablearray.jl
+++ b/test/12_nullablearray.jl
@@ -382,529 +382,529 @@ const ≅ = isequal
         end
 
         @testset "Vector created from range" begin
-            # (i.e. non-Array AbstractArray),
-            # direct conversion to a vector with different eltype
-            a = 0.0:0.5:1.5
-            x = CategoricalVector{Union{Float64, Null}, R}(a, ordered=ordered)
+        # (i.e. non-Array AbstractArray),
+        # direct conversion to a vector with different eltype
+        a = 0.0:0.5:1.5
+        x = CategoricalVector{Union{Float64, Null}, R}(a, ordered=ordered)
 
-            @test x == collect(a)
-            @test isordered(x) === ordered
-            @test levels(x) == unique(a)
-            @test size(x) === (4,)
-            @test length(x) === 4
-            @test leveltype(x) === Float64
-            @test catvaluetype(x) <: CategoricalArrays.CategoricalValue{Float64}
+        @test x == collect(a)
+        @test isordered(x) === ordered
+        @test levels(x) == unique(a)
+        @test size(x) === (4,)
+        @test length(x) === 4
+        @test leveltype(x) === Float64
+        @test catvaluetype(x) <: CategoricalArrays.CategoricalValue{Float64}
 
-            @test convert(CategoricalArray, x) === x
-            @test convert(CategoricalArray{Union{Float64, Null}}, x) === x
-            @test convert(CategoricalArray{Union{Float64, Null}, 1}, x) === x
-            @test convert(CategoricalArray{Union{Float64, Null}, 1, R}, x) === x
-            @test convert(CategoricalArray{Union{Float64, Null}, 1, DefaultRefType}, x) == x
-            @test convert(CategoricalArray{Union{Float64, Null}, 1, UInt8}, x) == x
+        @test convert(CategoricalArray, x) === x
+        @test convert(CategoricalArray{Union{Float64, Null}}, x) === x
+        @test convert(CategoricalArray{Union{Float64, Null}, 1}, x) === x
+        @test convert(CategoricalArray{Union{Float64, Null}, 1, R}, x) === x
+        @test convert(CategoricalArray{Union{Float64, Null}, 1, DefaultRefType}, x) == x
+        @test convert(CategoricalArray{Union{Float64, Null}, 1, UInt8}, x) == x
 
-            @test convert(CategoricalVector, x) === x
-            @test convert(CategoricalVector{Union{Float64, Null}}, x) === x
-            @test convert(CategoricalVector{Union{Float64, Null}, R}, x) === x
-            @test convert(CategoricalVector{Union{Float64, Null}, DefaultRefType}, x) == x
-            @test convert(CategoricalVector{Union{Float64, Null}, UInt8}, x) == x
+        @test convert(CategoricalVector, x) === x
+        @test convert(CategoricalVector{Union{Float64, Null}}, x) === x
+        @test convert(CategoricalVector{Union{Float64, Null}, R}, x) === x
+        @test convert(CategoricalVector{Union{Float64, Null}, DefaultRefType}, x) == x
+        @test convert(CategoricalVector{Union{Float64, Null}, UInt8}, x) == x
 
-            @test convert(CategoricalArray, a) == x
-            @test convert(CategoricalArray{Union{Float64, Null}}, a) == x
-            @test convert(CategoricalArray{Union{Float32, Null}}, a) == x
-            @test convert(CategoricalArray{Union{Float64, Null}, 1}, a) == x
-            @test convert(CategoricalArray{Union{Float32, Null}, 1}, a) == x
-            @test convert(CategoricalArray{Union{Float64, Null}, 1, R}, a) == x
-            @test convert(CategoricalArray{Union{Float32, Null}, 1, R}, a) == x
-            @test convert(CategoricalArray{Union{Float64, Null}, 1, DefaultRefType}, a) == x
-            @test convert(CategoricalArray{Union{Float32, Null}, 1, DefaultRefType}, a) == x
-            @test convert(CategoricalArray{Union{Float64, Null}, 1, UInt8}, a) == x
-            @test convert(CategoricalArray{Union{Float32, Null}, 1, UInt8}, a) == x
+        @test convert(CategoricalArray, a) == x
+        @test convert(CategoricalArray{Union{Float64, Null}}, a) == x
+        @test convert(CategoricalArray{Union{Float32, Null}}, a) == x
+        @test convert(CategoricalArray{Union{Float64, Null}, 1}, a) == x
+        @test convert(CategoricalArray{Union{Float32, Null}, 1}, a) == x
+        @test convert(CategoricalArray{Union{Float64, Null}, 1, R}, a) == x
+        @test convert(CategoricalArray{Union{Float32, Null}, 1, R}, a) == x
+        @test convert(CategoricalArray{Union{Float64, Null}, 1, DefaultRefType}, a) == x
+        @test convert(CategoricalArray{Union{Float32, Null}, 1, DefaultRefType}, a) == x
+        @test convert(CategoricalArray{Union{Float64, Null}, 1, UInt8}, a) == x
+        @test convert(CategoricalArray{Union{Float32, Null}, 1, UInt8}, a) == x
 
-            @test convert(CategoricalVector, a) == x
-            @test convert(CategoricalVector{Union{Float64, Null}}, a) == x
-            @test convert(CategoricalVector{Union{Float32, Null}}, a) == x
-            @test convert(CategoricalVector{Union{Float64, Null}, R}, a) == x
-            @test convert(CategoricalVector{Union{Float32, Null}, R}, a) == x
-            @test convert(CategoricalVector{Union{Float64, Null}, DefaultRefType}, a) == x
-            @test convert(CategoricalVector{Union{Float32, Null}, DefaultRefType}, a) == x
-            @test convert(CategoricalVector{Union{Float64, Null}, UInt8}, a) == x
-            @test convert(CategoricalVector{Union{Float32, Null}, UInt8}, a) == x
+        @test convert(CategoricalVector, a) == x
+        @test convert(CategoricalVector{Union{Float64, Null}}, a) == x
+        @test convert(CategoricalVector{Union{Float32, Null}}, a) == x
+        @test convert(CategoricalVector{Union{Float64, Null}, R}, a) == x
+        @test convert(CategoricalVector{Union{Float32, Null}, R}, a) == x
+        @test convert(CategoricalVector{Union{Float64, Null}, DefaultRefType}, a) == x
+        @test convert(CategoricalVector{Union{Float32, Null}, DefaultRefType}, a) == x
+        @test convert(CategoricalVector{Union{Float64, Null}, UInt8}, a) == x
+        @test convert(CategoricalVector{Union{Float32, Null}, UInt8}, a) == x
 
-            @test CategoricalArray{Union{Float64, Null}}(a, ordered=ordered) == x
-            @test CategoricalArray{Union{Float32, Null}}(a, ordered=ordered) == x
-            @test CategoricalArray{Union{Float64, Null}, 1}(a, ordered=ordered) == x
-            @test CategoricalArray{Union{Float32, Null}, 1}(a, ordered=ordered) == x
-            @test CategoricalArray{Union{Float64, Null}, 1, R}(a, ordered=ordered) == x
-            @test CategoricalArray{Union{Float32, Null}, 1, R}(a, ordered=ordered) == x
-            @test CategoricalArray{Union{Float64, Null}, 1, DefaultRefType}(a, ordered=ordered) == x
-            @test CategoricalArray{Union{Float32, Null}, 1, DefaultRefType}(a, ordered=ordered) == x
+        @test CategoricalArray{Union{Float64, Null}}(a, ordered=ordered) == x
+        @test CategoricalArray{Union{Float32, Null}}(a, ordered=ordered) == x
+        @test CategoricalArray{Union{Float64, Null}, 1}(a, ordered=ordered) == x
+        @test CategoricalArray{Union{Float32, Null}, 1}(a, ordered=ordered) == x
+        @test CategoricalArray{Union{Float64, Null}, 1, R}(a, ordered=ordered) == x
+        @test CategoricalArray{Union{Float32, Null}, 1, R}(a, ordered=ordered) == x
+        @test CategoricalArray{Union{Float64, Null}, 1, DefaultRefType}(a, ordered=ordered) == x
+        @test CategoricalArray{Union{Float32, Null}, 1, DefaultRefType}(a, ordered=ordered) == x
 
-            @test CategoricalVector(a, ordered=ordered) == x
-            @test CategoricalVector{Union{Float64, Null}}(a, ordered=ordered) == x
-            @test CategoricalVector{Union{Float32, Null}}(a, ordered=ordered) == x
-            @test CategoricalVector{Union{Float64, Null}, R}(a, ordered=ordered) == x
-            @test CategoricalVector{Union{Float32, Null}, R}(a, ordered=ordered) == x
-            @test CategoricalVector{Union{Float64, Null}, DefaultRefType}(a, ordered=ordered) == x
-            @test CategoricalVector{Union{Float32, Null}, DefaultRefType}(a, ordered=ordered) == x
+        @test CategoricalVector(a, ordered=ordered) == x
+        @test CategoricalVector{Union{Float64, Null}}(a, ordered=ordered) == x
+        @test CategoricalVector{Union{Float32, Null}}(a, ordered=ordered) == x
+        @test CategoricalVector{Union{Float64, Null}, R}(a, ordered=ordered) == x
+        @test CategoricalVector{Union{Float32, Null}, R}(a, ordered=ordered) == x
+        @test CategoricalVector{Union{Float64, Null}, DefaultRefType}(a, ordered=ordered) == x
+        @test CategoricalVector{Union{Float32, Null}, DefaultRefType}(a, ordered=ordered) == x
 
-            @testset "categorical($(typeof(y)), compress=$comp) R1=$R1 R2=$R2" for (y, R1, R2, comp) in
-                ((a, DefaultRefType, UInt8, true),
-                 (a, DefaultRefType, DefaultRefType, false),
-                 (x, R, UInt8, true),
-                 (x, R, R, false))
+        @testset "categorical($(typeof(y)), compress=$comp) R1=$R1 R2=$R2" for (y, R1, R2, comp) in
+            ((a, DefaultRefType, UInt8, true),
+             (a, DefaultRefType, DefaultRefType, false),
+             (x, R, UInt8, true),
+             (x, R, R, false))
 
-                x2 = categorical(y, ordered=ordered)
-                @test x2 == collect(y)
-                if eltype(y) >: Null
-                    @test isa(x2, CategoricalVector{Union{Float64, Null}, R1})
-                else
-                    @test isa(x2, CategoricalVector{Float64, R1})
-                end
-                @test isordered(x2) === ordered
-                @test leveltype(x2) === Float64
-                @test catvaluetype(x2) === CategoricalArrays.CategoricalValue{Float64, R1}
-
-                x2 = categorical(y, comp, ordered=ordered)
-                @test x2 == collect(y)
-                if eltype(y) >: Null
-                    @test isa(x2, CategoricalVector{Union{Float64, Null}, R2})
-                else
-                    @test isa(x2, CategoricalVector{Float64, R2})
-                end
-                @test isordered(x2) === ordered
-                @test leveltype(x2) === Float64
-                @test catvaluetype(x2) === CategoricalArrays.CategoricalValue{Float64, R2}
+            x2 = categorical(y, ordered=ordered)
+            @test x2 == collect(y)
+            if eltype(y) >: Null
+                @test isa(x2, CategoricalVector{Union{Float64, Null}, R1})
+            else
+                @test isa(x2, CategoricalVector{Float64, R1})
             end
+            @test isordered(x2) === ordered
+            @test leveltype(x2) === Float64
+            @test catvaluetype(x2) === CategoricalArrays.CategoricalValue{Float64, R1}
 
-            x2 = compress(x)
-            @test x2 == x
-            @test isordered(x2) === isordered(x)
-            @test isa(x2, CategoricalVector{Union{Float64, Null}, UInt8})
-            @test levels(x2) == levels(x)
-
-            x2 = copy(x)
-            @test x2 == x
-            @test isordered(x2) === isordered(x)
-            @test typeof(x2) === typeof(x)
-            @test levels(x2) == levels(x)
-
-            @test x[1] === x.pool.valindex[1]
-            @test x[2] === x.pool.valindex[2]
-            @test x[3] === x.pool.valindex[3]
-            @test x[4] === x.pool.valindex[4]
-            @test_throws BoundsError x[5]
-
-            x2 = x[:]
-            @test typeof(x2) === typeof(x)
-            @test x2 == x
-            @test x2 !== x
-            @test levels(x2) == levels(x)
-            @test levels(x2) !== levels(x)
-            @test isordered(x2) == isordered(x)
-
-            x2 = x[1:2]
-            @test typeof(x2) === typeof(x)
-            @test x2 == [0.0, 0.5]
-            @test levels(x2) == levels(x)
-            @test levels(x2) !== levels(x)
-            @test isordered(x2) == isordered(x)
-
-            x2 = x[1:1]
-            @test typeof(x2) === typeof(x)
-            @test x2 == [0.0]
-            @test levels(x2) == levels(x)
-            @test levels(x2) !== levels(x)
-            @test isordered(x2) == isordered(x)
-
-            x2 = x[2:1]
-            @test typeof(x2) === typeof(x)
-            @test isempty(x2)
-            @test levels(x2) == levels(x)
-            @test levels(x2) !== levels(x)
-            @test isordered(x2) == isordered(x)
-
-            x[2] = 1
-            @test x[1] === x.pool.valindex[1]
-            @test x[2] === x.pool.valindex[3]
-            @test x[3] === x.pool.valindex[3]
-            @test x[4] === x.pool.valindex[4]
-            @test levels(x) == unique(a)
-
-            x[1:2] = -1
-            @test x[1] === x.pool.valindex[5]
-            @test x[2] === x.pool.valindex[5]
-            @test x[3] === x.pool.valindex[3]
-            @test x[4] === x.pool.valindex[4]
-            @test levels(x) == vcat(unique(a), -1)
-
-            push!(x, 2.0)
-            @test length(x) == 5
-            @test x == [-1.0, -1.0, 1.0, 1.5, 2.0]
-            @test isordered(x) === ordered
-            @test levels(x) == [0.0,  0.5,  1.0,  1.5, -1.0,  2.0]
-
-            push!(x, x[1])
-            @test length(x) == 6
-            @test x == [-1.0, -1.0, 1.0, 1.5, 2.0, -1.0]
-            @test isordered(x) === ordered
-            @test levels(x) == [0.0,  0.5,  1.0,  1.5, -1.0,  2.0]
-
-            append!(x, x)
-            @test length(x) == 12
-            @test x == [-1.0, -1.0, 1.0, 1.5, 2.0, -1.0, -1.0, -1.0, 1.0, 1.5, 2.0, -1.0]
-            @test isordered(x) === ordered
-            @test levels(x) == [0.0,  0.5,  1.0,  1.5, -1.0,  2.0]
-
-            b = [2.5, 3.0, -3.5]
-            y = CategoricalVector{Union{Float64, Null}, R}(b)
-            append!(x, y)
-            @test length(x) == 15
-            @test x == [-1.0, -1.0, 1.0, 1.5, 2.0, -1.0, -1.0, -1.0, 1.0, 1.5, 2.0, -1.0, 2.5, 3.0, -3.5]
-            @test isordered(x) === ordered
-            @test levels(x) == [0.0, 0.5, 1.0, 1.5, -1.0, 2.0, -3.5, 2.5, 3.0]
-
-            empty!(x)
-            @test length(x) == 0
-            @test isordered(x) === ordered
-            @test levels(x) == [0.0, 0.5, 1.0, 1.5, -1.0, 2.0, -3.5, 2.5, 3.0]
+            x2 = categorical(y, comp, ordered=ordered)
+            @test x2 == collect(y)
+            if eltype(y) >: Null
+                @test isa(x2, CategoricalVector{Union{Float64, Null}, R2})
+            else
+                @test isa(x2, CategoricalVector{Float64, R2})
+            end
+            @test isordered(x2) === ordered
+            @test leveltype(x2) === Float64
+            @test catvaluetype(x2) === CategoricalArrays.CategoricalValue{Float64, R2}
         end
 
-        @testset "Matrix $(typeof(a)) with no null values" for a in
-            (["a" "b" "c"; "b" "a" "c"],
-             Union{String, Null}["a" "b" "c"; "b" "a" "c"])
+        x2 = compress(x)
+        @test x2 == x
+        @test isordered(x2) === isordered(x)
+        @test isa(x2, CategoricalVector{Union{Float64, Null}, UInt8})
+        @test levels(x2) == levels(x)
 
-            x = CategoricalMatrix{Union{String, Null}, R}(a, ordered=ordered)
+        x2 = copy(x)
+        @test x2 == x
+        @test isordered(x2) === isordered(x)
+        @test typeof(x2) === typeof(x)
+        @test levels(x2) == levels(x)
 
-            @test x == a
-            @test isordered(x) === ordered
-            @test levels(x) == unique(a)
-            @test size(x) === (2, 3)
-            @test length(x) === 6
+        @test x[1] === x.pool.valindex[1]
+        @test x[2] === x.pool.valindex[2]
+        @test x[3] === x.pool.valindex[3]
+        @test x[4] === x.pool.valindex[4]
+        @test_throws BoundsError x[5]
 
-            @test convert(CategoricalArray, x) === x
-            @test convert(CategoricalArray{Union{String, Null}}, x) === x
-            @test convert(CategoricalArray{Union{String, Null}, 2}, x) === x
-            @test convert(CategoricalArray{Union{String, Null}, 2, R}, x) === x
-            @test convert(CategoricalArray{Union{String, Null}, 2, DefaultRefType}, x) == x
-            @test convert(CategoricalArray{Union{String, Null}, 2, UInt8}, x) == x
+        x2 = x[:]
+        @test typeof(x2) === typeof(x)
+        @test x2 == x
+        @test x2 !== x
+        @test levels(x2) == levels(x)
+        @test levels(x2) !== levels(x)
+        @test isordered(x2) == isordered(x)
 
-            @test convert(CategoricalMatrix, x) === x
-            @test convert(CategoricalMatrix{Union{String, Null}}, x) === x
-            @test convert(CategoricalMatrix{Union{String, Null}, R}, x) === x
-            @test convert(CategoricalMatrix{Union{String, Null}, DefaultRefType}, x) == x
-            @test convert(CategoricalMatrix{Union{String, Null}, UInt8}, x) == x
+        x2 = x[1:2]
+        @test typeof(x2) === typeof(x)
+        @test x2 == [0.0, 0.5]
+        @test levels(x2) == levels(x)
+        @test levels(x2) !== levels(x)
+        @test isordered(x2) == isordered(x)
 
-            @test convert(CategoricalArray, a) == x
-            @test convert(CategoricalArray{Union{String, Null}}, a) == x
-            @test convert(CategoricalArray{Union{String, Null}, 2, R}, a) == x
-            @test convert(CategoricalArray{Union{String, Null}, 2, DefaultRefType}, a) == x
-            @test convert(CategoricalArray{Union{String, Null}, 2, UInt8}, a) == x
+        x2 = x[1:1]
+        @test typeof(x2) === typeof(x)
+        @test x2 == [0.0]
+        @test levels(x2) == levels(x)
+        @test levels(x2) !== levels(x)
+        @test isordered(x2) == isordered(x)
 
-            @test convert(CategoricalMatrix, a) == x
-            @test convert(CategoricalMatrix{Union{String, Null}}, a) == x
-            @test convert(CategoricalMatrix{Union{String, Null}, R}, a) == x
-            @test convert(CategoricalMatrix{Union{String, Null}, DefaultRefType}, a) == x
-            @test convert(CategoricalMatrix{Union{String, Null}, UInt8}, a) == x
+        x2 = x[2:1]
+        @test typeof(x2) === typeof(x)
+        @test isempty(x2)
+        @test levels(x2) == levels(x)
+        @test levels(x2) !== levels(x)
+        @test isordered(x2) == isordered(x)
 
-            @test CategoricalArray{Union{String, Null}}(a, ordered=ordered) == x
-            @test CategoricalArray{Union{String, Null}, 2}(a, ordered=ordered) == x
-            @test CategoricalArray{Union{String, Null}, 2}(a, ordered=ordered) == x
-            @test CategoricalArray{Union{String, Null}, 2, R}(a, ordered=ordered) == x
-            @test CategoricalArray{Union{String, Null}, 2, DefaultRefType}(a, ordered=ordered) == x
-            @test CategoricalArray{Union{String, Null}, 2, UInt8}(a, ordered=ordered) == x
+        x[2] = 1
+        @test x[1] === x.pool.valindex[1]
+        @test x[2] === x.pool.valindex[3]
+        @test x[3] === x.pool.valindex[3]
+        @test x[4] === x.pool.valindex[4]
+        @test levels(x) == unique(a)
 
-            @test CategoricalMatrix(a, ordered=ordered) == x
-            @test CategoricalMatrix{Union{String, Null}}(a, ordered=ordered) == x
-            @test CategoricalMatrix{Union{String, Null}, R}(a, ordered=ordered) == x
-            @test CategoricalMatrix{Union{String, Null}, DefaultRefType}(a, ordered=ordered) == x
-            @test CategoricalMatrix{Union{String, Null}, UInt8}(a, ordered=ordered) == x
+        x[1:2] = -1
+        @test x[1] === x.pool.valindex[5]
+        @test x[2] === x.pool.valindex[5]
+        @test x[3] === x.pool.valindex[3]
+        @test x[4] === x.pool.valindex[4]
+        @test levels(x) == vcat(unique(a), -1)
 
-            @testset "categorical($(typeof(y)), compress=$comp) R1=$R1 R2=$R2" for (y, R1, R2, comp) in
-                ((a, DefaultRefType, UInt8, true),
-                 (a, DefaultRefType, DefaultRefType, false),
-                 (x, R, UInt8, true),
-                 (x, R, R, false))
+        push!(x, 2.0)
+        @test length(x) == 5
+        @test x == [-1.0, -1.0, 1.0, 1.5, 2.0]
+        @test isordered(x) === ordered
+        @test levels(x) == [0.0,  0.5,  1.0,  1.5, -1.0,  2.0]
 
-                x2 = categorical(y, ordered=ordered)
-                @test x2 == y
-                if eltype(y) >: Null
-                    @test isa(x2, CategoricalMatrix{Union{String, Null}, R1})
-                else
-                    @test isa(x2, CategoricalMatrix{String, R1})
-                end
-                @test isordered(x2) === ordered
+        push!(x, x[1])
+        @test length(x) == 6
+        @test x == [-1.0, -1.0, 1.0, 1.5, 2.0, -1.0]
+        @test isordered(x) === ordered
+        @test levels(x) == [0.0,  0.5,  1.0,  1.5, -1.0,  2.0]
 
-                x2 = categorical(y, comp, ordered=ordered)
-                @test x2 == y
-                if eltype(y) >: Null
-                    @test isa(x2, CategoricalMatrix{Union{String, Null}, R2})
-                else
-                    @test isa(x2, CategoricalMatrix{String, R2})
-                end
-                @test isordered(x2) === ordered
+        append!(x, x)
+        @test length(x) == 12
+        @test x == [-1.0, -1.0, 1.0, 1.5, 2.0, -1.0, -1.0, -1.0, 1.0, 1.5, 2.0, -1.0]
+        @test isordered(x) === ordered
+        @test levels(x) == [0.0,  0.5,  1.0,  1.5, -1.0,  2.0]
+
+        b = [2.5, 3.0, -3.5]
+        y = CategoricalVector{Union{Float64, Null}, R}(b)
+        append!(x, y)
+        @test length(x) == 15
+        @test x == [-1.0, -1.0, 1.0, 1.5, 2.0, -1.0, -1.0, -1.0, 1.0, 1.5, 2.0, -1.0, 2.5, 3.0, -3.5]
+        @test isordered(x) === ordered
+        @test levels(x) == [0.0, 0.5, 1.0, 1.5, -1.0, 2.0, -3.5, 2.5, 3.0]
+
+        empty!(x)
+        @test length(x) == 0
+        @test isordered(x) === ordered
+        @test levels(x) == [0.0, 0.5, 1.0, 1.5, -1.0, 2.0, -3.5, 2.5, 3.0]
+    end
+
+    @testset "Matrix $(typeof(a)) with no null values" for a in
+        (["a" "b" "c"; "b" "a" "c"],
+         Union{String, Null}["a" "b" "c"; "b" "a" "c"])
+
+        x = CategoricalMatrix{Union{String, Null}, R}(a, ordered=ordered)
+
+        @test x == a
+        @test isordered(x) === ordered
+        @test levels(x) == unique(a)
+        @test size(x) === (2, 3)
+        @test length(x) === 6
+
+        @test convert(CategoricalArray, x) === x
+        @test convert(CategoricalArray{Union{String, Null}}, x) === x
+        @test convert(CategoricalArray{Union{String, Null}, 2}, x) === x
+        @test convert(CategoricalArray{Union{String, Null}, 2, R}, x) === x
+        @test convert(CategoricalArray{Union{String, Null}, 2, DefaultRefType}, x) == x
+        @test convert(CategoricalArray{Union{String, Null}, 2, UInt8}, x) == x
+
+        @test convert(CategoricalMatrix, x) === x
+        @test convert(CategoricalMatrix{Union{String, Null}}, x) === x
+        @test convert(CategoricalMatrix{Union{String, Null}, R}, x) === x
+        @test convert(CategoricalMatrix{Union{String, Null}, DefaultRefType}, x) == x
+        @test convert(CategoricalMatrix{Union{String, Null}, UInt8}, x) == x
+
+        @test convert(CategoricalArray, a) == x
+        @test convert(CategoricalArray{Union{String, Null}}, a) == x
+        @test convert(CategoricalArray{Union{String, Null}, 2, R}, a) == x
+        @test convert(CategoricalArray{Union{String, Null}, 2, DefaultRefType}, a) == x
+        @test convert(CategoricalArray{Union{String, Null}, 2, UInt8}, a) == x
+
+        @test convert(CategoricalMatrix, a) == x
+        @test convert(CategoricalMatrix{Union{String, Null}}, a) == x
+        @test convert(CategoricalMatrix{Union{String, Null}, R}, a) == x
+        @test convert(CategoricalMatrix{Union{String, Null}, DefaultRefType}, a) == x
+        @test convert(CategoricalMatrix{Union{String, Null}, UInt8}, a) == x
+
+        @test CategoricalArray{Union{String, Null}}(a, ordered=ordered) == x
+        @test CategoricalArray{Union{String, Null}, 2}(a, ordered=ordered) == x
+        @test CategoricalArray{Union{String, Null}, 2}(a, ordered=ordered) == x
+        @test CategoricalArray{Union{String, Null}, 2, R}(a, ordered=ordered) == x
+        @test CategoricalArray{Union{String, Null}, 2, DefaultRefType}(a, ordered=ordered) == x
+        @test CategoricalArray{Union{String, Null}, 2, UInt8}(a, ordered=ordered) == x
+
+        @test CategoricalMatrix(a, ordered=ordered) == x
+        @test CategoricalMatrix{Union{String, Null}}(a, ordered=ordered) == x
+        @test CategoricalMatrix{Union{String, Null}, R}(a, ordered=ordered) == x
+        @test CategoricalMatrix{Union{String, Null}, DefaultRefType}(a, ordered=ordered) == x
+        @test CategoricalMatrix{Union{String, Null}, UInt8}(a, ordered=ordered) == x
+
+        @testset "categorical($(typeof(y)), compress=$comp) R1=$R1 R2=$R2" for (y, R1, R2, comp) in
+            ((a, DefaultRefType, UInt8, true),
+             (a, DefaultRefType, DefaultRefType, false),
+             (x, R, UInt8, true),
+             (x, R, R, false))
+
+            x2 = categorical(y, ordered=ordered)
+            @test x2 == y
+            if eltype(y) >: Null
+                @test isa(x2, CategoricalMatrix{Union{String, Null}, R1})
+            else
+                @test isa(x2, CategoricalMatrix{String, R1})
             end
+            @test isordered(x2) === ordered
 
-            x2 = compress(x)
-            @test x2 == x
-            @test isa(x2, CategoricalMatrix{Union{String, Null}, UInt8})
-            @test isordered(x2) === isordered(x)
-            @test levels(x2) == levels(x)
+            x2 = categorical(y, comp, ordered=ordered)
+            @test x2 == y
+            if eltype(y) >: Null
+                @test isa(x2, CategoricalMatrix{Union{String, Null}, R2})
+            else
+                @test isa(x2, CategoricalMatrix{String, R2})
+            end
+            @test isordered(x2) === ordered
+        end
 
-            x2 = copy(x)
-            @test x2 == x
-            @test typeof(x2) === typeof(x)
-            @test isordered(x2) === isordered(x)
-            @test levels(x2) == levels(x)
+        x2 = compress(x)
+        @test x2 == x
+        @test isa(x2, CategoricalMatrix{Union{String, Null}, UInt8})
+        @test isordered(x2) === isordered(x)
+        @test levels(x2) == levels(x)
 
-            @test x[1] === x.pool.valindex[1]
-            @test x[2] === x.pool.valindex[2]
-            @test x[3] === x.pool.valindex[2]
-            @test x[4] === x.pool.valindex[1]
-            @test x[5] === x.pool.valindex[3]
-            @test x[6] === x.pool.valindex[3]
-            @test_throws BoundsError x[7]
+        x2 = copy(x)
+        @test x2 == x
+        @test typeof(x2) === typeof(x)
+        @test isordered(x2) === isordered(x)
+        @test levels(x2) == levels(x)
 
-            @test x[1,1] === x.pool.valindex[1]
-            @test x[2,1] === x.pool.valindex[2]
-            @test x[1,2] === x.pool.valindex[2]
-            @test x[2,2] === x.pool.valindex[1]
-            @test x[1,3] === x.pool.valindex[3]
-            @test x[2,3] === x.pool.valindex[3]
-            @test_throws BoundsError x[1,4]
-            @test_throws BoundsError x[4,1]
-            @test_throws BoundsError x[4,4]
+        @test x[1] === x.pool.valindex[1]
+        @test x[2] === x.pool.valindex[2]
+        @test x[3] === x.pool.valindex[2]
+        @test x[4] === x.pool.valindex[1]
+        @test x[5] === x.pool.valindex[3]
+        @test x[6] === x.pool.valindex[3]
+        @test_throws BoundsError x[7]
 
-            @test x[1:2,:] == x
-            @test typeof(x[1:2,:]) === typeof(x)
-            @test x[1:2,1] == ["a", "b"]
-            @test isa(x[1:2,1], CategoricalVector{Union{String, Null}, R})
+        @test x[1,1] === x.pool.valindex[1]
+        @test x[2,1] === x.pool.valindex[2]
+        @test x[1,2] === x.pool.valindex[2]
+        @test x[2,2] === x.pool.valindex[1]
+        @test x[1,3] === x.pool.valindex[3]
+        @test x[2,3] === x.pool.valindex[3]
+        @test_throws BoundsError x[1,4]
+        @test_throws BoundsError x[4,1]
+        @test_throws BoundsError x[4,4]
 
-            x[1] = "z"
-            @test x[1] === x.pool.valindex[4]
-            @test x[2] === x.pool.valindex[2]
-            @test x[3] === x.pool.valindex[2]
-            @test x[4] === x.pool.valindex[1]
-            @test x[5] === x.pool.valindex[3]
-            @test x[6] === x.pool.valindex[3]
-            @test levels(x) == ["a", "b", "c", "z"]
+        @test x[1:2,:] == x
+        @test typeof(x[1:2,:]) === typeof(x)
+        @test x[1:2,1] == ["a", "b"]
+        @test isa(x[1:2,1], CategoricalVector{Union{String, Null}, R})
 
-            x[1,:] = "a"
-            @test x[1] === x.pool.valindex[1]
-            @test x[2] === x.pool.valindex[2]
-            @test x[3] === x.pool.valindex[1]
-            @test x[4] === x.pool.valindex[1]
-            @test x[5] === x.pool.valindex[1]
-            @test x[6] === x.pool.valindex[3]
-            @test levels(x) == ["a", "b", "c", "z"]
+        x[1] = "z"
+        @test x[1] === x.pool.valindex[4]
+        @test x[2] === x.pool.valindex[2]
+        @test x[3] === x.pool.valindex[2]
+        @test x[4] === x.pool.valindex[1]
+        @test x[5] === x.pool.valindex[3]
+        @test x[6] === x.pool.valindex[3]
+        @test levels(x) == ["a", "b", "c", "z"]
 
-            x[1,1:2] = "z"
-            @test x[1] === x.pool.valindex[4]
-            @test x[2] === x.pool.valindex[2]
-            @test x[3] === x.pool.valindex[4]
-            @test x[4] === x.pool.valindex[1]
-            @test x[5] === x.pool.valindex[1]
-            @test x[6] === x.pool.valindex[3]
-            @test levels(x) == ["a", "b", "c", "z"]
+        x[1,:] = "a"
+        @test x[1] === x.pool.valindex[1]
+        @test x[2] === x.pool.valindex[2]
+        @test x[3] === x.pool.valindex[1]
+        @test x[4] === x.pool.valindex[1]
+        @test x[5] === x.pool.valindex[1]
+        @test x[6] === x.pool.valindex[3]
+        @test levels(x) == ["a", "b", "c", "z"]
+
+        x[1,1:2] = "z"
+        @test x[1] === x.pool.valindex[4]
+        @test x[2] === x.pool.valindex[2]
+        @test x[3] === x.pool.valindex[4]
+        @test x[4] === x.pool.valindex[1]
+        @test x[5] === x.pool.valindex[1]
+        @test x[6] === x.pool.valindex[3]
+        @test levels(x) == ["a", "b", "c", "z"]
         end
 
         @testset "Matrix with null values" begin
-            a = ["a" null "c"; "b" "a" null]
-            x = CategoricalMatrix{Union{String, Null}, R}(a, ordered=ordered)
+        a = ["a" null "c"; "b" "a" null]
+        x = CategoricalMatrix{Union{String, Null}, R}(a, ordered=ordered)
 
-            @test x ≅ a
-            @test isordered(x) === ordered
-            @test levels(x) == filter(x->!isnull(x), unique(a))
-            @test size(x) === (2, 3)
-            @test length(x) === 6
+        @test x ≅ a
+        @test isordered(x) === ordered
+        @test levels(x) == filter(x->!isnull(x), unique(a))
+        @test size(x) === (2, 3)
+        @test length(x) === 6
 
-            @test convert(CategoricalArray, x) === x
-            @test convert(CategoricalArray{Union{String, Null}}, x) === x
-            @test convert(CategoricalArray{Union{String, Null}, 2}, x) === x
-            @test convert(CategoricalArray{Union{String, Null}, 2, R}, x) === x
-            @test convert(CategoricalArray{Union{String, Null}, 2, DefaultRefType}, x) ≅ x
-            @test convert(CategoricalArray{Union{String, Null}, 2, UInt8}, x) ≅ x
+        @test convert(CategoricalArray, x) === x
+        @test convert(CategoricalArray{Union{String, Null}}, x) === x
+        @test convert(CategoricalArray{Union{String, Null}, 2}, x) === x
+        @test convert(CategoricalArray{Union{String, Null}, 2, R}, x) === x
+        @test convert(CategoricalArray{Union{String, Null}, 2, DefaultRefType}, x) ≅ x
+        @test convert(CategoricalArray{Union{String, Null}, 2, UInt8}, x) ≅ x
 
-            @test convert(CategoricalMatrix, x) === x
-            @test convert(CategoricalMatrix{Union{String, Null}}, x) === x
-            @test convert(CategoricalMatrix{Union{String, Null}, R}, x) === x
-            @test convert(CategoricalMatrix{Union{String, Null}, DefaultRefType}, x) ≅ x
-            @test convert(CategoricalMatrix{Union{String, Null}, UInt8}, x) ≅ x
+        @test convert(CategoricalMatrix, x) === x
+        @test convert(CategoricalMatrix{Union{String, Null}}, x) === x
+        @test convert(CategoricalMatrix{Union{String, Null}, R}, x) === x
+        @test convert(CategoricalMatrix{Union{String, Null}, DefaultRefType}, x) ≅ x
+        @test convert(CategoricalMatrix{Union{String, Null}, UInt8}, x) ≅ x
 
-            @test convert(CategoricalArray, a) ≅ x
-            @test convert(CategoricalArray{Union{String, Null}}, a) ≅ x
-            @test convert(CategoricalArray{Union{String, Null}, 2, R}, a) ≅ x
-            @test convert(CategoricalArray{Union{String, Null}, 2, DefaultRefType}, a) ≅ x
-            @test convert(CategoricalArray{Union{String, Null}, 2, UInt8}, a) ≅ x
+        @test convert(CategoricalArray, a) ≅ x
+        @test convert(CategoricalArray{Union{String, Null}}, a) ≅ x
+        @test convert(CategoricalArray{Union{String, Null}, 2, R}, a) ≅ x
+        @test convert(CategoricalArray{Union{String, Null}, 2, DefaultRefType}, a) ≅ x
+        @test convert(CategoricalArray{Union{String, Null}, 2, UInt8}, a) ≅ x
 
-            @test convert(CategoricalMatrix, a) ≅ x
-            @test convert(CategoricalMatrix{Union{String, Null}}, a) ≅ x
-            @test convert(CategoricalMatrix{Union{String, Null}, R}, a) ≅ x
-            @test convert(CategoricalMatrix{Union{String, Null}, DefaultRefType}, a) ≅ x
-            @test convert(CategoricalMatrix{Union{String, Null}, UInt8}, a) ≅ x
+        @test convert(CategoricalMatrix, a) ≅ x
+        @test convert(CategoricalMatrix{Union{String, Null}}, a) ≅ x
+        @test convert(CategoricalMatrix{Union{String, Null}, R}, a) ≅ x
+        @test convert(CategoricalMatrix{Union{String, Null}, DefaultRefType}, a) ≅ x
+        @test convert(CategoricalMatrix{Union{String, Null}, UInt8}, a) ≅ x
 
-            @test CategoricalArray{Union{String, Null}}(a, ordered=ordered) ≅ x
-            @test CategoricalArray{Union{String, Null}, 2}(a, ordered=ordered) ≅ x
-            @test CategoricalArray{Union{String, Null}, 2}(a, ordered=ordered) ≅ x
-            @test CategoricalArray{Union{String, Null}, 2, R}(a, ordered=ordered) ≅ x
-            @test CategoricalArray{Union{String, Null}, 2, DefaultRefType}(a, ordered=ordered) ≅ x
-            @test CategoricalArray{Union{String, Null}, 2, UInt8}(a, ordered=ordered) ≅ x
+        @test CategoricalArray{Union{String, Null}}(a, ordered=ordered) ≅ x
+        @test CategoricalArray{Union{String, Null}, 2}(a, ordered=ordered) ≅ x
+        @test CategoricalArray{Union{String, Null}, 2}(a, ordered=ordered) ≅ x
+        @test CategoricalArray{Union{String, Null}, 2, R}(a, ordered=ordered) ≅ x
+        @test CategoricalArray{Union{String, Null}, 2, DefaultRefType}(a, ordered=ordered) ≅ x
+        @test CategoricalArray{Union{String, Null}, 2, UInt8}(a, ordered=ordered) ≅ x
 
-            @test CategoricalMatrix(a, ordered=ordered) ≅ x
-            @test CategoricalMatrix{Union{String, Null}}(a, ordered=ordered) ≅ x
-            @test CategoricalMatrix{Union{String, Null}, R}(a, ordered=ordered) ≅ x
-            @test CategoricalMatrix{Union{String, Null}, DefaultRefType}(a, ordered=ordered) ≅ x
-            @test CategoricalMatrix{Union{String, Null}, UInt8}(a, ordered=ordered) ≅ x
+        @test CategoricalMatrix(a, ordered=ordered) ≅ x
+        @test CategoricalMatrix{Union{String, Null}}(a, ordered=ordered) ≅ x
+        @test CategoricalMatrix{Union{String, Null}, R}(a, ordered=ordered) ≅ x
+        @test CategoricalMatrix{Union{String, Null}, DefaultRefType}(a, ordered=ordered) ≅ x
+        @test CategoricalMatrix{Union{String, Null}, UInt8}(a, ordered=ordered) ≅ x
 
-            @testset "categorical($(typeof(y)), compress=$comp) R1=$R1 R2=$R2" for (y, R1, R2, comp) in
-                ((a, DefaultRefType, UInt8, true),
-                 (a, DefaultRefType, DefaultRefType, false),
-                 (x, R, UInt8, true),
-                 (x, R, R, false))
+        @testset "categorical($(typeof(y)), compress=$comp) R1=$R1 R2=$R2" for (y, R1, R2, comp) in
+            ((a, DefaultRefType, UInt8, true),
+             (a, DefaultRefType, DefaultRefType, false),
+             (x, R, UInt8, true),
+             (x, R, R, false))
 
-                x2 = categorical(y, ordered=ordered)
-                @test x2 ≅ y
-                @test isa(x2, CategoricalMatrix{Union{String, Null}, R1})
-                @test isordered(x2) === ordered
+            x2 = categorical(y, ordered=ordered)
+            @test x2 ≅ y
+            @test isa(x2, CategoricalMatrix{Union{String, Null}, R1})
+            @test isordered(x2) === ordered
 
-                x2 = categorical(y, comp, ordered=ordered)
-                @test x2 ≅ y
-                @test isa(x2, CategoricalMatrix{Union{String, Null}, R2})
-                @test isordered(x2) === ordered
-            end
+            x2 = categorical(y, comp, ordered=ordered)
+            @test x2 ≅ y
+            @test isa(x2, CategoricalMatrix{Union{String, Null}, R2})
+            @test isordered(x2) === ordered
+        end
 
-            x2 = compress(x)
-            @test x2 ≅ x
-            @test isa(x2, CategoricalMatrix{Union{String, Null}, UInt8})
-            @test isordered(x2) === isordered(x)
-            @test levels(x2) == levels(x)
+        x2 = compress(x)
+        @test x2 ≅ x
+        @test isa(x2, CategoricalMatrix{Union{String, Null}, UInt8})
+        @test isordered(x2) === isordered(x)
+        @test levels(x2) == levels(x)
 
-            x2 = copy(x)
-            @test x2 ≅ x
-            @test typeof(x2) === typeof(x)
-            @test isordered(x2) === isordered(x)
-            @test levels(x2) == levels(x)
+        x2 = copy(x)
+        @test x2 ≅ x
+        @test typeof(x2) === typeof(x)
+        @test isordered(x2) === isordered(x)
+        @test levels(x2) == levels(x)
 
-            @test x[1] === x.pool.valindex[1]
-            @test x[2] === x.pool.valindex[2]
-            @test x[3] === null
-            @test x[4] === x.pool.valindex[1]
-            @test x[5] === x.pool.valindex[3]
-            @test x[6] === null
-            @test_throws BoundsError x[7]
+        @test x[1] === x.pool.valindex[1]
+        @test x[2] === x.pool.valindex[2]
+        @test x[3] === null
+        @test x[4] === x.pool.valindex[1]
+        @test x[5] === x.pool.valindex[3]
+        @test x[6] === null
+        @test_throws BoundsError x[7]
 
-            @test x[1,1] === x.pool.valindex[1]
-            @test x[2,1] === x.pool.valindex[2]
-            @test x[1,2] === null
-            @test x[2,2] === x.pool.valindex[1]
-            @test x[1,3] === x.pool.valindex[3]
-            @test x[2,3] === null
-            @test_throws BoundsError x[1,4]
-            @test_throws BoundsError x[4,1]
-            @test_throws BoundsError x[4,4]
+        @test x[1,1] === x.pool.valindex[1]
+        @test x[2,1] === x.pool.valindex[2]
+        @test x[1,2] === null
+        @test x[2,2] === x.pool.valindex[1]
+        @test x[1,3] === x.pool.valindex[3]
+        @test x[2,3] === null
+        @test_throws BoundsError x[1,4]
+        @test_throws BoundsError x[4,1]
+        @test_throws BoundsError x[4,4]
 
-            x2 = x[1:2,:]
-            @test typeof(x2) === typeof(x)
-            @test x2 ≅ x
-            @test levels(x2) == levels(x)
-            @test levels(x2) !== levels(x)
-            @test isordered(x2) == isordered(x)
+        x2 = x[1:2,:]
+        @test typeof(x2) === typeof(x)
+        @test x2 ≅ x
+        @test levels(x2) == levels(x)
+        @test levels(x2) !== levels(x)
+        @test isordered(x2) == isordered(x)
 
-            x2 = x[:,[1, 3]]
-            @test typeof(x2) === typeof(x)
-            @test x2 ≅ ["a" "c"; "b" null]
-            @test levels(x2) == levels(x)
-            @test levels(x2) !== levels(x)
-            @test isordered(x2) == isordered(x)
+        x2 = x[:,[1, 3]]
+        @test typeof(x2) === typeof(x)
+        @test x2 ≅ ["a" "c"; "b" null]
+        @test levels(x2) == levels(x)
+        @test levels(x2) !== levels(x)
+        @test isordered(x2) == isordered(x)
 
-            x2 = x[1:1,2]
-            @test isa(x2, CategoricalVector{Union{String, Null}, R})
-            @test x2 ≅ [null]
-            @test levels(x2) == levels(x)
-            @test levels(x2) !== levels(x)
-            @test isordered(x2) == isordered(x)
+        x2 = x[1:1,2]
+        @test isa(x2, CategoricalVector{Union{String, Null}, R})
+        @test x2 ≅ [null]
+        @test levels(x2) == levels(x)
+        @test levels(x2) !== levels(x)
+        @test isordered(x2) == isordered(x)
 
-            x2 = x[1:0,:]
-            @test typeof(x2) === typeof(x)
-            @test size(x2) == (0,3)
-            @test levels(x2) == levels(x)
-            @test levels(x2) !== levels(x)
-            @test isordered(x2) == isordered(x)
+        x2 = x[1:0,:]
+        @test typeof(x2) === typeof(x)
+        @test size(x2) == (0,3)
+        @test levels(x2) == levels(x)
+        @test levels(x2) !== levels(x)
+        @test isordered(x2) == isordered(x)
 
-            @test_throws BoundsError x[1:4, :]
-            @test_throws BoundsError x[1:1, -1:1]
-            @test_throws BoundsError x[4, :]
+        @test_throws BoundsError x[1:4, :]
+        @test_throws BoundsError x[1:1, -1:1]
+        @test_throws BoundsError x[4, :]
 
-            x[1] = "z"
-            @test x[1] === x.pool.valindex[4]
-            @test x[2] === x.pool.valindex[2]
-            @test x[3] === null
-            @test x[4] === x.pool.valindex[1]
-            @test x[5] === x.pool.valindex[3]
-            @test x[6] === null
-            @test levels(x) == ["a", "b", "c", "z"]
+        x[1] = "z"
+        @test x[1] === x.pool.valindex[4]
+        @test x[2] === x.pool.valindex[2]
+        @test x[3] === null
+        @test x[4] === x.pool.valindex[1]
+        @test x[5] === x.pool.valindex[3]
+        @test x[6] === null
+        @test levels(x) == ["a", "b", "c", "z"]
 
-            x[1,:] = "a"
-            @test x[1] === x.pool.valindex[1]
-            @test x[2] === x.pool.valindex[2]
-            @test x[3] === x.pool.valindex[1]
-            @test x[4] === x.pool.valindex[1]
-            @test x[5] === x.pool.valindex[1]
-            @test x[6] === null
-            @test levels(x) == ["a", "b", "c", "z"]
+        x[1,:] = "a"
+        @test x[1] === x.pool.valindex[1]
+        @test x[2] === x.pool.valindex[2]
+        @test x[3] === x.pool.valindex[1]
+        @test x[4] === x.pool.valindex[1]
+        @test x[5] === x.pool.valindex[1]
+        @test x[6] === null
+        @test levels(x) == ["a", "b", "c", "z"]
 
-            x[1,1:2] = "z"
-            @test x[1] === x.pool.valindex[4]
-            @test x[2] === x.pool.valindex[2]
-            @test x[3] === x.pool.valindex[4]
-            @test x[4] === x.pool.valindex[1]
-            @test x[5] === x.pool.valindex[1]
-            @test x[6] === null
-            @test levels(x) == ["a", "b", "c", "z"]
+        x[1,1:2] = "z"
+        @test x[1] === x.pool.valindex[4]
+        @test x[2] === x.pool.valindex[2]
+        @test x[3] === x.pool.valindex[4]
+        @test x[4] === x.pool.valindex[1]
+        @test x[5] === x.pool.valindex[1]
+        @test x[6] === null
+        @test levels(x) == ["a", "b", "c", "z"]
 
-            x[1] = null
-            @test x[1] === null
-            @test x[2] === x.pool.valindex[2]
-            @test x[3] === x.pool.valindex[4]
-            @test x[4] === x.pool.valindex[1]
-            @test x[5] === x.pool.valindex[1]
-            @test x[6] === null
-            @test levels(x) == ["a", "b", "c", "z"]
+        x[1] = null
+        @test x[1] === null
+        @test x[2] === x.pool.valindex[2]
+        @test x[3] === x.pool.valindex[4]
+        @test x[4] === x.pool.valindex[1]
+        @test x[5] === x.pool.valindex[1]
+        @test x[6] === null
+        @test levels(x) == ["a", "b", "c", "z"]
 
-            x[1,1:2] = null
-            @test x[1] === null
-            @test x[2] === x.pool.valindex[2]
-            @test x[3] === null
-            @test x[4] === x.pool.valindex[1]
-            @test x[5] === x.pool.valindex[1]
-            @test x[6] === null
-            @test levels(x) == ["a", "b", "c", "z"]
+        x[1,1:2] = null
+        @test x[1] === null
+        @test x[2] === x.pool.valindex[2]
+        @test x[3] === null
+        @test x[4] === x.pool.valindex[1]
+        @test x[5] === x.pool.valindex[1]
+        @test x[6] === null
+        @test levels(x) == ["a", "b", "c", "z"]
 
-            x[:,2] = null
-            @test x[1] === null
-            @test x[2] === x.pool.valindex[2]
-            @test x[3] === null
-            @test x[4] === null
-            @test x[5] === x.pool.valindex[1]
-            @test x[6] === null
-            @test levels(x) == ["a", "b", "c", "z"]
+        x[:,2] = null
+        @test x[1] === null
+        @test x[2] === x.pool.valindex[2]
+        @test x[3] === null
+        @test x[4] === null
+        @test x[5] === x.pool.valindex[1]
+        @test x[6] === null
+        @test levels(x) == ["a", "b", "c", "z"]
 
-            x[1,2] = "a"
-            @test x[1] === null
-            @test x[2] === x.pool.valindex[2]
-            @test x[3] === x.pool.valindex[1]
-            @test x[4] === null
-            @test x[5] === x.pool.valindex[1]
-            @test x[6] === null
-            @test levels(x) == ["a", "b", "c", "z"]
+        x[1,2] = "a"
+        @test x[1] === null
+        @test x[2] === x.pool.valindex[2]
+        @test x[3] === x.pool.valindex[1]
+        @test x[4] === null
+        @test x[5] === x.pool.valindex[1]
+        @test x[6] === null
+        @test levels(x) == ["a", "b", "c", "z"]
 
-            x[2,1] = null
-            @test x[1] === null
-            @test x[2] === null
-            @test x[3] === x.pool.valindex[1]
-            @test x[4] === null
-            @test x[5] === x.pool.valindex[1]
-            @test x[6] === null
-            @test levels(x) == ["a", "b", "c", "z"]
+        x[2,1] = null
+        @test x[1] === null
+        @test x[2] === null
+        @test x[3] === x.pool.valindex[1]
+        @test x[4] === null
+        @test x[5] === x.pool.valindex[1]
+        @test x[6] === null
+        @test levels(x) == ["a", "b", "c", "z"]
         end
 
         # Uninitialized array
@@ -920,42 +920,42 @@ const ≅ = isequal
                 CategoricalMatrix{Union{String, Null}, R}(2, 3, ordered=ordered)]
 
         @testset "Uninitialized $(typeof(x))" for x in v
-            @test isordered(x) === ordered
-            @test isnull(x[1])
-            @test isnull(x[2])
-            @test levels(x) == []
+        @test isordered(x) === ordered
+        @test isnull(x[1])
+        @test isnull(x[2])
+        @test levels(x) == []
 
-            x2 = compress(x)
-            @test x2 ≅ x
-            @test isa(x2, CategoricalArray{Union{leveltype(x), Null}, ndims(x), UInt8})
-            @test isordered(x2) === isordered(x)
-            @test levels(x2) == []
+        x2 = compress(x)
+        @test x2 ≅ x
+        @test isa(x2, CategoricalArray{Union{leveltype(x), Null}, ndims(x), UInt8})
+        @test isordered(x2) === isordered(x)
+        @test levels(x2) == []
 
-            x2 = copy(x)
-            @test x2 ≅ x
-            @test typeof(x2) === typeof(x)
-            @test isordered(x2) === isordered(x)
-            @test levels(x2) == []
+        x2 = copy(x)
+        @test x2 ≅ x
+        @test typeof(x2) === typeof(x)
+        @test isordered(x2) === isordered(x)
+        @test levels(x2) == []
 
-            x[1] = "c"
-            @test x[1] === x.pool.valindex[1]
-            @test isnull(x[2])
-            @test levels(x) == ["c"]
+        x[1] = "c"
+        @test x[1] === x.pool.valindex[1]
+        @test isnull(x[2])
+        @test levels(x) == ["c"]
 
-            x[1] = "a"
-            @test x[1] === x.pool.valindex[2]
-            @test isnull(x[2])
-            @test levels(x) == ["c", "a"]
+        x[1] = "a"
+        @test x[1] === x.pool.valindex[2]
+        @test isnull(x[2])
+        @test levels(x) == ["c", "a"]
 
-            x[2] = null
-            @test x[1] === x.pool.valindex[2]
-            @test x[2] === null
-            @test levels(x) == ["c", "a"]
+        x[2] = null
+        @test x[1] === x.pool.valindex[2]
+        @test x[2] === null
+        @test levels(x) == ["c", "a"]
 
-            x[1] = "b"
-            @test x[1] === x.pool.valindex[3]
-            @test x[2] === null
-            @test levels(x) == ["c", "a", "b"]
+        x[1] = "b"
+        @test x[1] === x.pool.valindex[3]
+        @test x[2] === null
+        @test levels(x) == ["c", "a", "b"]
         end
     end
 end
@@ -984,12 +984,12 @@ end
     @test !isordered(r)
 
     @testset "preserves isordered" begin
-        # needed for instance when expanding an array with nulls
-        # such as vcat of DataFrame with missing columns
-        ordered!(ca1, true)
-        @test isempty(levels(ca2))
-        r = vcat(ca1, ca2)
-        @test isordered(r)
+    # needed for instance when expanding an array with nulls
+    # such as vcat of DataFrame with missing columns
+    ordered!(ca1, true)
+    @test isempty(levels(ca2))
+    r = vcat(ca1, ca2)
+    @test isordered(r)
     end
 end
 

--- a/test/12_nullablearray.jl
+++ b/test/12_nullablearray.jl
@@ -1,16 +1,13 @@
 module TestNullableArray
-
 using Base.Test
 using CategoricalArrays
 using CategoricalArrays: DefaultRefType, catvaluetype, leveltype
 
 const ≅ = isequal
 
-for ordered in (false, true)
-    for R in (CategoricalArrays.DefaultRefType, UInt8, UInt, Int8, Int)
-        # Vector with no null values
-        for a in (["b", "a", "b"],
-                  Union{String, Null}["b", "a", "b"])
+@testset "conversion ordered=$ordered" for ordered in (false, true)
+    @testset "conversion reftype=$R" for R in (CategoricalArrays.DefaultRefType, UInt8, UInt, Int8, Int)
+        @testset "conversion of $(typeof(a))" for a in (["b", "a", "b"], Union{String, Null}["b", "a", "b"])
             x = CategoricalVector{Union{String, Null}, R}(a, ordered=ordered)
 
             @test x == a
@@ -61,10 +58,12 @@ for ordered in (false, true)
             @test CategoricalVector{Union{String, Null}, DefaultRefType}(a, ordered=ordered) == x
             @test CategoricalVector{Union{String, Null}, UInt8}(a, ordered=ordered) == x
 
-            for (y, R1, R2, comp) in ((a, DefaultRefType, UInt8, true),
-                                      (a, DefaultRefType, DefaultRefType, false),
-                                      (x, R, UInt8, true),
-                                      (x, R, R, false))
+            @testset "categorical($(typeof(y)), compress=$comp) R1=$R1 R2=$R2" for (y, R1, R2, comp) in
+                ((a, DefaultRefType, UInt8, true),
+                 (a, DefaultRefType, DefaultRefType, false),
+                 (x, R, UInt8, true),
+                 (x, R, R, false))
+
                 x2 = categorical(y, ordered=ordered)
                 @test leveltype(x2) === String
                 @test catvaluetype(x2) === CategoricalArrays.CategoricalString{R1}
@@ -242,9 +241,8 @@ for ordered in (false, true)
             @test levels(x) == ["e", "c", "zz", "x", "y", "z"]
         end
 
-
-        # Vector with null values
-        let a = ["a", "b", null],
+        @testset "Vector with null values" begin
+            a = ["a", "b", null]
             x = CategoricalVector{Union{String, Null}, R}(a, ordered=ordered)
 
             @test x ≅ a
@@ -290,10 +288,12 @@ for ordered in (false, true)
             @test CategoricalVector{Union{String, Null}, DefaultRefType}(a, ordered=ordered) ≅ x
             @test CategoricalVector{Union{String, Null}, UInt8}(a, ordered=ordered) ≅ x
 
-            for (y, R1, R2, comp) in ((a, DefaultRefType, UInt8, true),
-                                      (a, DefaultRefType, DefaultRefType, false),
-                                      (x, R, UInt8, true),
-                                      (x, R, R, false))
+            @testset "categorical($(typeof(y)), compress=$comp) R1=$R1 R2=$R2" for (y, R1, R2, comp) in
+                ((a, DefaultRefType, UInt8, true),
+                 (a, DefaultRefType, DefaultRefType, false),
+                 (x, R, UInt8, true),
+                 (x, R, R, false))
+
                 x2 = categorical(y, ordered=ordered)
                 @test x2 ≅ y
                 if eltype(y) >: Null
@@ -381,193 +381,198 @@ for ordered in (false, true)
             @test levels(x) == ["a", "b", "c"]
         end
 
+        @testset "Vector created from range" begin
+            # (i.e. non-Array AbstractArray),
+            # direct conversion to a vector with different eltype
+            a = 0.0:0.5:1.5
+            x = CategoricalVector{Union{Float64, Null}, R}(a, ordered=ordered)
 
-        # Vector created from range (i.e. non-Array AbstractArray),
-        # direct conversion to a vector with different eltype
-        a = 0.0:0.5:1.5
-        x = CategoricalVector{Union{Float64, Null}, R}(a, ordered=ordered)
+            @test x == collect(a)
+            @test isordered(x) === ordered
+            @test levels(x) == unique(a)
+            @test size(x) === (4,)
+            @test length(x) === 4
+            @test leveltype(x) === Float64
+            @test catvaluetype(x) <: CategoricalArrays.CategoricalValue{Float64}
 
-        @test x == collect(a)
-        @test isordered(x) === ordered
-        @test levels(x) == unique(a)
-        @test size(x) === (4,)
-        @test length(x) === 4
-        @test leveltype(x) === Float64
-        @test catvaluetype(x) <: CategoricalArrays.CategoricalValue{Float64}
+            @test convert(CategoricalArray, x) === x
+            @test convert(CategoricalArray{Union{Float64, Null}}, x) === x
+            @test convert(CategoricalArray{Union{Float64, Null}, 1}, x) === x
+            @test convert(CategoricalArray{Union{Float64, Null}, 1, R}, x) === x
+            @test convert(CategoricalArray{Union{Float64, Null}, 1, DefaultRefType}, x) == x
+            @test convert(CategoricalArray{Union{Float64, Null}, 1, UInt8}, x) == x
 
-        @test convert(CategoricalArray, x) === x
-        @test convert(CategoricalArray{Union{Float64, Null}}, x) === x
-        @test convert(CategoricalArray{Union{Float64, Null}, 1}, x) === x
-        @test convert(CategoricalArray{Union{Float64, Null}, 1, R}, x) === x
-        @test convert(CategoricalArray{Union{Float64, Null}, 1, DefaultRefType}, x) == x
-        @test convert(CategoricalArray{Union{Float64, Null}, 1, UInt8}, x) == x
+            @test convert(CategoricalVector, x) === x
+            @test convert(CategoricalVector{Union{Float64, Null}}, x) === x
+            @test convert(CategoricalVector{Union{Float64, Null}, R}, x) === x
+            @test convert(CategoricalVector{Union{Float64, Null}, DefaultRefType}, x) == x
+            @test convert(CategoricalVector{Union{Float64, Null}, UInt8}, x) == x
 
-        @test convert(CategoricalVector, x) === x
-        @test convert(CategoricalVector{Union{Float64, Null}}, x) === x
-        @test convert(CategoricalVector{Union{Float64, Null}, R}, x) === x
-        @test convert(CategoricalVector{Union{Float64, Null}, DefaultRefType}, x) == x
-        @test convert(CategoricalVector{Union{Float64, Null}, UInt8}, x) == x
+            @test convert(CategoricalArray, a) == x
+            @test convert(CategoricalArray{Union{Float64, Null}}, a) == x
+            @test convert(CategoricalArray{Union{Float32, Null}}, a) == x
+            @test convert(CategoricalArray{Union{Float64, Null}, 1}, a) == x
+            @test convert(CategoricalArray{Union{Float32, Null}, 1}, a) == x
+            @test convert(CategoricalArray{Union{Float64, Null}, 1, R}, a) == x
+            @test convert(CategoricalArray{Union{Float32, Null}, 1, R}, a) == x
+            @test convert(CategoricalArray{Union{Float64, Null}, 1, DefaultRefType}, a) == x
+            @test convert(CategoricalArray{Union{Float32, Null}, 1, DefaultRefType}, a) == x
+            @test convert(CategoricalArray{Union{Float64, Null}, 1, UInt8}, a) == x
+            @test convert(CategoricalArray{Union{Float32, Null}, 1, UInt8}, a) == x
 
-        @test convert(CategoricalArray, a) == x
-        @test convert(CategoricalArray{Union{Float64, Null}}, a) == x
-        @test convert(CategoricalArray{Union{Float32, Null}}, a) == x
-        @test convert(CategoricalArray{Union{Float64, Null}, 1}, a) == x
-        @test convert(CategoricalArray{Union{Float32, Null}, 1}, a) == x
-        @test convert(CategoricalArray{Union{Float64, Null}, 1, R}, a) == x
-        @test convert(CategoricalArray{Union{Float32, Null}, 1, R}, a) == x
-        @test convert(CategoricalArray{Union{Float64, Null}, 1, DefaultRefType}, a) == x
-        @test convert(CategoricalArray{Union{Float32, Null}, 1, DefaultRefType}, a) == x
-        @test convert(CategoricalArray{Union{Float64, Null}, 1, UInt8}, a) == x
-        @test convert(CategoricalArray{Union{Float32, Null}, 1, UInt8}, a) == x
+            @test convert(CategoricalVector, a) == x
+            @test convert(CategoricalVector{Union{Float64, Null}}, a) == x
+            @test convert(CategoricalVector{Union{Float32, Null}}, a) == x
+            @test convert(CategoricalVector{Union{Float64, Null}, R}, a) == x
+            @test convert(CategoricalVector{Union{Float32, Null}, R}, a) == x
+            @test convert(CategoricalVector{Union{Float64, Null}, DefaultRefType}, a) == x
+            @test convert(CategoricalVector{Union{Float32, Null}, DefaultRefType}, a) == x
+            @test convert(CategoricalVector{Union{Float64, Null}, UInt8}, a) == x
+            @test convert(CategoricalVector{Union{Float32, Null}, UInt8}, a) == x
 
-        @test convert(CategoricalVector, a) == x
-        @test convert(CategoricalVector{Union{Float64, Null}}, a) == x
-        @test convert(CategoricalVector{Union{Float32, Null}}, a) == x
-        @test convert(CategoricalVector{Union{Float64, Null}, R}, a) == x
-        @test convert(CategoricalVector{Union{Float32, Null}, R}, a) == x
-        @test convert(CategoricalVector{Union{Float64, Null}, DefaultRefType}, a) == x
-        @test convert(CategoricalVector{Union{Float32, Null}, DefaultRefType}, a) == x
-        @test convert(CategoricalVector{Union{Float64, Null}, UInt8}, a) == x
-        @test convert(CategoricalVector{Union{Float32, Null}, UInt8}, a) == x
+            @test CategoricalArray{Union{Float64, Null}}(a, ordered=ordered) == x
+            @test CategoricalArray{Union{Float32, Null}}(a, ordered=ordered) == x
+            @test CategoricalArray{Union{Float64, Null}, 1}(a, ordered=ordered) == x
+            @test CategoricalArray{Union{Float32, Null}, 1}(a, ordered=ordered) == x
+            @test CategoricalArray{Union{Float64, Null}, 1, R}(a, ordered=ordered) == x
+            @test CategoricalArray{Union{Float32, Null}, 1, R}(a, ordered=ordered) == x
+            @test CategoricalArray{Union{Float64, Null}, 1, DefaultRefType}(a, ordered=ordered) == x
+            @test CategoricalArray{Union{Float32, Null}, 1, DefaultRefType}(a, ordered=ordered) == x
 
-        @test CategoricalArray{Union{Float64, Null}}(a, ordered=ordered) == x
-        @test CategoricalArray{Union{Float32, Null}}(a, ordered=ordered) == x
-        @test CategoricalArray{Union{Float64, Null}, 1}(a, ordered=ordered) == x
-        @test CategoricalArray{Union{Float32, Null}, 1}(a, ordered=ordered) == x
-        @test CategoricalArray{Union{Float64, Null}, 1, R}(a, ordered=ordered) == x
-        @test CategoricalArray{Union{Float32, Null}, 1, R}(a, ordered=ordered) == x
-        @test CategoricalArray{Union{Float64, Null}, 1, DefaultRefType}(a, ordered=ordered) == x
-        @test CategoricalArray{Union{Float32, Null}, 1, DefaultRefType}(a, ordered=ordered) == x
+            @test CategoricalVector(a, ordered=ordered) == x
+            @test CategoricalVector{Union{Float64, Null}}(a, ordered=ordered) == x
+            @test CategoricalVector{Union{Float32, Null}}(a, ordered=ordered) == x
+            @test CategoricalVector{Union{Float64, Null}, R}(a, ordered=ordered) == x
+            @test CategoricalVector{Union{Float32, Null}, R}(a, ordered=ordered) == x
+            @test CategoricalVector{Union{Float64, Null}, DefaultRefType}(a, ordered=ordered) == x
+            @test CategoricalVector{Union{Float32, Null}, DefaultRefType}(a, ordered=ordered) == x
 
-        @test CategoricalVector(a, ordered=ordered) == x
-        @test CategoricalVector{Union{Float64, Null}}(a, ordered=ordered) == x
-        @test CategoricalVector{Union{Float32, Null}}(a, ordered=ordered) == x
-        @test CategoricalVector{Union{Float64, Null}, R}(a, ordered=ordered) == x
-        @test CategoricalVector{Union{Float32, Null}, R}(a, ordered=ordered) == x
-        @test CategoricalVector{Union{Float64, Null}, DefaultRefType}(a, ordered=ordered) == x
-        @test CategoricalVector{Union{Float32, Null}, DefaultRefType}(a, ordered=ordered) == x
+            @testset "categorical($(typeof(y)), compress=$comp) R1=$R1 R2=$R2" for (y, R1, R2, comp) in
+                ((a, DefaultRefType, UInt8, true),
+                 (a, DefaultRefType, DefaultRefType, false),
+                 (x, R, UInt8, true),
+                 (x, R, R, false))
 
-        for (y, R1, R2, comp) in ((a, DefaultRefType, UInt8, true),
-                                  (a, DefaultRefType, DefaultRefType, false),
-                                  (x, R, UInt8, true),
-                                  (x, R, R, false))
-            x2 = categorical(y, ordered=ordered)
-            @test x2 == collect(y)
-            if eltype(y) >: Null
-                @test isa(x2, CategoricalVector{Union{Float64, Null}, R1})
-            else
-                @test isa(x2, CategoricalVector{Float64, R1})
+                x2 = categorical(y, ordered=ordered)
+                @test x2 == collect(y)
+                if eltype(y) >: Null
+                    @test isa(x2, CategoricalVector{Union{Float64, Null}, R1})
+                else
+                    @test isa(x2, CategoricalVector{Float64, R1})
+                end
+                @test isordered(x2) === ordered
+                @test leveltype(x2) === Float64
+                @test catvaluetype(x2) === CategoricalArrays.CategoricalValue{Float64, R1}
+
+                x2 = categorical(y, comp, ordered=ordered)
+                @test x2 == collect(y)
+                if eltype(y) >: Null
+                    @test isa(x2, CategoricalVector{Union{Float64, Null}, R2})
+                else
+                    @test isa(x2, CategoricalVector{Float64, R2})
+                end
+                @test isordered(x2) === ordered
+                @test leveltype(x2) === Float64
+                @test catvaluetype(x2) === CategoricalArrays.CategoricalValue{Float64, R2}
             end
-            @test isordered(x2) === ordered
-            @test leveltype(x2) === Float64
-            @test catvaluetype(x2) === CategoricalArrays.CategoricalValue{Float64, R1}
 
-            x2 = categorical(y, comp, ordered=ordered)
-            @test x2 == collect(y)
-            if eltype(y) >: Null
-                @test isa(x2, CategoricalVector{Union{Float64, Null}, R2})
-            else
-                @test isa(x2, CategoricalVector{Float64, R2})
-            end
-            @test isordered(x2) === ordered
-            @test leveltype(x2) === Float64
-            @test catvaluetype(x2) === CategoricalArrays.CategoricalValue{Float64, R2}
+            x2 = compress(x)
+            @test x2 == x
+            @test isordered(x2) === isordered(x)
+            @test isa(x2, CategoricalVector{Union{Float64, Null}, UInt8})
+            @test levels(x2) == levels(x)
+
+            x2 = copy(x)
+            @test x2 == x
+            @test isordered(x2) === isordered(x)
+            @test typeof(x2) === typeof(x)
+            @test levels(x2) == levels(x)
+
+            @test x[1] === x.pool.valindex[1]
+            @test x[2] === x.pool.valindex[2]
+            @test x[3] === x.pool.valindex[3]
+            @test x[4] === x.pool.valindex[4]
+            @test_throws BoundsError x[5]
+
+            x2 = x[:]
+            @test typeof(x2) === typeof(x)
+            @test x2 == x
+            @test x2 !== x
+            @test levels(x2) == levels(x)
+            @test levels(x2) !== levels(x)
+            @test isordered(x2) == isordered(x)
+
+            x2 = x[1:2]
+            @test typeof(x2) === typeof(x)
+            @test x2 == [0.0, 0.5]
+            @test levels(x2) == levels(x)
+            @test levels(x2) !== levels(x)
+            @test isordered(x2) == isordered(x)
+
+            x2 = x[1:1]
+            @test typeof(x2) === typeof(x)
+            @test x2 == [0.0]
+            @test levels(x2) == levels(x)
+            @test levels(x2) !== levels(x)
+            @test isordered(x2) == isordered(x)
+
+            x2 = x[2:1]
+            @test typeof(x2) === typeof(x)
+            @test isempty(x2)
+            @test levels(x2) == levels(x)
+            @test levels(x2) !== levels(x)
+            @test isordered(x2) == isordered(x)
+
+            x[2] = 1
+            @test x[1] === x.pool.valindex[1]
+            @test x[2] === x.pool.valindex[3]
+            @test x[3] === x.pool.valindex[3]
+            @test x[4] === x.pool.valindex[4]
+            @test levels(x) == unique(a)
+
+            x[1:2] = -1
+            @test x[1] === x.pool.valindex[5]
+            @test x[2] === x.pool.valindex[5]
+            @test x[3] === x.pool.valindex[3]
+            @test x[4] === x.pool.valindex[4]
+            @test levels(x) == vcat(unique(a), -1)
+
+            push!(x, 2.0)
+            @test length(x) == 5
+            @test x == [-1.0, -1.0, 1.0, 1.5, 2.0]
+            @test isordered(x) === ordered
+            @test levels(x) == [0.0,  0.5,  1.0,  1.5, -1.0,  2.0]
+
+            push!(x, x[1])
+            @test length(x) == 6
+            @test x == [-1.0, -1.0, 1.0, 1.5, 2.0, -1.0]
+            @test isordered(x) === ordered
+            @test levels(x) == [0.0,  0.5,  1.0,  1.5, -1.0,  2.0]
+
+            append!(x, x)
+            @test length(x) == 12
+            @test x == [-1.0, -1.0, 1.0, 1.5, 2.0, -1.0, -1.0, -1.0, 1.0, 1.5, 2.0, -1.0]
+            @test isordered(x) === ordered
+            @test levels(x) == [0.0,  0.5,  1.0,  1.5, -1.0,  2.0]
+
+            b = [2.5, 3.0, -3.5]
+            y = CategoricalVector{Union{Float64, Null}, R}(b)
+            append!(x, y)
+            @test length(x) == 15
+            @test x == [-1.0, -1.0, 1.0, 1.5, 2.0, -1.0, -1.0, -1.0, 1.0, 1.5, 2.0, -1.0, 2.5, 3.0, -3.5]
+            @test isordered(x) === ordered
+            @test levels(x) == [0.0, 0.5, 1.0, 1.5, -1.0, 2.0, -3.5, 2.5, 3.0]
+
+            empty!(x)
+            @test length(x) == 0
+            @test isordered(x) === ordered
+            @test levels(x) == [0.0, 0.5, 1.0, 1.5, -1.0, 2.0, -3.5, 2.5, 3.0]
         end
 
-        x2 = compress(x)
-        @test x2 == x
-        @test isordered(x2) === isordered(x)
-        @test isa(x2, CategoricalVector{Union{Float64, Null}, UInt8})
-        @test levels(x2) == levels(x)
+        @testset "Matrix $(typeof(a)) with no null values" for a in
+            (["a" "b" "c"; "b" "a" "c"],
+             Union{String, Null}["a" "b" "c"; "b" "a" "c"])
 
-        x2 = copy(x)
-        @test x2 == x
-        @test isordered(x2) === isordered(x)
-        @test typeof(x2) === typeof(x)
-        @test levels(x2) == levels(x)
-
-        @test x[1] === x.pool.valindex[1]
-        @test x[2] === x.pool.valindex[2]
-        @test x[3] === x.pool.valindex[3]
-        @test x[4] === x.pool.valindex[4]
-        @test_throws BoundsError x[5]
-
-        x2 = x[:]
-        @test typeof(x2) === typeof(x)
-        @test x2 == x
-        @test x2 !== x
-        @test levels(x2) == levels(x)
-        @test levels(x2) !== levels(x)
-        @test isordered(x2) == isordered(x)
-
-        x2 = x[1:2]
-        @test typeof(x2) === typeof(x)
-        @test x2 == [0.0, 0.5]
-        @test levels(x2) == levels(x)
-        @test levels(x2) !== levels(x)
-        @test isordered(x2) == isordered(x)
-
-        x2 = x[1:1]
-        @test typeof(x2) === typeof(x)
-        @test x2 == [0.0]
-        @test levels(x2) == levels(x)
-        @test levels(x2) !== levels(x)
-        @test isordered(x2) == isordered(x)
-
-        x2 = x[2:1]
-        @test typeof(x2) === typeof(x)
-        @test isempty(x2)
-        @test levels(x2) == levels(x)
-        @test levels(x2) !== levels(x)
-        @test isordered(x2) == isordered(x)
-
-        x[2] = 1
-        @test x[1] === x.pool.valindex[1]
-        @test x[2] === x.pool.valindex[3]
-        @test x[3] === x.pool.valindex[3]
-        @test x[4] === x.pool.valindex[4]
-        @test levels(x) == unique(a)
-
-        x[1:2] = -1
-        @test x[1] === x.pool.valindex[5]
-        @test x[2] === x.pool.valindex[5]
-        @test x[3] === x.pool.valindex[3]
-        @test x[4] === x.pool.valindex[4]
-        @test levels(x) == vcat(unique(a), -1)
-
-        push!(x, 2.0)
-        @test length(x) == 5
-        @test x == [-1.0, -1.0, 1.0, 1.5, 2.0]
-        @test isordered(x) === ordered
-        @test levels(x) == [0.0,  0.5,  1.0,  1.5, -1.0,  2.0]
-
-        push!(x, x[1])
-        @test length(x) == 6
-        @test x == [-1.0, -1.0, 1.0, 1.5, 2.0, -1.0]
-        @test isordered(x) === ordered
-        @test levels(x) == [0.0,  0.5,  1.0,  1.5, -1.0,  2.0]
-
-        append!(x, x)
-        @test length(x) == 12
-        @test x == [-1.0, -1.0, 1.0, 1.5, 2.0, -1.0, -1.0, -1.0, 1.0, 1.5, 2.0, -1.0]
-        @test isordered(x) === ordered
-        @test levels(x) == [0.0,  0.5,  1.0,  1.5, -1.0,  2.0]
-
-        b = [2.5, 3.0, -3.5]
-        y = CategoricalVector{Union{Float64, Null}, R}(b)
-        append!(x, y)
-        @test length(x) == 15
-        @test x == [-1.0, -1.0, 1.0, 1.5, 2.0, -1.0, -1.0, -1.0, 1.0, 1.5, 2.0, -1.0, 2.5, 3.0, -3.5]
-        @test isordered(x) === ordered
-        @test levels(x) == [0.0, 0.5, 1.0, 1.5, -1.0, 2.0, -3.5, 2.5, 3.0]
-
-        empty!(x)
-        @test length(x) == 0
-        @test isordered(x) === ordered
-        @test levels(x) == [0.0, 0.5, 1.0, 1.5, -1.0, 2.0, -3.5, 2.5, 3.0]
-
-        # Matrix with no null values
-        for a in (["a" "b" "c"; "b" "a" "c"], Union{String, Null}["a" "b" "c"; "b" "a" "c"])
             x = CategoricalMatrix{Union{String, Null}, R}(a, ordered=ordered)
 
             @test x == a
@@ -614,27 +619,29 @@ for ordered in (false, true)
             @test CategoricalMatrix{Union{String, Null}, DefaultRefType}(a, ordered=ordered) == x
             @test CategoricalMatrix{Union{String, Null}, UInt8}(a, ordered=ordered) == x
 
-            for (y, R1, R2, comp) in ((a, DefaultRefType, UInt8, true),
-                                      (a, DefaultRefType, DefaultRefType, false),
-                                      (x, R, UInt8, true),
-                                      (x, R, R, false))
-            x2 = categorical(y, ordered=ordered)
-            @test x2 == y
-            if eltype(y) >: Null
-                @test isa(x2, CategoricalMatrix{Union{String, Null}, R1})
-            else
-                @test isa(x2, CategoricalMatrix{String, R1})
-            end
-            @test isordered(x2) === ordered
+            @testset "categorical($(typeof(y)), compress=$comp) R1=$R1 R2=$R2" for (y, R1, R2, comp) in
+                ((a, DefaultRefType, UInt8, true),
+                 (a, DefaultRefType, DefaultRefType, false),
+                 (x, R, UInt8, true),
+                 (x, R, R, false))
 
-            x2 = categorical(y, comp, ordered=ordered)
-            @test x2 == y
-            if eltype(y) >: Null
-                @test isa(x2, CategoricalMatrix{Union{String, Null}, R2})
-            else
-                @test isa(x2, CategoricalMatrix{String, R2})
-            end
-            @test isordered(x2) === ordered
+                x2 = categorical(y, ordered=ordered)
+                @test x2 == y
+                if eltype(y) >: Null
+                    @test isa(x2, CategoricalMatrix{Union{String, Null}, R1})
+                else
+                    @test isa(x2, CategoricalMatrix{String, R1})
+                end
+                @test isordered(x2) === ordered
+
+                x2 = categorical(y, comp, ordered=ordered)
+                @test x2 == y
+                if eltype(y) >: Null
+                    @test isa(x2, CategoricalMatrix{Union{String, Null}, R2})
+                else
+                    @test isa(x2, CategoricalMatrix{String, R2})
+                end
+                @test isordered(x2) === ordered
             end
 
             x2 = compress(x)
@@ -700,9 +707,8 @@ for ordered in (false, true)
             @test levels(x) == ["a", "b", "c", "z"]
         end
 
-
-        # Matrix with null values
-        let a = ["a" null "c"; "b" "a" null]
+        @testset "Matrix with null values" begin
+            a = ["a" null "c"; "b" "a" null]
             x = CategoricalMatrix{Union{String, Null}, R}(a, ordered=ordered)
 
             @test x ≅ a
@@ -749,10 +755,12 @@ for ordered in (false, true)
             @test CategoricalMatrix{Union{String, Null}, DefaultRefType}(a, ordered=ordered) ≅ x
             @test CategoricalMatrix{Union{String, Null}, UInt8}(a, ordered=ordered) ≅ x
 
-            for (y, R1, R2, comp) in ((a, DefaultRefType, UInt8, true),
-                                      (a, DefaultRefType, DefaultRefType, false),
-                                      (x, R, UInt8, true),
-                                      (x, R, R, false))
+            @testset "categorical($(typeof(y)), compress=$comp) R1=$R1 R2=$R2" for (y, R1, R2, comp) in
+                ((a, DefaultRefType, UInt8, true),
+                 (a, DefaultRefType, DefaultRefType, false),
+                 (x, R, UInt8, true),
+                 (x, R, R, false))
+
                 x2 = categorical(y, ordered=ordered)
                 @test x2 ≅ y
                 @test isa(x2, CategoricalMatrix{Union{String, Null}, R1})
@@ -899,7 +907,6 @@ for ordered in (false, true)
             @test levels(x) == ["a", "b", "c", "z"]
         end
 
-
         # Uninitialized array
         v = Any[CategoricalArray{Union{String, Null}}(2, ordered=ordered),
                 CategoricalArray{Union{String, Null}, 1}(2, ordered=ordered),
@@ -912,7 +919,7 @@ for ordered in (false, true)
                 CategoricalMatrix{Union{String, Null}}(2, 3, ordered=ordered),
                 CategoricalMatrix{Union{String, Null}, R}(2, 3, ordered=ordered)]
 
-        for x in v
+        @testset "Uninitialized $(typeof(x))" for x in v
             @test isordered(x) === ordered
             @test isnull(x[1])
             @test isnull(x[2])
@@ -953,103 +960,107 @@ for ordered in (false, true)
     end
 end
 
-# Test vcat with nulls
-ca1 = CategoricalArray(["a", null])
-ca2 = CategoricalArray([null, "a"])
-r = vcat(ca1, ca2)
-@test r ≅ CategoricalArray(["a", null, null, "a"])
-@test levels(r) == ["a"]
-@test !isordered(r)
-ordered!(ca1,true)
-@test !isordered(vcat(ca1, ca2))
-ordered!(ca2,true)
-@test isordered(vcat(ca1, ca2))
-ordered!(ca1,false)
-@test !isordered(vcat(ca1, ca2))
+@testset "vcat with nulls" begin
+    ca1 = CategoricalArray(["a", null])
+    ca2 = CategoricalArray([null, "a"])
+    r = vcat(ca1, ca2)
+    @test r ≅ CategoricalArray(["a", null, null, "a"])
+    @test levels(r) == ["a"]
+    @test !isordered(r)
+    ordered!(ca1,true)
+    @test !isordered(vcat(ca1, ca2))
+    ordered!(ca2,true)
+    @test isordered(vcat(ca1, ca2))
+    ordered!(ca1,false)
+    @test !isordered(vcat(ca1, ca2))
+end
 
-# vcat with all nulls
-ca1 = CategoricalArray(["a", null])
-ca2 = CategoricalArray([null, null])
-r = vcat(ca1, ca2)
-@test r ≅ ["a", null, null, null]
-@test levels(r) == ["a"]
-@test !isordered(r)
+@testset "vcat with all nulls" begin
+    ca1 = CategoricalArray(["a", null])
+    ca2 = CategoricalArray([null, null])
+    r = vcat(ca1, ca2)
+    @test r ≅ ["a", null, null, null]
+    @test levels(r) == ["a"]
+    @test !isordered(r)
 
-# vcat with all nulls preserves isordered
-# needed for instance when expanding an array with nulls
-# such as vcat of DataFrame with missing columns
-ordered!(ca1, true)
-@test isempty(levels(ca2))
-r = vcat(ca1, ca2)
-@test isordered(r)
+    @testset "preserves isordered" begin
+        # needed for instance when expanding an array with nulls
+        # such as vcat of DataFrame with missing columns
+        ordered!(ca1, true)
+        @test isempty(levels(ca2))
+        r = vcat(ca1, ca2)
+        @test isordered(r)
+    end
+end
 
-# vcat with all empty array
-ca1 = CategoricalArray(0)
-ca2 = CategoricalArray([null, "b"])
-r = vcat(ca1, ca2)
-@test r ≅ [null, "b"]
-@test levels(r) == ["b"]
-@test !isordered(r)
+@testset "vcat with all empty array" begin
+    ca1 = CategoricalArray(0)
+    ca2 = CategoricalArray([null, "b"])
+    r = vcat(ca1, ca2)
+    @test r ≅ [null, "b"]
+    @test levels(r) == ["b"]
+    @test !isordered(r)
+end
 
-# vcat with all nulls and empty
-ca1 = CategoricalArray(0)
-ca2 = CategoricalArray([null, null])
-r = vcat(ca1, ca2)
-@test r ≅ [null, null]
-@test levels(r) == String[]
-@test !isordered(r)
+@testset "vcat with all nulls and empty" begin
+    ca1 = CategoricalArray(0)
+    ca2 = CategoricalArray([null, null])
+    r = vcat(ca1, ca2)
+    @test r ≅ [null, null]
+    @test levels(r) == String[]
+    @test !isordered(r)
 
-ordered!(ca1, true)
-@test isempty(levels(ca2))
-r = vcat(ca1, ca2)
-@test isordered(r)
+    ordered!(ca1, true)
+    @test isempty(levels(ca2))
+    r = vcat(ca1, ca2)
+    @test isordered(r)
 
-ca1 = CategoricalArray(["a", null])
-ca2 = CategoricalArray{Union{String, Null}}(2)
-ordered!(ca1, true)
-@test isempty(levels(ca2))
-r = vcat(ca1, ca2)
-@test r ≅ ["a", null, null, null]
-@test isordered(r)
+    ca1 = CategoricalArray(["a", null])
+    ca2 = CategoricalArray{Union{String, Null}}(2)
+    ordered!(ca1, true)
+    @test isempty(levels(ca2))
+    r = vcat(ca1, ca2)
+    @test r ≅ ["a", null, null, null]
+    @test isordered(r)
+end
 
+@testset "unique() and levels()" begin
+    x = CategoricalArray(["Old", "Young", "Middle", null, "Young"])
+    @test levels(x) == ["Middle", "Old", "Young"]
+    @test unique(x) ≅ ["Middle", "Old", "Young", null]
+    @test levels!(x, ["Young", "Middle", "Old"]) === x
+    @test levels(x) == ["Young", "Middle", "Old"]
+    @test unique(x) ≅ ["Young", "Middle", "Old", null]
+    @test levels!(x, ["Young", "Middle", "Old", "Unused"]) === x
+    @test levels(x) == ["Young", "Middle", "Old", "Unused"]
+    @test unique(x) ≅ ["Young", "Middle", "Old", null]
+    @test levels!(x, ["Unused1", "Young", "Middle", "Old", "Unused2"]) === x
+    @test levels(x) == ["Unused1", "Young", "Middle", "Old", "Unused2"]
+    @test unique(x) ≅["Young", "Middle", "Old", null]
 
-# Test unique() and levels()
+    x = CategoricalArray((Union{String, Null})[null])
+    @test isa(levels(x), Vector{String}) && isempty(levels(x))
+    @test unique(x) ≅ [null]
+    @test levels!(x, ["Young", "Middle", "Old"]) === x
+    @test levels(x) == ["Young", "Middle", "Old"]
+    @test unique(x) ≅ [null]
 
-x = CategoricalArray(["Old", "Young", "Middle", null, "Young"])
-@test levels(x) == ["Middle", "Old", "Young"]
-@test unique(x) ≅ ["Middle", "Old", "Young", null]
-@test levels!(x, ["Young", "Middle", "Old"]) === x
-@test levels(x) == ["Young", "Middle", "Old"]
-@test unique(x) ≅ ["Young", "Middle", "Old", null]
-@test levels!(x, ["Young", "Middle", "Old", "Unused"]) === x
-@test levels(x) == ["Young", "Middle", "Old", "Unused"]
-@test unique(x) ≅ ["Young", "Middle", "Old", null]
-@test levels!(x, ["Unused1", "Young", "Middle", "Old", "Unused2"]) === x
-@test levels(x) == ["Unused1", "Young", "Middle", "Old", "Unused2"]
-@test unique(x) ≅["Young", "Middle", "Old", null]
+    # To test short-circuit after 1000 elements
+    x = CategoricalArray{Union{Int, Null}}(repeat(1:1500, inner=10))
+    @test levels(x) == collect(1:1500)
+    @test unique(x) == collect(1:1500)
+    @test levels!(x, [1600:-1:1; 2000]) === x
+    x[3] = null
+    @test levels(x) == [1600:-1:1; 2000]
+    @test unique(x) ≅ [1500:-1:3; 2; 1; null]
 
-x = CategoricalArray((Union{String, Null})[null])
-@test isa(levels(x), Vector{String}) && isempty(levels(x))
-@test unique(x) ≅ [null]
-@test levels!(x, ["Young", "Middle", "Old"]) === x
-@test levels(x) == ["Young", "Middle", "Old"]
-@test unique(x) ≅ [null]
+    # in
+    x = CategoricalArray{Int}(repeat(1:1500, inner=10))
+    @test !(null in x)
 
-# To test short-circuit after 1000 elements
-x = CategoricalArray{Union{Int, Null}}(repeat(1:1500, inner=10))
-@test levels(x) == collect(1:1500)
-@test unique(x) == collect(1:1500)
-@test levels!(x, [1600:-1:1; 2000]) === x
-x[3] = null
-@test levels(x) == [1600:-1:1; 2000]
-@test unique(x) ≅ [1500:-1:3; 2; 1; null]
-
-# in
-x = CategoricalArray{Int}(repeat(1:1500, inner=10))
-@test !(null in x)
-
-x = CategoricalArray{Union{Int, Null}}(repeat(1:1500, inner=10))
-x[1] = null
-@test null in x
+    x = CategoricalArray{Union{Int, Null}}(repeat(1:1500, inner=10))
+    x[1] = null
+    @test null in x
+end
 
 end

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -1,5 +1,4 @@
 module TestArrayCommon
-
 using Base.Test
 using CategoricalArrays
 using CategoricalArrays: DefaultRefType, index
@@ -7,198 +6,201 @@ using CategoricalArrays: DefaultRefType, index
 const ≅ = isequal
 const ≇ = !isequal
 
-# Test that mergelevels handles mutually compatible orderings
-@test CategoricalArrays.mergelevels(true, [6, 2, 4, 8], [2, 3, 5, 4], [2, 4, 8]) ==
-    ([6, 2, 3, 5, 4, 8], true)
-@test CategoricalArrays.mergelevels(true, ["A", "B", "D"], ["C", "D", "E", "F"], ["B", "C", "E"]) ==
-    (["A", "B", "C", "D", "E", "F"], true)
-@test CategoricalArrays.mergelevels(true, ["A", "B", "D"], ["C", "D", "E", "F"], ["A", "B", "C", "F"]) ==
-    (["A", "B", "C", "D", "E", "F"], true)
-@test CategoricalArrays.mergelevels(true, ["B", "C", "D"], ["A", "B"]) ==
-    (["A", "B", "C", "D"], true)
-@test CategoricalArrays.mergelevels(true, ["B", "C", "D"], []) ==
-    (["B", "C", "D"], true)
-@test CategoricalArrays.mergelevels(true, [], ["A", "C"]) ==
-    (["A", "C"], true)
-@test CategoricalArrays.mergelevels(true, [], []) ==
-    ([], true)
-@test CategoricalArrays.mergelevels(true, ["A", "B", "C"], [], ["A", "C", "D"]) ==
-    (["A", "B", "C", "D"], true)
-@test CategoricalArrays.mergelevels(true, [], ["A", "B", "C"], ["A", "C", "D"]) ==
-    (["A", "B", "C", "D"], true)
-@test CategoricalArrays.mergelevels(true, ["A", "C", "D"], ["A", "B", "C"], []) ==
-    (["A", "B", "C", "D"], true)
-@test CategoricalArrays.mergelevels(true, [], ["A", "C", "D"], []) ==
-    (["A", "C", "D"], true)
-@test CategoricalArrays.mergelevels(true, ["A", "C", "D"], [], []) ==
-    (["A", "C", "D"], true)
-@test CategoricalArrays.mergelevels(true, [], [], ["A", "C", "D"]) ==
-    (["A", "C", "D"], true)
-@test CategoricalArrays.mergelevels(true, [], [], []) ==
-    ([], true)
-@test CategoricalArrays.mergelevels(true, ["A", "C", "D"], ["A", "B", "C"], ["A", "D", "E"], ["C", "D"]) ==
-    (["A", "B", "C", "D", "E"], true)
+@testset "mergelevels()" begin
+    # Test that mergelevels handles mutually compatible orderings
+    @test CategoricalArrays.mergelevels(true, [6, 2, 4, 8], [2, 3, 5, 4], [2, 4, 8]) ==
+        ([6, 2, 3, 5, 4, 8], true)
+    @test CategoricalArrays.mergelevels(true, ["A", "B", "D"], ["C", "D", "E", "F"], ["B", "C", "E"]) ==
+        (["A", "B", "C", "D", "E", "F"], true)
+    @test CategoricalArrays.mergelevels(true, ["A", "B", "D"], ["C", "D", "E", "F"], ["A", "B", "C", "F"]) ==
+        (["A", "B", "C", "D", "E", "F"], true)
+    @test CategoricalArrays.mergelevels(true, ["B", "C", "D"], ["A", "B"]) ==
+        (["A", "B", "C", "D"], true)
+    @test CategoricalArrays.mergelevels(true, ["B", "C", "D"], []) ==
+        (["B", "C", "D"], true)
+    @test CategoricalArrays.mergelevels(true, [], ["A", "C"]) ==
+        (["A", "C"], true)
+    @test CategoricalArrays.mergelevels(true, [], []) ==
+        ([], true)
+    @test CategoricalArrays.mergelevels(true, ["A", "B", "C"], [], ["A", "C", "D"]) ==
+        (["A", "B", "C", "D"], true)
+    @test CategoricalArrays.mergelevels(true, [], ["A", "B", "C"], ["A", "C", "D"]) ==
+        (["A", "B", "C", "D"], true)
+    @test CategoricalArrays.mergelevels(true, ["A", "C", "D"], ["A", "B", "C"], []) ==
+        (["A", "B", "C", "D"], true)
+    @test CategoricalArrays.mergelevels(true, [], ["A", "C", "D"], []) ==
+        (["A", "C", "D"], true)
+    @test CategoricalArrays.mergelevels(true, ["A", "C", "D"], [], []) ==
+        (["A", "C", "D"], true)
+    @test CategoricalArrays.mergelevels(true, [], [], ["A", "C", "D"]) ==
+        (["A", "C", "D"], true)
+    @test CategoricalArrays.mergelevels(true, [], [], []) ==
+        ([], true)
+    @test CategoricalArrays.mergelevels(true, ["A", "C", "D"], ["A", "B", "C"], ["A", "D", "E"], ["C", "D"]) ==
+        (["A", "B", "C", "D", "E"], true)
 
-# Test that mergelevels handles mutually incompatible orderings
-@test CategoricalArrays.mergelevels(true, [6, 3, 4, 7], [2, 3, 6, 5, 4], [2, 4, 8]) ==
-    ([6, 2, 3, 5, 4, 7, 8], false)
-@test CategoricalArrays.mergelevels(true, ["A", "C", "D"], ["D", "C"], []) ==
-    (["A", "C", "D"], false)
-@test CategoricalArrays.mergelevels(true, ["A", "D", "C"], ["A", "B", "C"], ["A", "D", "E"], ["C", "D"]) ==
-    (["A", "D", "B", "C", "E"], false)
+    # Test that mergelevels handles mutually incompatible orderings
+    @test CategoricalArrays.mergelevels(true, [6, 3, 4, 7], [2, 3, 6, 5, 4], [2, 4, 8]) ==
+        ([6, 2, 3, 5, 4, 7, 8], false)
+    @test CategoricalArrays.mergelevels(true, ["A", "C", "D"], ["D", "C"], []) ==
+        (["A", "C", "D"], false)
+    @test CategoricalArrays.mergelevels(true, ["A", "D", "C"], ["A", "B", "C"], ["A", "D", "E"], ["C", "D"]) ==
+        (["A", "D", "B", "C", "E"], false)
 
-# Test that mergelevels handles incomplete orderings
-@test CategoricalArrays.mergelevels(true, ["B", "C", "D"], ["A", "C"]) ==
-    (["B", "A", "C", "D"], false)
-@test CategoricalArrays.mergelevels(true, ["A", "B", "D"], ["C", "D", "E", "F"]) ==
-    (["A", "B", "C", "D", "E", "F"], false)
-@test CategoricalArrays.mergelevels(true, ["A", "B", "E", "G"], ["C", "D", "E", "F"]) ==
-    (["A", "B", "C", "D", "E", "G", "F"], false)
-@test CategoricalArrays.mergelevels(true, ["A", "B", "D"], ["C", "D", "E", "F"], ["A", "B", "D", "F"]) ==
-    (["A", "B", "C", "D", "E", "F"], false)
+    # Test that mergelevels handles incomplete orderings
+    @test CategoricalArrays.mergelevels(true, ["B", "C", "D"], ["A", "C"]) ==
+        (["B", "A", "C", "D"], false)
+    @test CategoricalArrays.mergelevels(true, ["A", "B", "D"], ["C", "D", "E", "F"]) ==
+        (["A", "B", "C", "D", "E", "F"], false)
+    @test CategoricalArrays.mergelevels(true, ["A", "B", "E", "G"], ["C", "D", "E", "F"]) ==
+        (["A", "B", "C", "D", "E", "G", "F"], false)
+    @test CategoricalArrays.mergelevels(true, ["A", "B", "D"], ["C", "D", "E", "F"], ["A", "B", "D", "F"]) ==
+        (["A", "B", "C", "D", "E", "F"], false)
 
-# Test with ordered=false (simpler, almost a subset of code paths tested above)
-@test CategoricalArrays.mergelevels(false, ["A", "B", "E", "G"], ["C", "D", "E", "F"]) ==
-    (["A", "B", "C", "D", "E", "G", "F"], false)
+    # Test with ordered=false (simpler, almost a subset of code paths tested above)
+    @test CategoricalArrays.mergelevels(false, ["A", "B", "E", "G"], ["C", "D", "E", "F"]) ==
+        (["A", "B", "C", "D", "E", "G", "F"], false)
+end
 
+@testset "Testing $T" for T in (Union{}, Null)
+    @testset "vcat()" begin
+        # Test that vcat of compress arrays uses a reftype that doesn't overflow
+        a1 = 3:200
+        a2 = 300:-1:100
+        ca1 = CategoricalArray{Union{T, Int}}(a1)
+        ca2 = CategoricalArray{Union{T, Int}}(a2)
+        cca1 = compress(ca1)
+        cca2 = compress(ca2)
+        r = vcat(cca1, cca2)
+        @test r == vcat(a1, a2)
+        @test isa(cca1, CategoricalArray{Union{T, Int}, 1, UInt8})
+        @test isa(cca2, CategoricalArray{Union{T, Int}, 1, UInt8})
+        @test isa(r, CategoricalArray{Union{T, Int}, 1, CategoricalArrays.DefaultRefType})
+        @test isa(vcat(cca1, ca2), CategoricalArray{Union{T, Int}, 1, CategoricalArrays.DefaultRefType})
+        @test isordered(r) == false
+        @test levels(r) == collect(3:300)
 
-for T in (Union{}, Null)
-    # Test vcat()
+        # Test vcat of multidimensional arrays
+        a1 = Array{Int}(2, 3, 4, 5)
+        a2 = Array{Int}(3, 3, 4, 5)
+        a1[1:end] = (length(a1):-1:1) + 2
+        a2[1:end] = (1:length(a2)) + 10
+        ca1 = CategoricalArray{Union{T, Int}}(a1)
+        ca2 = CategoricalArray{Union{T, Int}}(a2)
+        cca1 = compress(ca1)
+        cca2 = compress(ca2)
+        r = vcat(cca1, cca2)
+        @test r == vcat(a1, a2)
+        @test isa(r, CategoricalArray{Union{T, Int}, 4, CategoricalArrays.DefaultRefType})
+        @test isordered(r) == false
+        @test levels(r) == collect(3:length(a2)+10)
 
-    # Test that vcat of compress arrays uses a reftype that doesn't overflow
-    a1 = 3:200
-    a2 = 300:-1:100
-    ca1 = CategoricalArray{Union{T, Int}}(a1)
-    ca2 = CategoricalArray{Union{T, Int}}(a2)
-    cca1 = compress(ca1)
-    cca2 = compress(ca2)
-    r = vcat(cca1, cca2)
-    @test r == vcat(a1, a2)
-    @test isa(cca1, CategoricalArray{Union{T, Int}, 1, UInt8})
-    @test isa(cca2, CategoricalArray{Union{T, Int}, 1, UInt8})
-    @test isa(r, CategoricalArray{Union{T, Int}, 1, CategoricalArrays.DefaultRefType})
-    @test isa(vcat(cca1, ca2), CategoricalArray{Union{T, Int}, 1, CategoricalArrays.DefaultRefType})
-    @test isordered(r) == false
-    @test levels(r) == collect(3:300)
+        # Test concatenation of mutually compatible levels
+        a1 = ["Young", "Middle"]
+        a2 = ["Middle", "Old"]
+        ca1 = CategoricalArray{Union{T, String}}(a1, ordered=true)
+        ca2 = CategoricalArray{Union{T, String}}(a2, ordered=true)
+        @test levels!(ca1, ["Young", "Middle"]) === ca1
+        @test levels!(ca2, ["Middle", "Old"]) === ca2
+        r = vcat(ca1, ca2)
+        @test r == vcat(a1, a2)
+        @test levels(r) == ["Young", "Middle", "Old"]
+        @test isordered(r) == true
 
-    # Test vcat of multidimensional arrays
-    a1 = Array{Int}(2, 3, 4, 5)
-    a2 = Array{Int}(3, 3, 4, 5)
-    a1[1:end] = (length(a1):-1:1) + 2
-    a2[1:end] = (1:length(a2)) + 10
-    ca1 = CategoricalArray{Union{T, Int}}(a1)
-    ca2 = CategoricalArray{Union{T, Int}}(a2)
-    cca1 = compress(ca1)
-    cca2 = compress(ca2)
-    r = vcat(cca1, cca2)
-    @test r == vcat(a1, a2)
-    @test isa(r, CategoricalArray{Union{T, Int}, 4, CategoricalArrays.DefaultRefType})
-    @test isordered(r) == false
-    @test levels(r) == collect(3:length(a2)+10)
-
-    # Test concatenation of mutually compatible levels
-    a1 = ["Young", "Middle"]
-    a2 = ["Middle", "Old"]
-    ca1 = CategoricalArray{Union{T, String}}(a1, ordered=true)
-    ca2 = CategoricalArray{Union{T, String}}(a2, ordered=true)
-    @test levels!(ca1, ["Young", "Middle"]) === ca1
-    @test levels!(ca2, ["Middle", "Old"]) === ca2
-    r = vcat(ca1, ca2)
-    @test r == vcat(a1, a2)
-    @test levels(r) == ["Young", "Middle", "Old"]
-    @test isordered(r) == true
-
-    # Test concatenation of conflicting ordering. This drops the ordering
-    a1 = ["Old", "Young", "Young"]
-    a2 = ["Old", "Young", "Middle", "Young"]
-    ca1 = CategoricalArray{Union{T, String}}(a1, ordered=true)
-    ca2 = CategoricalArray{Union{T, String}}(a2, ordered=true)
-    levels!(ca1, ["Young", "Middle", "Old"])
-    # ca2 has another order
-    r = vcat(ca1, ca2)
-    @test r == vcat(a1, a2)
-    @test levels(r) == ["Young", "Middle", "Old"]
-    @test isordered(r) == false
-
-
-    # Test similar()
-
-    x = CategoricalArray{Union{T, String}}(["Old", "Young", "Middle", "Young"])
-    y = similar(x)
-    @test typeof(x) === typeof(y)
-    @test size(y) == size(x)
-
-    x = CategoricalArray{Union{T, String}}(["Old", "Young", "Middle", "Young"])
-    y = similar(x, 3)
-    @test typeof(x) === typeof(y)
-    @test size(y) == (3,)
-
-    x = CategoricalArray{Union{T, String}, 1, UInt8}(["Old", "Young", "Middle", "Young"])
-    y = similar(x, Int)
-    @test isa(y, CategoricalArray{Int, 1, UInt8})
-    @test size(y) == size(x)
-
-    x = CategoricalArray{Union{T, String}}(["Old", "Young", "Middle", "Young"])
-    y = similar(x, Int, 3, 2)
-    @test isa(y, CategoricalArray{Int, 2, CategoricalArrays.DefaultRefType})
-    @test size(y) == (3, 2)
-
-
-    # Test copy!()
-
-    x = CategoricalArray{Union{T, String}}(["Old", "Young", "Middle", "Young"])
-    levels!(x, ["Young", "Middle", "Old"])
-    ordered!(x, true)
-    y = CategoricalArray{Union{T, String}}(["X", "Z", "Y", "X"])
-    @test copy!(x, y) === x
-    @test x == y
-    @test levels(x) == ["Young", "Middle", "Old", "X", "Y", "Z"]
-    @test !isordered(x)
-
-    x = CategoricalArray{Union{T, String}}(["Old", "Young", "Middle", "Young"])
-    levels!(x, ["Young", "Middle", "Old"])
-    ordered!(x, true)
-    y = CategoricalArray{Union{T, String}}(["X", "Z", "Y", "X"])
-    a = (Union{String, Null})["Z", "Y", "X", "Young"]
-    # Test with null values
-    if T === Null
-        x[3] = null
-        y[3] = a[2] = null
-    end
-    @test copy!(x, 1, y, 2) === x
-    @test x ≅ a
-    @test levels(x) == ["Young", "Middle", "Old", "X", "Y", "Z"]
-    @test !isordered(x)
-
-    # Test that no corruption happens in case of bounds error
-    @test_throws BoundsError copy!(x, 10, y, 2)
-    @test x ≅ a
-    @test_throws BoundsError copy!(x, 1, y, 10)
-    @test x ≅ a
-    @test_throws BoundsError copy!(x, 10, y, 20)
-    @test x ≅ a
-    @test_throws BoundsError copy!(x, 10, y, 2)
-    @test x ≅ a
-    @test_throws BoundsError copy!(x, 1, y, 2, 10)
-    @test x ≅ a
-    @test_throws BoundsError copy!(x, 4, y, 1, 2)
-    @test x ≅ a
-    @test_throws BoundsError copy!(x, 1, y, 4, 2)
-    @test x ≅ a
-
-    # Test resize!()
-    x = CategoricalArray{Union{T, String}}(["Old", "Young", "Middle", "Young"])
-    @test resize!(x, 3) === x
-    @test x == ["Old", "Young", "Middle"]
-    @test resize!(x, 4) === x
-    if T === Null
-        @test x ≅ ["Old", "Young", "Middle", null]
-    else
-        @test x[1:3] == ["Old", "Young", "Middle"]
-        @test !isassigned(x, 4)
+        # Test concatenation of conflicting ordering. This drops the ordering
+        a1 = ["Old", "Young", "Young"]
+        a2 = ["Old", "Young", "Middle", "Young"]
+        ca1 = CategoricalArray{Union{T, String}}(a1, ordered=true)
+        ca2 = CategoricalArray{Union{T, String}}(a2, ordered=true)
+        levels!(ca1, ["Young", "Middle", "Old"])
+        # ca2 has another order
+        r = vcat(ca1, ca2)
+        @test r == vcat(a1, a2)
+        @test levels(r) == ["Young", "Middle", "Old"]
+        @test isordered(r) == false
     end
 
-    for (sstart, dstart, n) in ((1, 1, 4), (1, 2, 3))
+    @testset "similar()" begin
+        x = CategoricalArray{Union{T, String}}(["Old", "Young", "Middle", "Young"])
+        y = similar(x)
+        @test typeof(x) === typeof(y)
+        @test size(y) == size(x)
+
+        x = CategoricalArray{Union{T, String}}(["Old", "Young", "Middle", "Young"])
+        y = similar(x, 3)
+        @test typeof(x) === typeof(y)
+        @test size(y) == (3,)
+
+        x = CategoricalArray{Union{T, String}, 1, UInt8}(["Old", "Young", "Middle", "Young"])
+        y = similar(x, Int)
+        @test isa(y, CategoricalArray{Int, 1, UInt8})
+        @test size(y) == size(x)
+
+        x = CategoricalArray{Union{T, String}}(["Old", "Young", "Middle", "Young"])
+        y = similar(x, Int, 3, 2)
+        @test isa(y, CategoricalArray{Int, 2, CategoricalArrays.DefaultRefType})
+        @test size(y) == (3, 2)
+    end
+
+
+    @testset "copy!()" begin
+        x = CategoricalArray{Union{T, String}}(["Old", "Young", "Middle", "Young"])
+        levels!(x, ["Young", "Middle", "Old"])
+        ordered!(x, true)
+        y = CategoricalArray{Union{T, String}}(["X", "Z", "Y", "X"])
+        @test copy!(x, y) === x
+        @test x == y
+        @test levels(x) == ["Young", "Middle", "Old", "X", "Y", "Z"]
+        @test !isordered(x)
+
+        x = CategoricalArray{Union{T, String}}(["Old", "Young", "Middle", "Young"])
+        levels!(x, ["Young", "Middle", "Old"])
+        ordered!(x, true)
+        y = CategoricalArray{Union{T, String}}(["X", "Z", "Y", "X"])
+        a = (Union{String, Null})["Z", "Y", "X", "Young"]
+        # Test with null values
+        if T === Null
+            x[3] = null
+            y[3] = a[2] = null
+        end
+        @test copy!(x, 1, y, 2) === x
+        @test x ≅ a
+        @test levels(x) == ["Young", "Middle", "Old", "X", "Y", "Z"]
+        @test !isordered(x)
+
+        @testset "no corruption happens in case of bounds error" begin
+            @test_throws BoundsError copy!(x, 10, y, 2)
+            @test x ≅ a
+            @test_throws BoundsError copy!(x, 1, y, 10)
+            @test x ≅ a
+            @test_throws BoundsError copy!(x, 10, y, 20)
+            @test x ≅ a
+            @test_throws BoundsError copy!(x, 10, y, 2)
+            @test x ≅ a
+            @test_throws BoundsError copy!(x, 1, y, 2, 10)
+            @test x ≅ a
+            @test_throws BoundsError copy!(x, 4, y, 1, 2)
+            @test x ≅ a
+            @test_throws BoundsError copy!(x, 1, y, 4, 2)
+            @test x ≅ a
+        end
+    end
+
+    @testset "resize!()" begin
+        x = CategoricalArray{Union{T, String}}(["Old", "Young", "Middle", "Young"])
+        @test resize!(x, 3) === x
+        @test x == ["Old", "Young", "Middle"]
+        @test resize!(x, 4) === x
+        if T === Null
+            @test x ≅ ["Old", "Young", "Middle", null]
+        else
+            @test x[1:3] == ["Old", "Young", "Middle"]
+            @test !isassigned(x, 4)
+        end
+    end
+
+    @testset "copy!() and conflicting orders sstart=$sstart dstart=$dstart n=$n" for
+        (sstart, dstart, n) in ((1, 1, 4), (1, 2, 3))
         # Conflicting orders: check that the destination wins and that result is not ordered
         x = CategoricalArray{Union{T, String}}(["Old", "Young", "Middle", "Young"])
         levels!(x, ["Young", "Middle", "Old"])
@@ -251,197 +253,198 @@ for T in (Union{}, Null)
         @test !isordered(x)
     end
 
+    @testset "overflow of reftype is detected and doesn't corrupt data and levels" begin
+        res = @test_throws LevelsException{Int, UInt8} CategoricalArray{Union{T, Int}, 1, UInt8}(256:-1:1)
+        @test res.value.levels == [1]
+        @test sprint(showerror, res.value) == "cannot store level(s) 1 since reference type UInt8 can only hold 255 levels. Use the decompress function to make room for more levels."
 
-    # Test that overflow of reftype is detected and doesn't corrupt data and levels
+        x = CategoricalArray{Union{T, Int}, 1, UInt8}(254:-1:1)
+        x[1] = 1000
+        res = @test_throws LevelsException{Int, UInt8} x[1] = 1001
+        @test res.value.levels == [1001]
+        @test sprint(showerror, res.value) == "cannot store level(s) 1001 since reference type UInt8 can only hold 255 levels. Use the decompress function to make room for more levels."
+        @test x == vcat(1000, 253:-1:1)
+        @test levels(x) == vcat(1:254, 1000)
 
-    res = @test_throws LevelsException{Int, UInt8} CategoricalArray{Union{T, Int}, 1, UInt8}(256:-1:1)
-    @test res.value.levels == [1]
-    @test sprint(showerror, res.value) == "cannot store level(s) 1 since reference type UInt8 can only hold 255 levels. Use the decompress function to make room for more levels."
+        x = CategoricalArray{Union{T, Int}, 1, UInt8}(1:254)
+        res = @test_throws LevelsException{Int, UInt8} x[1:2] = 1000:1001
+        @test res.value.levels == [1001]
+        @test sprint(showerror, res.value) == "cannot store level(s) 1001 since reference type UInt8 can only hold 255 levels. Use the decompress function to make room for more levels."
+        @test x == vcat(1000, 2:254)
+        @test levels(x) == vcat(1:254, 1000)
 
-    x = CategoricalArray{Union{T, Int}, 1, UInt8}(254:-1:1)
-    x[1] = 1000
-    res = @test_throws LevelsException{Int, UInt8} x[1] = 1001
-    @test res.value.levels == [1001]
-    @test sprint(showerror, res.value) == "cannot store level(s) 1001 since reference type UInt8 can only hold 255 levels. Use the decompress function to make room for more levels."
-    @test x == vcat(1000, 253:-1:1)
-    @test levels(x) == vcat(1:254, 1000)
+        x = CategoricalArray{Union{T, Int}, 1, UInt8}([1, 3, 256])
+        res = @test_throws LevelsException{Int, UInt8} levels!(x, collect(1:256))
+        @test res.value.levels == [255]
+        @test sprint(showerror, res.value) == "cannot store level(s) 255 since reference type UInt8 can only hold 255 levels. Use the decompress function to make room for more levels."
 
-    x = CategoricalArray{Union{T, Int}, 1, UInt8}(1:254)
-    res = @test_throws LevelsException{Int, UInt8} x[1:2] = 1000:1001
-    @test res.value.levels == [1001]
-    @test sprint(showerror, res.value) == "cannot store level(s) 1001 since reference type UInt8 can only hold 255 levels. Use the decompress function to make room for more levels."
-    @test x == vcat(1000, 2:254)
-    @test levels(x) == vcat(1:254, 1000)
+        x = CategoricalArray{Union{T, Int}}(30:2:131115)
+        res = @test_throws LevelsException{Int, UInt16} CategoricalVector{Int, UInt16}(x)
+        @test res.value.levels == collect(131100:2:131114)
+        @test sprint(showerror, res.value) == "cannot store level(s) 131100, 131102, 131104, 131106, 131108, 131110, 131112 and 131114 since reference type UInt16 can only hold 65535 levels. Use the decompress function to make room for more levels."
 
-    x = CategoricalArray{Union{T, Int}, 1, UInt8}([1, 3, 256])
-    res = @test_throws LevelsException{Int, UInt8} levels!(x, collect(1:256))
-    @test res.value.levels == [255]
-    @test sprint(showerror, res.value) == "cannot store level(s) 255 since reference type UInt8 can only hold 255 levels. Use the decompress function to make room for more levels."
-
-    x = CategoricalArray{Union{T, Int}}(30:2:131115)
-    res = @test_throws LevelsException{Int, UInt16} CategoricalVector{Int, UInt16}(x)
-    @test res.value.levels == collect(131100:2:131114)
-    @test sprint(showerror, res.value) == "cannot store level(s) 131100, 131102, 131104, 131106, 131108, 131110, 131112 and 131114 since reference type UInt16 can only hold 65535 levels. Use the decompress function to make room for more levels."
-
-    x = CategoricalArray{Union{T, String}, 1, UInt8}(string.(Char.(65:318)))
-    res = @test_throws LevelsException{String, UInt8} levels!(x, vcat(levels(x), "az", "bz", "cz"))
-    @test res.value.levels == ["bz", "cz"]
-    @test sprint(showerror, res.value) == "cannot store level(s) \"bz\" and \"cz\" since reference type UInt8 can only hold 255 levels. Use the decompress function to make room for more levels."
-    @test x == string.(Char.(65:318))
-    lev = copy(levels(x))
-    levels!(x, vcat(lev, "az"))
-    @test levels(x) == vcat(lev, "az")
-
-    x = compress(CategoricalArray{Union{T, Int}}([1, 3, 736251]))
-    ux = decompress(x)
-    @test x == ux
-    @test isa(x, CategoricalArray{Union{T, Int}, 1, UInt8})
-    @test isa(ux, CategoricalArray{Union{T, Int}, 1, CategoricalArrays.DefaultRefType})
-
-    # Test reshape()
-    x = CategoricalArray{Union{T, String}}(["Old", "Young", "Middle", "Young"])
-    levels!(x, ["Young", "Middle", "Old"])
-    ordered!(x, true)
-
-    y = reshape(x, 1, 4)
-    @test isa(y, CategoricalArray{Union{T, String}, 2, CategoricalArrays.DefaultRefType})
-    @test y == ["Old" "Young" "Middle" "Young"]
-    @test levels(x) == levels(y)
-    @test isordered(x)
-
-    y = reshape(x, 2, 2)
-    @test isa(y, CategoricalArray{Union{T, String}, 2, CategoricalArrays.DefaultRefType})
-    @test y == ["Old"  "Middle"; "Young" "Young"]
-    @test levels(x) == levels(y)
-    @test isordered(x)
-
-    # Test with null values
-    if T === Null
-        x[3] = null
-        y = reshape(x, 1, 4)
-        @test isa(y, CategoricalArray{Union{T, String}, 2, CategoricalArrays.DefaultRefType})
-        @test y ≅ ["Old" "Young" null "Young"]
-        @test levels(x) == levels(y)
-        @test isordered(x)
+        x = CategoricalArray{Union{T, String}, 1, UInt8}(string.(Char.(65:318)))
+        res = @test_throws LevelsException{String, UInt8} levels!(x, vcat(levels(x), "az", "bz", "cz"))
+        @test res.value.levels == ["bz", "cz"]
+        @test sprint(showerror, res.value) == "cannot store level(s) \"bz\" and \"cz\" since reference type UInt8 can only hold 255 levels. Use the decompress function to make room for more levels."
+        @test x == string.(Char.(65:318))
+        lev = copy(levels(x))
+        levels!(x, vcat(lev, "az"))
+        @test levels(x) == vcat(lev, "az")
     end
 
-    # Test sort() on both unordered and ordered arrays
-    x = CategoricalArray{Union{T, String}}(["Old", "Young", "Middle", "Young"])
-    levels!(x, ["Young", "Middle", "Old"])
-    @test sort(x) == ["Young", "Young", "Middle", "Old"]
-    ordered!(x, true)
-    @test sort(x) == ["Young", "Young", "Middle", "Old"]
-    @test sort!(x) === x
-    @test x == ["Young", "Young", "Middle", "Old"]
+    @testset "compresss/decompress?" begin
+        x = compress(CategoricalArray{Union{T, Int}}([1, 3, 736251]))
+        ux = decompress(x)
+        @test x == ux
+        @test isa(x, CategoricalArray{Union{T, Int}, 1, UInt8})
+        @test isa(ux, CategoricalArray{Union{T, Int}, 1, CategoricalArrays.DefaultRefType})
+    end
 
-    # Test constructors and convert() between categorical arrays:
-    # check that they preserve levels and ordering by default even across types,
-    # do not modify original array when changing ordering, and make copies
-    # only when necessary (though for construcors the pool is always copied because of ordered)
-    for ordered_orig in (true, false),
-        ordered in (true, false),
-        R in (DefaultRefType, UInt8, UInt, Int8, Int),
-        T in (String, Union{String, Null}),
-        (CVM2, N) in ((CategoricalVector, 1), (CategoricalMatrix, 2))
-        if CVM2 <: AbstractVector
-            x = CategoricalArray{T, N, R}(["A", "B"], ordered=ordered_orig)
-        else
-            x = CategoricalArray{T, N, R}(["A" "B"], ordered=ordered_orig)
-        end
+    @testset "reshape()" begin
+        x = CategoricalArray{Union{T, String}}(["Old", "Young", "Middle", "Young"])
+        levels!(x, ["Young", "Middle", "Old"])
+        ordered!(x, true)
 
-        # Do not use lexicographic order in order to catch bugs about order preservation
-        levels!(x, ["B", "A"])
+        y = reshape(x, 1, 4)
+        @test isa(y, CategoricalArray{Union{T, String}, 2, CategoricalArrays.DefaultRefType})
+        @test y == ["Old" "Young" "Middle" "Young"]
+        @test levels(x) == levels(y)
+        @test isordered(x)
 
-        for y in (CategoricalArray(x),
-                  CategoricalArray{T}(x),
-                  CategoricalArray{T, N}(x),
-                  CategoricalArray{T, N, R}(x),
-                  CategoricalArray{T, N, DefaultRefType}(x),
-                  CategoricalArray{T, N, UInt8}(x),
-                  CVM2(x),
-                  CVM2{T}(x),
-                  CVM2{T, R}(x),
-                  CVM2{T, DefaultRefType}(x),
-                  CVM2{T, UInt8}(x))
-            @test isa(y, CVM2{T})
-            @test isordered(y) === isordered(x)
-            @test isordered(x) === ordered_orig
-            @test y.refs == x.refs
-            @test index(y.pool) == index(x.pool)
-            @test levels(y) == levels(x)
-            @test (y.refs === x.refs) == (eltype(x.refs) === eltype(y.refs))
-            @test y.pool !== x.pool
+        y = reshape(x, 2, 2)
+        @test isa(y, CategoricalArray{Union{T, String}, 2, CategoricalArrays.DefaultRefType})
+        @test y == ["Old"  "Middle"; "Young" "Young"]
+        @test levels(x) == levels(y)
+        @test isordered(x)
+
+        # Test with null values
+        if T === Null
+            x[3] = null
+            y = reshape(x, 1, 4)
+            @test isa(y, CategoricalArray{Union{T, String}, 2, CategoricalArrays.DefaultRefType})
+            @test y ≅ ["Old" "Young" null "Young"]
+            @test levels(x) == levels(y)
+            @test isordered(x)
         end
-        for y in (categorical(x),
-                  categorical(x, false),
-                  categorical(x, true))
-            @test isa(y, CategoricalArray{T, N})
-            @test isordered(y) === isordered(x)
-            @test isordered(x) === ordered_orig
-            @test y.refs == x.refs
-            @test index(y.pool) == index(x.pool)
-            @test levels(y) == levels(x)
-            @test (y.refs === x.refs) == (eltype(x.refs) === eltype(y.refs))
-            @test y.pool !== x.pool
-        end
-        for y in (CategoricalArray(x, ordered=ordered),
-                  CategoricalArray{T}(x, ordered=ordered),
-                  CategoricalArray{T, N}(x, ordered=ordered),
-                  CategoricalArray{T, N, R}(x, ordered=ordered),
-                  CategoricalArray{T, N, DefaultRefType}(x, ordered=ordered),
-                  CategoricalArray{T, N, UInt8}(x, ordered=ordered),
-                  CVM2(x, ordered=ordered),
-                  CVM2{T}(x, ordered=ordered),
-                  CVM2{T, R}(x, ordered=ordered),
-                  CVM2{T, DefaultRefType}(x, ordered=ordered),
-                  CVM2{T, UInt8}(x, ordered=ordered))
-            @test isa(y, CVM2{T})
-            @test isordered(y) === ordered
-            @test isordered(x) === ordered_orig
-            @test y.refs == x.refs
-            @test index(y.pool) == index(x.pool)
-            @test levels(y) == levels(x)
-            @test (y.refs === x.refs) == (eltype(x.refs) === eltype(y.refs))
-            @test y.pool !== x.pool
-        end
-        for y in (categorical(x, ordered=ordered),
-                  categorical(x, false, ordered=ordered),
-                  categorical(x, true, ordered=ordered))
-            @test isa(y, CategoricalArray{T, N})
-            @test isordered(y) === ordered
-            @test isordered(x) === ordered_orig
-            @test y.refs == x.refs
-            @test index(y.pool) == index(x.pool)
-            @test levels(y) == levels(x)
-            @test (y.refs === x.refs) == (eltype(x.refs) === eltype(y.refs))
-            @test y.pool !== x.pool
-        end
-        for y in (convert(CategoricalArray, x),
-                  convert(CategoricalArray{T}, x),
-                  convert(CategoricalArray{T, N}, x),
-                  convert(CategoricalArray{T, N, R}, x),
-                  convert(CategoricalArray{T, N, DefaultRefType}, x),
-                  convert(CategoricalArray{T, N, UInt8}, x))
-            @test isa(y, CVM2{T})
-            @test isordered(y) === isordered(x)
-            @test isordered(x) === ordered_orig
-            @test y.refs == x.refs
-            @test index(y.pool) == index(x.pool)
-            @test levels(y) == levels(x)
-            @test (y.refs === x.refs) == (eltype(x.refs) === eltype(y.refs))
-            @test (y.pool === x.pool) == (eltype(x.refs) === eltype(y.refs))
-        end
+    end
+
+    @testset "sort() on both unordered and ordered arrays" begin
+        x = CategoricalArray{Union{T, String}}(["Old", "Young", "Middle", "Young"])
+        levels!(x, ["Young", "Middle", "Old"])
+        @test sort(x) == ["Young", "Young", "Middle", "Old"]
+        ordered!(x, true)
+        @test sort(x) == ["Young", "Young", "Middle", "Old"]
+        @test sort!(x) === x
+        @test x == ["Young", "Young", "Middle", "Old"]
     end
 end
 
-# Check that converting from nullable to non-nullable CategoricalArray fails with nulls
-x = CategoricalArray{Union{String, Null}}(1)
-@test_throws NullException CategoricalArray{String}(x)
-@test_throws NullException convert(CategoricalArray{String}, x)
+@testset "constructors and convert() between categorical arrays, ordered_orig=$ordered_orig, ordered=$ordered, R=$R, T=$T, CVM2=$CVM2, N=$N" for ordered_orig in (true, false),
+    ordered in (true, false),
+    R in (DefaultRefType, UInt8, UInt, Int8, Int),
+    T in (String, Union{String, Null}),
+    (CVM2, N) in ((CategoricalVector, 1), (CategoricalMatrix, 2))
+    # check that ctors/converters preserve levels and ordering by default even across types,
+    # do not modify original array when changing ordering, and make copies
+    # only when necessary (though for construcors the pool is always copied because of ordered)
+    if CVM2 <: AbstractVector
+        x = CategoricalArray{T, N, R}(["A", "B"], ordered=ordered_orig)
+    else
+        x = CategoricalArray{T, N, R}(["A" "B"], ordered=ordered_orig)
+    end
 
+    # Do not use lexicographic order in order to catch bugs about order preservation
+    levels!(x, ["B", "A"])
 
-# Test in()
-for T in (Int, Union{Int, Null})
+    for y in (CategoricalArray(x),
+              CategoricalArray{T}(x),
+              CategoricalArray{T, N}(x),
+              CategoricalArray{T, N, R}(x),
+              CategoricalArray{T, N, DefaultRefType}(x),
+              CategoricalArray{T, N, UInt8}(x),
+              CVM2(x),
+              CVM2{T}(x),
+              CVM2{T, R}(x),
+              CVM2{T, DefaultRefType}(x),
+              CVM2{T, UInt8}(x))
+        @test isa(y, CVM2{T})
+        @test isordered(y) === isordered(x)
+        @test isordered(x) === ordered_orig
+        @test y.refs == x.refs
+        @test index(y.pool) == index(x.pool)
+        @test levels(y) == levels(x)
+        @test (y.refs === x.refs) == (eltype(x.refs) === eltype(y.refs))
+        @test y.pool !== x.pool
+    end
+    for y in (categorical(x),
+              categorical(x, false),
+              categorical(x, true))
+        @test isa(y, CategoricalArray{T, N})
+        @test isordered(y) === isordered(x)
+        @test isordered(x) === ordered_orig
+        @test y.refs == x.refs
+        @test index(y.pool) == index(x.pool)
+        @test levels(y) == levels(x)
+        @test (y.refs === x.refs) == (eltype(x.refs) === eltype(y.refs))
+        @test y.pool !== x.pool
+    end
+    for y in (CategoricalArray(x, ordered=ordered),
+              CategoricalArray{T}(x, ordered=ordered),
+              CategoricalArray{T, N}(x, ordered=ordered),
+              CategoricalArray{T, N, R}(x, ordered=ordered),
+              CategoricalArray{T, N, DefaultRefType}(x, ordered=ordered),
+              CategoricalArray{T, N, UInt8}(x, ordered=ordered),
+              CVM2(x, ordered=ordered),
+              CVM2{T}(x, ordered=ordered),
+              CVM2{T, R}(x, ordered=ordered),
+              CVM2{T, DefaultRefType}(x, ordered=ordered),
+              CVM2{T, UInt8}(x, ordered=ordered))
+        @test isa(y, CVM2{T})
+        @test isordered(y) === ordered
+        @test isordered(x) === ordered_orig
+        @test y.refs == x.refs
+        @test index(y.pool) == index(x.pool)
+        @test levels(y) == levels(x)
+        @test (y.refs === x.refs) == (eltype(x.refs) === eltype(y.refs))
+        @test y.pool !== x.pool
+    end
+    for y in (categorical(x, ordered=ordered),
+              categorical(x, false, ordered=ordered),
+              categorical(x, true, ordered=ordered))
+        @test isa(y, CategoricalArray{T, N})
+        @test isordered(y) === ordered
+        @test isordered(x) === ordered_orig
+        @test y.refs == x.refs
+        @test index(y.pool) == index(x.pool)
+        @test levels(y) == levels(x)
+        @test (y.refs === x.refs) == (eltype(x.refs) === eltype(y.refs))
+        @test y.pool !== x.pool
+    end
+    for y in (convert(CategoricalArray, x),
+              convert(CategoricalArray{T}, x),
+              convert(CategoricalArray{T, N}, x),
+              convert(CategoricalArray{T, N, R}, x),
+              convert(CategoricalArray{T, N, DefaultRefType}, x),
+              convert(CategoricalArray{T, N, UInt8}, x))
+        @test isa(y, CVM2{T})
+        @test isordered(y) === isordered(x)
+        @test isordered(x) === ordered_orig
+        @test y.refs == x.refs
+        @test index(y.pool) == index(x.pool)
+        @test levels(y) == levels(x)
+        @test (y.refs === x.refs) == (eltype(x.refs) === eltype(y.refs))
+        @test (y.pool === x.pool) == (eltype(x.refs) === eltype(y.refs))
+    end
+end
+
+@testset "converting from nullable to non-nullable CategoricalArray fails with nulls" begin
+    x = CategoricalArray{Union{String, Null}}(1)
+    @test_throws NullException CategoricalArray{String}(x)
+    @test_throws NullException convert(CategoricalArray{String}, x)
+end
+
+@testset "in($T, CategoricalArray{$T})" for T in (Int, Union{Int, Null})
     ca1 = CategoricalArray{T}([1, 2, 3])
     ca2 = CategoricalArray{T}([4, 3, 2])
 
@@ -453,84 +456,90 @@ for T in (Int, Union{Int, Null})
     @test (5 in ca1) === false
 end
 
-# Test ==
-a1 = [1, 2, 3]
-a2 = Union{Int, Null}[1, 2, 3]
-a3 = [1, 2, null]
-a4 = [4, 3, 2]
-a5 = [1 2; 3 4]
-ca1 = CategoricalArray(a1)
-ca2 = CategoricalArray{Union{Int, Null}}(a2)
-ca2b = CategoricalArray{Union{Int, Null}, 1}(ca2.refs, ca2.pool)
-ca3 = CategoricalArray(a3)
-ca3b = CategoricalArray{Union{Int, Null}, 1}(ca3.refs, ca2.pool)
-ca4 = CategoricalArray(a4)
-ca5 = CategoricalArray(a5)
+@testset "comparison" begin
+    a1 = [1, 2, 3]
+    a2 = Union{Int, Null}[1, 2, 3]
+    a3 = [1, 2, null]
+    a4 = [4, 3, 2]
+    a5 = [1 2; 3 4]
+    ca1 = CategoricalArray(a1)
+    ca2 = CategoricalArray{Union{Int, Null}}(a2)
+    ca2b = CategoricalArray{Union{Int, Null}, 1}(ca2.refs, ca2.pool)
+    ca3 = CategoricalArray(a3)
+    ca3b = CategoricalArray{Union{Int, Null}, 1}(ca3.refs, ca2.pool)
+    ca4 = CategoricalArray(a4)
+    ca5 = CategoricalArray(a5)
 
-@test ca1 == copy(ca1) == a1
-@test ca2 == copy(ca2) == a2
-@test isnull(ca3 == copy(ca3)) && isnull(ca3 == ca3b) && isnull(ca3 == a3)
-@test ca4 == copy(ca4) == a4
-@test ca5 == copy(ca5) == a5
-@test ca1 == ca2 == a2
-@test isnull(ca1 != ca3) && isnull(ca1 != a3)
-@test ca1 != ca4
-@test ca1 != a4
-@test a1 != ca4
-@test ca1 != ca5
-@test ca1 != a5
-@test a1 != ca5
-@test ca3 != ca4
-@test ca3 != a4
-@test a3 != ca4
-@test isnull(ca2b != ca3b)
+    @testset "==" begin
+        @test ca1 == copy(ca1) == a1
+        @test ca2 == copy(ca2) == a2
+        @test isnull(ca3 == copy(ca3)) && isnull(ca3 == ca3b) && isnull(ca3 == a3)
+        @test ca4 == copy(ca4) == a4
+        @test ca5 == copy(ca5) == a5
+        @test ca1 == ca2 == a2
+        @test isnull(ca1 != ca3) && isnull(ca1 != a3)
+        @test ca1 != ca4
+        @test ca1 != a4
+        @test a1 != ca4
+        @test ca1 != ca5
+        @test ca1 != a5
+        @test a1 != ca5
+        @test ca3 != ca4
+        @test ca3 != a4
+        @test a3 != ca4
+        @test isnull(ca2b != ca3b)
+    end
 
-# Test isequal
-@test ca1 ≅ copy(ca1) ≅ a1
-@test ca2 ≅ copy(ca2) ≅ a2
-@test ca3 ≅ copy(ca3) ≅ ca3b ≅ a3
-@test ca4 ≅ copy(ca4) ≅ a4
-@test ca5 ≅ copy(ca5) ≅ a5
-@test ca1 ≅ ca2 ≅ a2
-@test ca1 ≇ ca3 && ca1 ≇ a3
-@test ca1 ≇ ca4
-@test ca1 ≇ a4
-@test a1 ≇ ca4
-@test ca1 ≇ ca5
-@test ca1 ≇ a5
-@test a1 ≇ ca5
-@test ca3 ≇ ca4
-@test ca3 ≇ a4
-@test a3 ≇ ca4
-@test ca2b ≇ ca3b
+    @testset "isequal()" begin
+        @test ca1 ≅ copy(ca1) ≅ a1
+        @test ca2 ≅ copy(ca2) ≅ a2
+        @test ca3 ≅ copy(ca3) ≅ ca3b ≅ a3
+        @test ca4 ≅ copy(ca4) ≅ a4
+        @test ca5 ≅ copy(ca5) ≅ a5
+        @test ca1 ≅ ca2 ≅ a2
+        @test ca1 ≇ ca3 && ca1 ≇ a3
+        @test ca1 ≇ ca4
+        @test ca1 ≇ a4
+        @test a1 ≇ ca4
+        @test ca1 ≇ ca5
+        @test ca1 ≇ a5
+        @test a1 ≇ ca5
+        @test ca3 ≇ ca4
+        @test ca3 ≇ a4
+        @test a3 ≇ ca4
+        @test ca2b ≇ ca3b
+    end
+end
 
-# Test summary()
-@test summary(CategoricalArray([1, 2, 3])) ==
-    "3-element CategoricalArrays.CategoricalArray{$Int,1,UInt32}"
-# Ordering changed in Julia 0.7
-@test summary(CategoricalArray{Union{Int, Null}}([1 2 3])) in
-    ("1×3 CategoricalArrays.CategoricalArray{Union{Nulls.Null, $Int},2,UInt32}",
-     "1×3 CategoricalArrays.CategoricalArray{Union{$Int, Nulls.Null},2,UInt32}")
+@testset "summary()" begin
+    @test summary(CategoricalArray([1, 2, 3])) ==
+        "3-element CategoricalArrays.CategoricalArray{$Int,1,UInt32}"
+    # Ordering changed in Julia 0.7
+    @test summary(CategoricalArray{Union{Int, Null}}([1 2 3])) in
+        ("1×3 CategoricalArrays.CategoricalArray{Union{Nulls.Null, $Int},2,UInt32}",
+         "1×3 CategoricalArrays.CategoricalArray{Union{$Int, Nulls.Null},2,UInt32}")
+end
 
-# Test that vcat() takes into account element type even when array is empty
-# or when both arrays have the same levels but of different types
-x = CategoricalVector{String}(0)
-y = CategoricalVector{Int}(0)
-z1 = CategoricalVector{Float64}([1.0])
-z2 = CategoricalVector{Int}([1])
-@inferred vcat(x, y)
-@test vcat(x, y) isa CategoricalVector{Any}
-@inferred vcat(x, z1)
-@test vcat(x, z1) isa CategoricalVector{Any}
-@inferred vcat(y, z1)
-@test vcat(y, z1) isa CategoricalVector{Float64}
-@inferred vcat(x, x)
-@test vcat(x, x) isa CategoricalVector{String}
-@inferred vcat(y, y)
-@test vcat(y, y) isa CategoricalVector{Int}
-@inferred vcat(z1, z1)
-@test vcat(z1, z1) isa CategoricalVector{Float64}
-@inferred vcat(z1, z2)
-@test vcat(z1, z2) isa CategoricalVector{Float64}
+@testset "vcat() takes into account element type even when array is empty" begin
+    # or when both arrays have the same levels but of different types
+    x = CategoricalVector{String}(0)
+    y = CategoricalVector{Int}(0)
+    z1 = CategoricalVector{Float64}([1.0])
+    z2 = CategoricalVector{Int}([1])
+    @inferred vcat(x, y)
+    @test vcat(x, y) isa CategoricalVector{Any}
+    @inferred vcat(x, z1)
+    @test vcat(x, z1) isa CategoricalVector{Any}
+    @inferred vcat(y, z1)
+    @test vcat(y, z1) isa CategoricalVector{Float64}
+    @inferred vcat(x, x)
+    @test vcat(x, x) isa CategoricalVector{String}
+    @inferred vcat(y, y)
+    @test vcat(y, y) isa CategoricalVector{Int}
+    @inferred vcat(z1, z1)
+    @test vcat(z1, z1) isa CategoricalVector{Float64}
+    @inferred vcat(z1, z2)
+    @test vcat(z1, z2) isa CategoricalVector{Float64}
+end
 
 end

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -293,7 +293,7 @@ end
         @test levels(x) == vcat(lev, "az")
     end
 
-    @testset "compresss/decompress?" begin
+    @testset "compress()/decompress()" begin
         x = compress(CategoricalArray{Union{T, Int}}([1, 3, 736251]))
         ux = decompress(x)
         @test x == ux

--- a/test/14_view.jl
+++ b/test/14_view.jl
@@ -1,34 +1,32 @@
 module TestView
-
 using Base.Test
 using CategoricalArrays
 
-for T in (Union{}, Null)
-    for order in (true, false)
-        for a in (1:10, 10:-1:1, ["a", "c", "b", "b", "a"])
-            for inds in [1:2, :, 1, []]
-                x = CategoricalArray{Union{T, eltype(a)}}(a, ordered=order)
-                v = view(x, inds)
-                @test levels(v) === levels(x)
-                @test unique(v) == (ndims(v) > 0 ? sort(unique(a[inds])) : [a[inds]])
-                @test isordered(v) === isordered(x)
-            end
-        end
-    end
+@testset "view($(CategoricalArray{Union{T, eltype(a)}}), $inds), ordered=$order construction" for
+    T in (Union{}, Null), order in (true, false),
+    a in (1:10, 10:-1:1, ["a", "c", "b", "b", "a"]),
+    inds in [1:2, :, 1, []]
+
+    x = CategoricalArray{Union{T, eltype(a)}}(a, ordered=order)
+    v = view(x, inds)
+    @test levels(v) === levels(x)
+    @test unique(v) == (ndims(v) > 0 ? sort(unique(a[inds])) : [a[inds]])
+    @test isordered(v) === isordered(x)
 end
 
-# Test ==
-ca1 = CategoricalArray([1, 2, 3])
-ca2 = CategoricalArray{Union{Int, Null}}([1, 2, 3])
-ca3 = CategoricalArray([1, 2, null])
-ca4 = CategoricalArray([4, 3, 2])
-ca5 = CategoricalArray([1 2; 3 4])
+@testset "views comparison" begin
+    ca1 = CategoricalArray([1, 2, 3])
+    ca2 = CategoricalArray{Union{Int, Null}}([1, 2, 3])
+    ca3 = CategoricalArray([1, 2, null])
+    ca4 = CategoricalArray([4, 3, 2])
+    ca5 = CategoricalArray([1 2; 3 4])
 
-@test view(ca1, 1:2) == view(ca1, 1:2)
-@test view(ca2, 1:2) == view(ca2, 1:2)
-@test view(ca1, 1:2) == view(ca2, 1:2)
-@test view(ca1, 1:2) == view(ca3, 1:2)
-@test view(ca1, 1:2) != view(ca2, 1:3)
-@test view(ca1, 1:2) != view(ca5, 1:2, 1:1)
+    @test view(ca1, 1:2) == view(ca1, 1:2)
+    @test view(ca2, 1:2) == view(ca2, 1:2)
+    @test view(ca1, 1:2) == view(ca2, 1:2)
+    @test view(ca1, 1:2) == view(ca3, 1:2)
+    @test view(ca1, 1:2) != view(ca2, 1:3)
+    @test view(ca1, 1:2) != view(ca5, 1:2, 1:1)
+end
 
 end

--- a/test/15_extras.jl
+++ b/test/15_extras.jl
@@ -1,13 +1,10 @@
 module TestExtras
-
 using Base.Test
 using CategoricalArrays
 
 const ≅ = isequal
 
-# Test cut
-
-for T in (Union{}, Null)
+@testset "cut($(Union{Int, T})[...])" for T in (Union{}, Null)
     x = @inferred cut(Vector{Union{Int, T}}([2, 3, 5]), [1, 3, 6])
     @test x == ["[1, 3)", "[3, 6)", "[3, 6)"]
     @test isa(x, CategoricalVector{Union{String, T}})
@@ -102,10 +99,12 @@ for T in (Union{}, Null)
 end
 
 # TODO: test on nullable arrays once a quantile() method is provided for them
-x = @inferred cut([5, 4, 3, 2], 2)
-@test x == ["[3.5, 5.0]", "[3.5, 5.0]", "[2.0, 3.5)", "[2.0, 3.5)"]
-@test isa(x, CategoricalArray)
-@test isordered(x)
-@test levels(x) == ["[2.0, 3.5)", "[3.5, 5.0]"]
+@testset "cut([5, 4, 3, 2], 2)" begin
+    x = @inferred cut([5, 4, 3, 2], 2)
+    @test x == ["[3.5, 5.0]", "[3.5, 5.0]", "[2.0, 3.5)", "[2.0, 3.5)"]
+    @test isa(x, CategoricalArray)
+    @test isordered(x)
+    @test levels(x) == ["[2.0, 3.5)", "[3.5, 5.0]"]
+end
 
 end

--- a/test/16_recode.jl
+++ b/test/16_recode.jl
@@ -1,385 +1,405 @@
 module TestRecode
-    using Base.Test
-    using CategoricalArrays
-    using CategoricalArrays: DefaultRefType
+using Base.Test
+using CategoricalArrays
+using CategoricalArrays: DefaultRefType
 
-    const ≅ = isequal
+const ≅ = isequal
 
-    ## Test recode!, used by recode
+## Test recode!, used by recode
 
-    # Test both recoding into x itself and into an uninitialized vector
-    # (since for CategoricalVectors possible bugs can happen when working in-place)
+# Test both recoding into x itself and into an uninitialized vector
+# (since for CategoricalVectors possible bugs can happen when working in-place)
 
-    # Recoding from Int to Int
-    for x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Null}}(1:10)),
-        y in (similar(x), Array{Int}(size(x)),
-              CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Null}}(size(x)), x)
-        z = @inferred recode!(y, x, 1=>100, 2:4=>0, [5; 9:10]=>-1)
-        @test y === z
-        @test y == [100, 0, 0, 0, -1, 6, 7, 8, -1, -1]
-        if isa(y, CategoricalArray)
-            @test levels(y) == [6, 7, 8, 100, 0, -1]
-            @test !isordered(y)
-        end
+@testset "Recoding from $(typeof(x)) to $(typeof(y))" for
+    x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Null}}(1:10)),
+    y in (similar(x), Array{Int}(size(x)),
+          CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Null}}(size(x)), x)
+
+    z = @inferred recode!(y, x, 1=>100, 2:4=>0, [5; 9:10]=>-1)
+    @test y === z
+    @test y == [100, 0, 0, 0, -1, 6, 7, 8, -1, -1]
+    if isa(y, CategoricalArray)
+        @test levels(y) == [6, 7, 8, 100, 0, -1]
+        @test !isordered(y)
+    end
+end
+
+@testset "Recoding from $(typeof(x)) to $(typeof(y)) with duplicate recoded values" for
+    x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Null}}(1:10)),
+    y in (similar(x), Array{Int}(size(x)),
+          CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Null}}(size(x)), x)
+
+    z = @inferred recode!(y, x, 1=>100, 2:4=>100, [5; 9:10]=>-1)
+    @test y === z
+    @test y == [100, 100, 100, 100, -1, 6, 7, 8, -1, -1]
+    if isa(y, CategoricalArray)
+        @test levels(y) == [6, 7, 8, 100, -1]
+        @test !isordered(y)
+    end
+end
+
+@testset "Recoding from $(typeof(x)) to $(typeof(y)) with unused level" for
+    x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Null}}(1:10)),
+    y in (similar(x), Array{Int}(size(x)),
+          CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Null}}(size(x)), x)
+
+    z = @inferred recode!(y, x, 1=>100, 2:4=>0, [5; 9:10]=>-1, 100=>1)
+    @test y === z
+    @test y == [100, 0, 0, 0, -1, 6, 7, 8, -1, -1]
+    if isa(y, CategoricalArray)
+        @test levels(y) == [6, 7, 8, 100, 0, -1, 1]
+        @test !isordered(y)
+    end
+end
+
+@testset "Recoding from $(typeof(x)) to $(typeof(y)) with duplicate default" for
+    x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Null}}(1:10)),
+    y in (similar(x), Array{Int}(size(x)),
+          CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Null}}(size(x)), x)
+
+    z = @inferred recode!(y, x, 100, 1=>100, 2:4=>100, [5; 9:10]=>-1)
+    @test y === z
+    @test y == [100, 100, 100, 100, -1, 100, 100, 100, -1, -1]
+    if isa(y, CategoricalArray)
+        @test levels(y) == [100, -1]
+        @test !isordered(y)
+    end
+end
+
+@testset "Recoding from $(typeof(x)) to $(typeof(y)) with default" for
+    x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Null}}(1:10)),
+    y in (similar(x), Array{Int}(size(x)),
+          CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Null}}(size(x)), x)
+
+    z = @inferred recode!(y, x, -10, 1=>100, 2:4=>0, [5; 9:10]=>-1)
+    @test y === z
+    @test y == [100, 0, 0, 0, -1, -10, -10, -10, -1, -1]
+    if isa(y, CategoricalArray)
+        @test levels(y) == [100, 0, -1, -10]
+        @test !isordered(y)
+    end
+end
+
+@testset "Recoding from $(typeof(x)) to $(typeof(y)) with first value being Float64" for
+    x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Null}}(1:10)),
+    y in (similar(x), Array{Int}(size(x)),
+          CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Null}}(size(x)), x)
+
+    z = @inferred recode!(y, x, 1.0=>100, 2:4=>0, [5; 9:10]=>-1)
+    @test y == [100, 0, 0, 0, -1, 6, 7, 8, -1, -1]
+    if isa(y, CategoricalArray)
+        @test levels(y) == [6, 7, 8, 100, 0, -1]
+        @test !isordered(y)
+    end
+end
+
+@testset "Recoding from $(typeof(x)) to $(typeof(y)) with overlapping pairs" for
+    x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Null}}(1:10)),
+    y in (similar(x), Array{Int}(size(x)),
+          CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Null}}(size(x)), x)
+
+    z = @inferred recode!(y, x, 1=>100, 2:4=>0, [5; 9:10]=>-1, 1:10=>0)
+    @test y === z
+    @test y == [100, 0, 0, 0, -1, 0, 0, 0, -1, -1]
+    if isa(y, CategoricalArray)
+        @test levels(y) == [100, 0, -1]
+        @test !isordered(y)
+    end
+end
+
+@testset "Recoding from $(typeof(x)) to $(typeof(y)) with changes to levels order" for
+    x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Null}}(1:10)),
+    y in (similar(x), Array{Int}(size(x)),
+          CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Null}}(size(x)), x)
+
+    z = @inferred recode!(y, x, 1=>100, 2:4=>0, [5; 9:10]=>-1)
+    @test y === z
+    @test y == [100, 0, 0, 0, -1, 6, 7, 8, -1, -1]
+    if isa(y, CategoricalArray)
+        @test levels(y) == [6, 7, 8, 100, 0, -1]
+        @test !isordered(y)
+    end
+end
+
+@testset "Recoding from $(typeof(x)) to non-nullable categorical array" for
+    x in (["a", null, "c", "d"], CategoricalArray(["a", null, "c", "d"]))
+    # check that error is thrown
+    y = Vector{String}(4)
+    @test_throws MethodError recode!(y, x, "a", "c"=>"b")
+
+    y = CategoricalVector{String}(4)
+    @test_throws NullException recode!(y, x, "a", "c"=>"b")
+end
+
+@testset "Recoding nullable array with null and default from $(typeof(x)) to $(typeof(y))" for
+    x in (["a", null, "c", "d"], CategoricalArray(["a", null, "c", "d"])),
+    y in (similar(x), Array{Union{String, Null}}(size(x)),
+          CategoricalArray{Union{String, Null}}(size(x)), x)
+
+    z = @inferred recode!(y, x, "a", "c"=>"b")
+    @test y === z
+    @test y ≅ ["a", null, "b", "a"]
+    if isa(y, CategoricalArray)
+        @test levels(y) == ["b", "a"]
+        @test !isordered(y)
+    end
+end
+
+@testset "Recoding nullable array with null and no default from $(typeof(x)) to $(typeof(y))" for
+    x in (["a", null, "c", "d"], CategoricalArray(["a", null, "c", "d"])),
+    y in (similar(x), Array{Union{String, Null}}(size(x)),
+          CategoricalArray{Union{String, Null}}(size(x)), x)
+
+    z = @inferred recode!(y, x, "c"=>"b")
+    @test y === z
+    @test y ≅ ["a", null, "b", "d"]
+    if isa(y, CategoricalArray)
+        @test levels(y) == ["a", "d", "b"]
+        @test !isordered(y)
+    end
+end
+
+@testset "Recoding nullable array with null, no default and with null as a key pair from $(typeof(x)) to $(typeof(y))" for
+    x in (["a", null, "c", "d"], CategoricalArray(["a", null, "c", "d"])),
+    y in (similar(x), Array{Union{String, Null}}(size(x)),
+          CategoricalArray{Union{String, Null}}(size(x)), x)
+
+    z = @inferred recode!(y, x, "a", "c"=>"b", null=>"d")
+    @test y === z
+    @test y == ["a", "d", "b", "a"]
+    if isa(y, CategoricalArray)
+        @test levels(y) == ["b", "d", "a"]
+        @test !isordered(y)
+    end
+end
+
+@testset "Recoding nullable array with null, no default and with null as a key pair from $(typeof(x)) to $(typeof(y))" for
+    x in (["a", null, "c", "d"], CategoricalArray(["a", null, "c", "d"])),
+    y in (similar(x), Array{Union{String, Null}}(size(x)),
+          CategoricalArray{Union{String, Null}}(size(x)), x)
+
+    z = @inferred recode!(y, x, "c"=>"b", null=>"d")
+    @test y === z
+    @test y == ["a", "d", "b", "d"]
+    if isa(y, CategoricalArray)
+        @test levels(y) == ["a", "b", "d"]
+        @test !isordered(y)
+    end
+end
+
+@testset "Recoding into an array of incompatible size from $(typeof(x)) to $(typeof(y))" for
+    x in (["a", null, "c", "d"], CategoricalArray(["a", null, "c", "d"])),
+    y in (similar(x, 0), Array{Union{String, Null}}(0),
+          CategoricalArray{Union{String, Null}}(0))
+
+    @test_throws DimensionMismatch recode!(y, x, "c"=>"b", null=>"d")
+end
+
+@testset "Recoding into an array with incompatible eltype from $(typeof(x)) to $(typeof(y))" for
+    x in ([1:10;], CategoricalArray(1:10)),
+    y in (similar(x, String), Array{String}(size(x)), CategoricalArray{String}(size(x)))
+
+    @test_throws ArgumentError recode!(y, x, 1=>"a", 2:4=>"b", [5; 9:10]=>"c")
+end
+
+@testset "Recoding into an array with incompatible eltype from $(typeof(x)) to $(typeof(y))" for
+    x in ((Union{Int, Null})[1:10;], CategoricalArray{Union{Int, Null}}(1:10)),
+    y in (similar(x), Array{Union{Int, Null}}(size(x)), CategoricalArray{Union{Int, Null}}(size(x)))
+
+    @test_throws MethodError recode!(y, x, 1=>"a", 2:4=>"b", [5; 9:10]=>"c")
+end
+
+## Test in-place recode!()
+
+@testset "Recoding from $(typeof(x)) to $(typeof(x)) without default" for
+    x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Null}}(1:10))
+
+    z = @inferred recode!(x, 1=>100, 2:4=>0, [5; 9:10]=>-1)
+    @test x === z
+    @test x == [100, 0, 0, 0, -1, 6, 7, 8, -1, -1]
+    if isa(x, CategoricalArray)
+        @test levels(x) == [6, 7, 8, 100, 0, -1]
+        @test !isordered(x)
+    end
+end
+
+@testset "Recoding from $(typeof(x)) to $(typeof(x)) without default" for
+    x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Null}}(1:10))
+
+    z = @inferred recode!(x, 1, 1=>100, 2:4=>0, [5; 9:10]=>-1)
+    @test x === z
+    @test x == [100, 0, 0, 0, -1, 1, 1, 1, -1, -1]
+    if isa(x, CategoricalArray)
+        @test levels(x) == [100, 0, -1, 1]
+        @test !isordered(x)
+    end
+end
+
+@testset "recode() promotion for $(typeof(x))" for x in (1:10, [1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Null}}(1:10))
+    T = eltype(x) >: Null ? Null : Union{}
+
+    # Recoding from Int to Float64 due to a second value being Float64
+    y = @inferred recode(x, 1=>100.0, 2:4=>0, [5; 9:10]=>-1)
+    @test y == [100, 0, 0, 0, -1, 6, 7, 8, -1, -1]
+    if isa(x, CategoricalArray)
+        @test isa(y, CategoricalVector{Union{Float64, T}, DefaultRefType})
+        @test levels(y) == [6, 7, 8, 100, 0, -1]
+        @test !isordered(y)
+    else
+        @test typeof(y) === Vector{Union{Float64, T}}
     end
 
-    # Recoding from Int to Int with duplicate recoded values
-    for x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Null}}(1:10)),
-        y in (similar(x), Array{Int}(size(x)),
-              CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Null}}(size(x)), x)
-        z = @inferred recode!(y, x, 1=>100, 2:4=>100, [5; 9:10]=>-1)
-        @test y === z
-        @test y == [100, 100, 100, 100, -1, 6, 7, 8, -1, -1]
-        if isa(y, CategoricalArray)
-            @test levels(y) == [6, 7, 8, 100, -1]
-            @test !isordered(y)
-        end
+    # Recoding from Int to Float64, with Float64 default and all other values Int
+    y = @inferred recode(x, -10.0, 1=>100, 2:4=>0, [5; 9:10]=>-1)
+    @test y == [100, 0, 0, 0, -1, -10, -10, -10, -1, -1]
+    if isa(x, CategoricalArray)
+        @test isa(y, CategoricalVector{Union{Float64, T}, DefaultRefType})
+        @test levels(y) == [100, 0, -1, -10]
+        @test !isordered(y)
+    else
+        @test typeof(y) === Vector{Union{Float64, T}}
     end
 
-    # Recoding from Int to Int with unused level
-    for x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Null}}(1:10)),
-        y in (similar(x), Array{Int}(size(x)),
-              CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Null}}(size(x)), x)
-        z = @inferred recode!(y, x, 1=>100, 2:4=>0, [5; 9:10]=>-1, 100=>1)
-        @test y === z
-        @test y == [100, 0, 0, 0, -1, 6, 7, 8, -1, -1]
-        if isa(y, CategoricalArray)
-            @test levels(y) == [6, 7, 8, 100, 0, -1, 1]
-            @test !isordered(y)
-        end
+    # Recoding from Int to Any
+    y = @inferred recode(x, 1=>"a", 2:4=>0, [5; 9:10]=>-1)
+    @test y == ["a", 0, 0, 0, -1, 6, 7, 8, -1, -1]
+    if isa(x, CategoricalArray)
+        @test isa(y, CategoricalVector{Any, DefaultRefType})
+        @test levels(y) == [6, 7, 8, "a", 0, -1]
+        @test !isordered(y)
+    else
+        @test typeof(y) === Vector{Any}
     end
 
-    # Recoding from Int to Int with duplicate default
-    for x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Null}}(1:10)),
-        y in (similar(x), Array{Int}(size(x)),
-              CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Null}}(size(x)), x)
-        z = @inferred recode!(y, x, 100, 1=>100, 2:4=>100, [5; 9:10]=>-1)
-        @test y === z
-        @test y == [100, 100, 100, 100, -1, 100, 100, 100, -1, -1]
-        if isa(y, CategoricalArray)
-            @test levels(y) == [100, -1]
-            @test !isordered(y)
-        end
+    # Recoding from Int to String, with String default
+    y = @inferred recode(x, "d", 1=>"a", 2:4=>"b", [5; 9:10]=>"c")
+    @test y == ["a", "b", "b", "b", "c", "d", "d", "d", "c", "c"]
+    if isa(x, CategoricalArray)
+        @test isa(y, CategoricalVector{Union{String, T}, DefaultRefType})
+        @test levels(y) == ["a", "b", "c", "d"]
+        @test !isordered(y)
+    else
+        @test typeof(y) === Vector{Union{String, T}}
     end
 
-    # Recoding from Int to Int, with default
-    for x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Null}}(1:10)),
-        y in (similar(x), Array{Int}(size(x)),
-              CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Null}}(size(x)), x)
-        z = @inferred recode!(y, x, -10, 1=>100, 2:4=>0, [5; 9:10]=>-1)
-        @test y === z
-        @test y == [100, 0, 0, 0, -1, -10, -10, -10, -1, -1]
-        if isa(y, CategoricalArray)
-            @test levels(y) == [100, 0, -1, -10]
-            @test !isordered(y)
-        end
+    # Recoding from Int to String, with all original levels recoded
+    y = @inferred recode(x, 1:4=>"a", [5; 9:10]=>"b", 6:8=>"c")
+    @test y == ["a", "a", "a", "a", "b", "c", "c", "c", "b", "b"]
+    if isa(x, CategoricalArray)
+        @test isa(y, CategoricalVector{Union{String, T}, DefaultRefType})
+        @test levels(y) == ["a", "b", "c"]
+        @test !isordered(y)
+    else
+        @test typeof(y) === Vector{Union{String, T}}
     end
 
-    # Recoding from Int to Int, with a first value being Float64
-    for x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Null}}(1:10)),
-        y in (similar(x), Array{Int}(size(x)),
-              CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Null}}(size(x)), x)
-        z = @inferred recode!(y, x, 1.0=>100, 2:4=>0, [5; 9:10]=>-1)
-        @test y == [100, 0, 0, 0, -1, 6, 7, 8, -1, -1]
-        if isa(y, CategoricalArray)
-            @test levels(y) == [6, 7, 8, 100, 0, -1]
-            @test !isordered(y)
-        end
+    # Recoding from Int to Int/String (i.e. Any), with default String and other values Int
+    y = @inferred recode(x, "x", 1=>100, 2:4=>0, [5; 9:10]=>-1)
+    @test y == [100, 0, 0, 0, -1, "x", "x", "x", -1, -1]
+    if isa(x, CategoricalArray)
+        @test isa(y, CategoricalVector{Any, DefaultRefType})
+        @test levels(y) == [100, 0, -1, "x"]
+        @test !isordered(y)
+    else
+        @test typeof(y) === Vector{Any}
     end
 
-    # Recoding from Int to Int with overlapping pairs
-    for x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Null}}(1:10)),
-        y in (similar(x), Array{Int}(size(x)),
-              CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Null}}(size(x)), x)
-        z = @inferred recode!(y, x, 1=>100, 2:4=>0, [5; 9:10]=>-1, 1:10=>0)
-        @test y === z
-        @test y == [100, 0, 0, 0, -1, 0, 0, 0, -1, -1]
-        if isa(y, CategoricalArray)
-            @test levels(y) == [100, 0, -1]
-            @test !isordered(y)
-        end
+    # Recoding from Int to Int/String, without any Int value in pairs
+    # and keeping some original Int levels
+    # This must fail since we cannot take into account original eltype (whether original
+    # levels are kept is only known at run time)
+    res = @test_throws ArgumentError recode(x, 1=>"a", 2:4=>"b", [5; 9:10]=>"c")
+    @test sprint(showerror, res.value) ==
+        "ArgumentError: cannot `convert` value 6 (of type $Int) to type of recoded levels ($(Union{String, T})). " *
+        "This will happen with recode() when not all original levels are recoded " *
+        "(i.e. some are preserved) and their type is incompatible with that of recoded levels."
+
+    # Recoding from Int to Union{Int, Null} with null default
+    y = @inferred recode(x, null, 1=>100, 2:4=>0, [5; 9:10]=>-1)
+    @test y ≅ [100, 0, 0, 0, -1, null, null, null, -1, -1]
+    if isa(x, CategoricalArray)
+        @test isa(y, CategoricalVector{Union{Int, Null}, DefaultRefType})
+        @test levels(y) == [100, 0, -1]
+        @test !isordered(y)
+    else
+        @test typeof(y) === Vector{Union{Int, Null}}
     end
 
-    # Recoding from Int to Int, with changes to levels order
-    for x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Null}}(1:10)),
-        y in (similar(x), Array{Int}(size(x)),
-              CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Null}}(size(x)), x)
-        z = @inferred recode!(y, x, 1=>100, 2:4=>0, [5; 9:10]=>-1)
-        @test y === z
-        @test y == [100, 0, 0, 0, -1, 6, 7, 8, -1, -1]
-        if isa(y, CategoricalArray)
-            @test levels(y) == [6, 7, 8, 100, 0, -1]
-            @test !isordered(y)
-        end
+    # Recoding from Int to Union{Int, Null} with null RHS
+    y = @inferred recode(x, 1=>null, 2:4=>0, [5; 9:10]=>-1)
+    @test y ≅ [null, 0, 0, 0, -1, 6, 7, 8, -1, -1]
+    if isa(x, CategoricalArray)
+        @test isa(y, CategoricalVector{Union{Int, Null}, DefaultRefType})
+        @test levels(y) == [6, 7, 8, 0, -1]
+        @test !isordered(y)
+    else
+        @test typeof(y) === Vector{Union{Int, Null}}
+    end
+end
+
+@testset "Recoding from $(typeof(x)) to $(typeof(x))" for
+    x in (["a", "c", "b", "a"], CategoricalArray(["a", "c", "b", "a"]))
+
+    y = @inferred recode(x, "c"=>"x", "b"=>"y", "a"=>"z")
+    @test y == ["z", "x", "y", "z"]
+    if isa(x, CategoricalArray)
+        @test isa(y, CategoricalVector{String, DefaultRefType})
+        @test levels(y) == ["x", "y", "z"]
+        @test !isordered(y)
+    else
+        @test typeof(y) === Vector{String}
+    end
+end
+
+@testset "Recoding a matrix $(typeof(x))" for
+    x in (['a' 'c'; 'b' 'a'], CategoricalArray(['a' 'c'; 'b' 'a']))
+
+    y = @inferred recode(x, 'c'=>'x', 'b'=>'y', 'a'=>'z')
+    @test y == ['z' 'x'; 'y' 'z']
+    if isa(x, CategoricalArray)
+        @test isa(y, CategoricalMatrix{Char, DefaultRefType})
+        @test levels(y) == ['x', 'y', 'z']
+        @test !isordered(y)
+    else
+        @test typeof(y) === Matrix{Char}
+    end
+end
+
+@testset "Recoding from $(typeof(x)) to Int/String (i.e. Any), with index and levels in different orders" for
+    x in (10:-1:1, CategoricalArray(10:-1:1))
+
+    y = @inferred recode(x, 0, 1=>"a", 2:4=>"c", [5; 9:10]=>"b")
+    @test y == ["b", "b", 0, 0, 0, "b", "c", "c", "c", "a"]
+    if isa(x, CategoricalArray)
+        @test isa(y, CategoricalVector{Any, DefaultRefType})
+        @test levels(y) == ["a", "c", "b", 0]
+        @test !isordered(y)
+    else
+        @test typeof(y) === Vector{Any}
     end
 
-    # Recoding nullable array to non-nullable categorical array: check that error is thrown
-    for x in (["a", null, "c", "d"], CategoricalArray(["a", null, "c", "d"]))
-        y = Vector{String}(4)
-        @test_throws MethodError recode!(y, x, "a", "c"=>"b")
-
-        y = CategoricalVector{String}(4)
-        @test_throws NullException recode!(y, x, "a", "c"=>"b")
+    # Recoding from Int to String via default, with index and levels in different orders
+    y = @inferred recode(x, "x", 1=>"a", 2:4=>"c", [5; 9:10]=>"b")
+    @test y == ["b", "b", "x", "x", "x", "b", "c", "c", "c", "a"]
+    if isa(x, CategoricalArray)
+        @test isa(y, CategoricalVector{String, DefaultRefType})
+        @test levels(y) == ["a", "c", "b", "x"]
+        @test !isordered(y)
+    else
+        @test typeof(y) === Vector{String}
     end
+end
 
-    # Recoding nullable array with null value and default
-    for x in (["a", null, "c", "d"], CategoricalArray(["a", null, "c", "d"])),
-        y in (similar(x), Array{Union{String, Null}}(size(x)),
-              CategoricalArray{Union{String, Null}}(size(x)), x)
-        z = @inferred recode!(y, x, "a", "c"=>"b")
-        @test y === z
-        @test y ≅ ["a", null, "b", "a"]
-        if isa(y, CategoricalArray)
-            @test levels(y) == ["b", "a"]
-            @test !isordered(y)
-        end
-    end
-
-    # Recoding nullable array with null value and no default
-    for x in (["a", null, "c", "d"], CategoricalArray(["a", null, "c", "d"])),
-        y in (similar(x), Array{Union{String, Null}}(size(x)),
-              CategoricalArray{Union{String, Null}}(size(x)), x)
-        z = @inferred recode!(y, x, "c"=>"b")
-        @test y === z
-        @test y ≅ ["a", null, "b", "d"]
-        if isa(y, CategoricalArray)
-            @test levels(y) == ["a", "d", "b"]
-            @test !isordered(y)
-        end
-    end
-
-    # Recoding nullable array with null value, no default and with null as a key pair
-    for x in (["a", null, "c", "d"], CategoricalArray(["a", null, "c", "d"])),
-        y in (similar(x), Array{Union{String, Null}}(size(x)),
-              CategoricalArray{Union{String, Null}}(size(x)), x)
-        z = @inferred recode!(y, x, "a", "c"=>"b", null=>"d")
-        @test y === z
-        @test y == ["a", "d", "b", "a"]
-        if isa(y, CategoricalArray)
-            @test levels(y) == ["b", "d", "a"]
-            @test !isordered(y)
-        end
-    end
-
-    # Recoding nullable array with null value, no default and with null as a key pair
-    for x in (["a", null, "c", "d"], CategoricalArray(["a", null, "c", "d"])),
-        y in (similar(x), Array{Union{String, Null}}(size(x)),
-              CategoricalArray{Union{String, Null}}(size(x)), x)
-        z = @inferred recode!(y, x, "c"=>"b", null=>"d")
-        @test y === z
-        @test y == ["a", "d", "b", "d"]
-        if isa(y, CategoricalArray)
-            @test levels(y) == ["a", "b", "d"]
-            @test !isordered(y)
-        end
-    end
-
-    # Recoding into array with incompatible size
-    for x in (["a", null, "c", "d"], CategoricalArray(["a", null, "c", "d"])),
-        y in (similar(x, 0), Array{Union{String, Null}}(0),
-              CategoricalArray{Union{String, Null}}(0))
-        @test_throws DimensionMismatch recode!(y, x, "c"=>"b", null=>"d")
-    end
-
-    # Recoding into array with incompatible element type
-    for x in ([1:10;], CategoricalArray(1:10)),
-        y in (similar(x, String), Array{String}(size(x)), CategoricalArray{String}(size(x)))
-        @test_throws ArgumentError recode!(y, x, 1=>"a", 2:4=>"b", [5; 9:10]=>"c")
-    end
-    for x in ((Union{Int, Null})[1:10;], CategoricalArray{Union{Int, Null}}(1:10)),
-        y in (similar(x), Array{Union{Int, Null}}(size(x)), CategoricalArray{Union{Int, Null}}(size(x)))
-        res = @test_throws MethodError recode!(y, x, 1=>"a", 2:4=>"b", [5; 9:10]=>"c")
-    end
-
-
-    ## Test in-place recode!()
-
-    # Recoding from Int to Int without default
-    for x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Null}}(1:10))
-        z = @inferred recode!(x, 1=>100, 2:4=>0, [5; 9:10]=>-1)
-        @test x === z
-        @test x == [100, 0, 0, 0, -1, 6, 7, 8, -1, -1]
-        if isa(x, CategoricalArray)
-            @test levels(x) == [6, 7, 8, 100, 0, -1]
-            @test !isordered(x)
-        end
-    end
-
-    # Recoding from Int to Int with default
-    for x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Null}}(1:10))
-        z = @inferred recode!(x, 1, 1=>100, 2:4=>0, [5; 9:10]=>-1)
-        @test x === z
-        @test x == [100, 0, 0, 0, -1, 1, 1, 1, -1, -1]
-        if isa(x, CategoricalArray)
-            @test levels(x) == [100, 0, -1, 1]
-            @test !isordered(x)
-        end
-    end
-
-
-    ## Test recode() promotion
-
-    for x in (1:10, [1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Null}}(1:10))
-        T = eltype(x) >: Null ? Null : Union{}
-
-        # Recoding from Int to Float64 due to a second value being Float64
-        y = @inferred recode(x, 1=>100.0, 2:4=>0, [5; 9:10]=>-1)
-        @test y == [100, 0, 0, 0, -1, 6, 7, 8, -1, -1]
-        if isa(x, CategoricalArray)
-            @test isa(y, CategoricalVector{Union{Float64, T}, DefaultRefType})
-            @test levels(y) == [6, 7, 8, 100, 0, -1]
-            @test !isordered(y)
-        else
-            @test typeof(y) === Vector{Union{Float64, T}}
-        end
-
-        # Recoding from Int to Float64, with Float64 default and all other values Int
-        y = @inferred recode(x, -10.0, 1=>100, 2:4=>0, [5; 9:10]=>-1)
-        @test y == [100, 0, 0, 0, -1, -10, -10, -10, -1, -1]
-        if isa(x, CategoricalArray)
-            @test isa(y, CategoricalVector{Union{Float64, T}, DefaultRefType})
-            @test levels(y) == [100, 0, -1, -10]
-            @test !isordered(y)
-        else
-            @test typeof(y) === Vector{Union{Float64, T}}
-        end
-
-        # Recoding from Int to Any
-        y = @inferred recode(x, 1=>"a", 2:4=>0, [5; 9:10]=>-1)
-        @test y == ["a", 0, 0, 0, -1, 6, 7, 8, -1, -1]
-        if isa(x, CategoricalArray)
-            @test isa(y, CategoricalVector{Any, DefaultRefType})
-            @test levels(y) == [6, 7, 8, "a", 0, -1]
-            @test !isordered(y)
-        else
-            @test typeof(y) === Vector{Any}
-        end
-
-        # Recoding from Int to String, with String default
-        y = @inferred recode(x, "d", 1=>"a", 2:4=>"b", [5; 9:10]=>"c")
-        @test y == ["a", "b", "b", "b", "c", "d", "d", "d", "c", "c"]
-        if isa(x, CategoricalArray)
-            @test isa(y, CategoricalVector{Union{String, T}, DefaultRefType})
-            @test levels(y) == ["a", "b", "c", "d"]
-            @test !isordered(y)
-        else
-            @test typeof(y) === Vector{Union{String, T}}
-        end
-
-        # Recoding from Int to String, with all original levels recoded
-        y = @inferred recode(x, 1:4=>"a", [5; 9:10]=>"b", 6:8=>"c")
-        @test y == ["a", "a", "a", "a", "b", "c", "c", "c", "b", "b"]
-        if isa(x, CategoricalArray)
-            @test isa(y, CategoricalVector{Union{String, T}, DefaultRefType})
-            @test levels(y) == ["a", "b", "c"]
-            @test !isordered(y)
-        else
-            @test typeof(y) === Vector{Union{String, T}}
-        end
-
-        # Recoding from Int to Int/String (i.e. Any), with default String and other values Int
-        y = @inferred recode(x, "x", 1=>100, 2:4=>0, [5; 9:10]=>-1)
-        @test y == [100, 0, 0, 0, -1, "x", "x", "x", -1, -1]
-        if isa(x, CategoricalArray)
-            @test isa(y, CategoricalVector{Any, DefaultRefType})
-            @test levels(y) == [100, 0, -1, "x"]
-            @test !isordered(y)
-        else
-            @test typeof(y) === Vector{Any}
-        end
-
-        # Recoding from Int to Int/String, without any Int value in pairs
-        # and keeping some original Int levels
-        # This must fail since we cannot take into account original eltype (whether original
-        # levels are kept is only known at run time)
-        res = @test_throws ArgumentError recode(x, 1=>"a", 2:4=>"b", [5; 9:10]=>"c")
-        @test sprint(showerror, res.value) ==
-            "ArgumentError: cannot `convert` value 6 (of type $Int) to type of recoded levels ($(Union{String, T})). " *
-            "This will happen with recode() when not all original levels are recoded " *
-            "(i.e. some are preserved) and their type is incompatible with that of recoded levels."
-
-        # Recoding from Int to Union{Int, Null} with null default
-        y = @inferred recode(x, null, 1=>100, 2:4=>0, [5; 9:10]=>-1)
-        @test y ≅ [100, 0, 0, 0, -1, null, null, null, -1, -1]
-        if isa(x, CategoricalArray)
-            @test isa(y, CategoricalVector{Union{Int, Null}, DefaultRefType})
-            @test levels(y) == [100, 0, -1]
-            @test !isordered(y)
-        else
-            @test typeof(y) === Vector{Union{Int, Null}}
-        end
-
-        # Recoding from Int to Union{Int, Null} with null RHS
-        y = @inferred recode(x, 1=>null, 2:4=>0, [5; 9:10]=>-1)
-        @test y ≅ [null, 0, 0, 0, -1, 6, 7, 8, -1, -1]
-        if isa(x, CategoricalArray)
-            @test isa(y, CategoricalVector{Union{Int, Null}, DefaultRefType})
-            @test levels(y) == [6, 7, 8, 0, -1]
-            @test !isordered(y)
-        else
-            @test typeof(y) === Vector{Union{Int, Null}}
-        end
-    end
-
-    for x in (["a", "c", "b", "a"], CategoricalArray(["a", "c", "b", "a"]))
-        # Recoding from String to String
-        y = @inferred recode(x, "c"=>"x", "b"=>"y", "a"=>"z")
-        @test y == ["z", "x", "y", "z"]
-        if isa(x, CategoricalArray)
-            @test isa(y, CategoricalVector{String, DefaultRefType})
-            @test levels(y) == ["x", "y", "z"]
-            @test !isordered(y)
-        else
-            @test typeof(y) === Vector{String}
-        end
-    end
-
-    for x in (['a' 'c'; 'b' 'a'], CategoricalArray(['a' 'c'; 'b' 'a']))
-        # Recoding a Matrix
-        y = @inferred recode(x, 'c'=>'x', 'b'=>'y', 'a'=>'z')
-        @test y == ['z' 'x'; 'y' 'z']
-        if isa(x, CategoricalArray)
-            @test isa(y, CategoricalMatrix{Char, DefaultRefType})
-            @test levels(y) == ['x', 'y', 'z']
-            @test !isordered(y)
-        else
-            @test typeof(y) === Matrix{Char}
-        end
-    end
-
-    for x in (10:-1:1, CategoricalArray(10:-1:1))
-        # Recoding from Int to Int/String (i.e. Any), with index and levels in different orders
-        y = @inferred recode(x, 0, 1=>"a", 2:4=>"c", [5; 9:10]=>"b")
-        @test y == ["b", "b", 0, 0, 0, "b", "c", "c", "c", "a"]
-        if isa(x, CategoricalArray)
-            @test isa(y, CategoricalVector{Any, DefaultRefType})
-            @test levels(y) == ["a", "c", "b", 0]
-            @test !isordered(y)
-        else
-            @test typeof(y) === Vector{Any}
-        end
-
-        # Recoding from Int to String via default, with index and levels in different orders
-        y = @inferred recode(x, "x", 1=>"a", 2:4=>"c", [5; 9:10]=>"b")
-        @test y == ["b", "b", "x", "x", "x", "b", "c", "c", "c", "a"]
-        if isa(x, CategoricalArray)
-            @test isa(y, CategoricalVector{String, DefaultRefType})
-            @test levels(y) == ["a", "c", "b", "x"]
-            @test !isordered(y)
-        else
-            @test typeof(y) === Vector{String}
-        end
-    end
-
-    # Recoding CategoricalArray with custom reftype
+@testset "Recoding CategoricalArray with custom reftype" begin
     x = CategoricalVector{Int, UInt8}(1:10)
     y = @inferred recode(x, 1=>100, 2:4=>0, [5; 9:10]=>-1)
     @test y == [100, 0, 0, 0, -1, 6, 7, 8, -1, -1]
     @test isa(y, CategoricalVector{Int, UInt8})
     @test levels(y) == [6, 7, 8, 100, 0, -1]
     @test !isordered(y)
+end
 
-    # Recoding ordered CategoricalArray and merging two categories
+@testset "Recoding ordered CategoricalArray and merging two categories" begin
     x = CategoricalArray(["a", "c", "b", "a"])
     ordered!(x, true)
     y = @inferred recode(x, "c"=>"a")
@@ -387,8 +407,9 @@ module TestRecode
     @test isa(y, CategoricalVector{String, DefaultRefType})
     @test levels(y) == ["a", "b"]
     @test isordered(y)
+end
 
-    # Recoding ordered CategoricalArray and merging one category into another (contd.)
+@testset "Recoding ordered CategoricalArray and merging one category into another (contd.)" begin
     x = CategoricalArray(["a", "c", "b", "a"])
     ordered!(x, true)
     y = @inferred recode(x, "b"=>"c")
@@ -396,8 +417,9 @@ module TestRecode
     @test isa(y, CategoricalVector{String, DefaultRefType})
     @test levels(y) == ["a", "c"]
     @test isordered(y)
+end
 
-    # Recoding ordered CategoricalArray with new level which cannot be ordered
+@testset "Recoding ordered CategoricalArray with new level which cannot be ordered" begin
     x = CategoricalArray(["a", "c", "b", "a"])
     ordered!(x, true)
     y = @inferred recode(x, "b"=>"d")
@@ -405,8 +427,9 @@ module TestRecode
     @test isa(y, CategoricalVector{String, DefaultRefType})
     @test levels(y) == ["a", "c", "d"]
     @test !isordered(y)
+end
 
-    # Recoding ordered CategoricalArray with conflicting orders
+@testset "Recoding ordered CategoricalArray with conflicting orders" begin
     x = CategoricalArray(["a", "c", "b", "a"])
     ordered!(x, true)
     y = @inferred recode(x, "b"=>"b", "a"=>"a")
@@ -414,8 +437,9 @@ module TestRecode
     @test isa(y, CategoricalVector{String, DefaultRefType})
     @test levels(y) == ["c", "b", "a"]
     @test !isordered(y)
+end
 
-    # Recoding ordered CategoricalArray with default already in levels
+@testset "Recoding ordered CategoricalArray with default already in levels" begin
     x = CategoricalArray(["a", "c", "b", "a"])
     ordered!(x, true)
     y = @inferred recode(x, "a", "c"=>"b")
@@ -423,8 +447,9 @@ module TestRecode
     @test isa(y, CategoricalVector{String, DefaultRefType})
     @test levels(y) == ["b", "a"]
     @test !isordered(y)
+end
 
-    # Recoding ordered CategoricalArray with default not in levels
+@testset "Recoding ordered CategoricalArray with default not in levels" begin
     x = CategoricalArray(["d", "c", "b", "d"])
     ordered!(x, true)
     y = @inferred recode(x, "a", "c"=>"b")
@@ -432,8 +457,9 @@ module TestRecode
     @test isa(y, CategoricalVector{String, DefaultRefType})
     @test levels(y) == ["b", "a"]
     @test !isordered(y)
+end
 
-    # Recoding nullable CategoricalArray with null values and no default
+@testset "Recoding nullable CategoricalArray with null values and no default" begin
     x = CategoricalArray{Union{String, Null}}(["a", "b", "c", "d"])
     x[2] = null
     y = @inferred recode(x, "c"=>"b")
@@ -441,8 +467,9 @@ module TestRecode
     @test isa(y, CategoricalVector{Union{String, Null}, DefaultRefType})
     @test levels(y) == ["a", "b", "d"]
     @test !isordered(y)
+end
 
-    # Recoding nullable CategoricalArray with null values and non-null default
+@testset "Recoding nullable CategoricalArray with null values and non-null default" begin
     x = CategoricalArray{Union{String, Null}}(["a", "b", "c", "d"])
     x[2] = null
     y = @inferred recode(x, "a", "c"=>"b")
@@ -450,4 +477,6 @@ module TestRecode
     @test isa(y, CategoricalVector{Union{String, Null}, DefaultRefType})
     @test levels(y) == ["b", "a"]
     @test !isordered(y)
+end
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,25 +31,7 @@ module TestCategoricalArrays
         "16_recode.jl"
     ]
 
-    println("Running tests:")
-
-    for test in tests
-        try
-            include(test)
-            println("\t\033[1m\033[32mPASSED\033[0m: $(test)")
-        catch e
-            anyerrors = true
-            println("\t\033[1m\033[31mFAILED\033[0m: $(test)")
-            if fatalerrors
-                rethrow(e)
-            elseif !quiet
-                showerror(STDOUT, e, backtrace())
-                println()
-            end
-        end
-    end
-
-    if anyerrors
-        throw("Tests failed")
+    @testset "$test" for test in tests
+        include(test)
     end
 end


### PR DESCRIPTION
Convert tests to use `@testsets` (extracted from #87).
Simplifies code and structurizes tests a bit + improves reporting and diagnostics in case of failure.