### PR TITLE
Expand copy! to handle nulls and view(::CategoricalArray)

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -389,7 +389,7 @@ end
 # Methods preserving levels and more efficient than AbstractArray fallbacks
 copy(A::CategoricalArray) = deepcopy(A)
 
-function copy!(dest::CategoricalArray{T, N}, dstart::Integer,
+function copy!(dest::CategoricalArray{<:Union{T, Null}, N}, dstart::Integer,
                src::CategoricalArray{T, N}, sstart::Integer,
                n::Integer=length(src)-sstart+1) where {T, N}
     destinds, srcinds = linearindices(dest), linearindices(src)
@@ -433,8 +433,10 @@ function copy!(dest::CategoricalArray{T, N}, dstart::Integer,
     dest
 end
 
-copy!(dest::CategoricalArray{T, N}, src::CategoricalArray{T, N}) where {T,N} =
+copy!(dest::CategoricalArray, src::CategoricalArray) =
     copy!(dest, 1, src, 1, length(src))
+copy!(dest::CategoricalArray, dstart::Integer, src::CategoricalArray) =
+    copy!(dest, dstart, src, 1, length(src))
 
 """
     similar(A::CategoricalArray, element_type=eltype(A), dims=size(A))

--- a/src/array.jl
+++ b/src/array.jl
@@ -434,10 +434,8 @@ function copy!(dest::CategoricalArray{<:Union{T,Null}, N}, dstart::Integer,
     dest
 end
 
-CA_OR_CA_VIEW = Union{CategoricalArray{T, N},
-                      SubArray{A, B, C, D} where
-                              {A, B, C <: CategoricalArray{T, N} where {T, N}, D}
-                      } where {T, N}
+CA_OR_CA_VIEW = Union{CategoricalArray, SubArray{A,B,C,D} where
+                                                {A,B,C<:CategoricalArray,D}}
 
 copy!(dest::CategoricalArray, src::CA_OR_CA_VIEW) =
     copy!(dest, 1, src, 1, length(src))

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -261,13 +261,14 @@ end
             @test levels(dest) == levels(src) == reverse(v)
         end
 
-        @testset "TODO" begin
-            # test what happens when non-nullable element-types aren't equal
-            # I think it will default to a Base.copy! fxn
-
-            # test what happens when we view a subset of the CategoricalArray
-            # fix currently just calls viewarray.parent.refs & viewarray.parent.pool which isn't subset properly,
-            # so I think there are still issues to solve due to that
+        @testset "copy a viewed subset of src into dest" begin
+            v = ["a", "b", "c"]
+            src = levels!(CategoricalVector(v), reverse(v))
+            vsrc = view(src, 1:2)
+            dest = CategoricalVector{String}(3)
+            copy!(dest, vsrc)
+            @test dest[1:2] == src[1:2]
+            @test levels(dest) == levels(src)
         end
     end
 

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -185,35 +185,89 @@ end
             @test x ≅ a
         end
 
-        @testset "level preservation with copy!" begin
-            using CategoricalArrays, Base.Test
+        @testset "copy non-nullable src into non-nullable dest" begin
             v = ["a", "b", "c"]
-            src = CategoricalVector(v)
-            dest = CategoricalVector{String}(3)
-            @test levels(copy!(dest, src)) == v
-
             src = levels!(CategoricalVector(v), reverse(v))
             dest = CategoricalVector{String}(3)
-            @test levels(copy!(dest, src)) == reverse(v)
+            copy!(dest, src)
+            @test dest == src
+            @test levels(dest) == levels(src) == reverse(v)
+        end
 
-            dest = CategoricalVector{Union{String, Null}}(3)
-            @test levels(copy!(dest, src)) == reverse(v)
-
-            dest = CategoricalVector{Union{String, Null}}(3)
-            dest[1] = src[1]
-            @test levels(copy!(dest, 2, src[2:end])) == reverse(v)
-
-            src = levels!(CategoricalVector{Union{String, Null}}(v), reverse(v))
-            dest = CategoricalVector{Union{String, Null}}(3)
-            @test levels(copy!(dest, src)) == reverse(v)
-
-            src = levels!(CategoricalVector{Union{String, Null}}(v), reverse(v))
+        @testset "copy nullable src into non-nullable dest" begin
+            v = ["a", "b", "c"]
+            src = levels!(CategoricalVector{Union{Null, String}}(v), reverse(v))
             dest = CategoricalVector{String}(3)
-            @test levels(copy!(dest, src)) == reverse(v)
+            copy!(dest, src)
+            @test dest == src
+            @test levels(dest) == levels(src) == reverse(v)
+        end
 
+        @testset "copy non-nullable src into nullable dest" begin
+            v = ["a", "b", "c"]
+            src = levels!(CategoricalVector(v), reverse(v))
             dest = CategoricalVector{Union{String, Null}}(3)
+            copy!(dest, src)
+            @test dest == src
+            @test levels(dest) == levels(src) == reverse(v)
+        end
+
+        @testset "copy nullable src into nullable dest" begin
+            v = ["a", "b", "c"]
+            src = levels!(CategoricalVector{Union{String, Null}}(v), reverse(v))
+            dest = CategoricalVector{Union{String, Null}}(3)
+            copy!(dest, src)
+            @test dest == src
+            @test levels(dest) == levels(src) == reverse(v)
+        end
+
+        @testset "copy non-nullable viewed src into non-nullable dest" begin
+            v = ["a", "b", "c"]
+            src = levels!(CategoricalVector(v), reverse(v))
             vsrc = view(src, 1:length(src))
-            @test levels(copy!(dest, vsrc)) == reverse(v)
+            dest = CategoricalVector{String}(3)
+            copy!(dest, vsrc)
+            @test dest == src
+            @test levels(dest) == levels(src) == reverse(v)
+        end
+
+        @testset "copy nullable viewed src into non-nullable dest" begin
+            v = ["a", "b", "c"]
+            src = levels!(CategoricalVector{Union{String, Null}}(v), reverse(v))
+            vsrc = view(src, 1:length(src))
+            dest = CategoricalVector{String}(3)
+            copy!(dest, vsrc)
+            @test dest == src
+            @test levels(dest) == levels(src) == reverse(v)
+        end
+
+        @testset "copy non-nullable viewed src into nullable dest" begin
+            v = ["a", "b", "c"]
+            src = levels!(CategoricalVector(v), reverse(v))
+            vsrc = view(src, 1:length(src))
+            dest = CategoricalVector{Union{String, Null}}(3)
+            copy!(dest, vsrc)
+            @test dest == src
+            @test levels(dest) == levels(src) == reverse(v)
+        end
+
+        @testset "copy nullable viewed src into nullable dest" begin
+            v = ["a", "b", "c"]
+            src = levels!(CategoricalVector{Union{String, Null}}(v), reverse(v))
+            vsrc = view(src, 1:length(src))
+            dest = CategoricalVector{Union{String, Null}}(3)
+            copy!(dest, vsrc)
+            @test dest == src
+            @test levels(dest) == levels(src) == reverse(v)
+        end
+
+        @testset "TODO" begin
+            # test what happens when non-nullable element-types aren't equal
+            # I think it will default to a Base.copy! fxn
+
+            # test what happens when we view a subset of the CategoricalArray
+            # fix currently just calls viewarray.parent.refs & viewarray.parent.pool which isn't subset properly,
+            # so I think there are still issues to solve due to that
         end
     end
 

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -186,6 +186,7 @@ end
         end
 
         @testset "level preservation with copy!" begin
+            using CategoricalArrays, Base.Test
             v = ["a", "b", "c"]
             src = CategoricalVector(v)
             dest = CategoricalVector{String}(3)
@@ -210,13 +211,6 @@ end
             dest = CategoricalVector{String}(3)
             @test levels(copy!(dest, src)) == reverse(v)
 
-            # incorrectly leaves #undef in 1st entry of dest
-            src = levels!(CategoricalVector{Union{String, Null}}(v), reverse(v))
-            src[1] = null
-            dest = CategoricalVector{String}(3)
-            @test levels(copy!(dest, src)) == reverse(v)
-
-            # does not dispatch correctly
             dest = CategoricalVector{Union{String, Null}}(3)
             vsrc = view(src, 1:length(src))
             @test levels(copy!(dest, vsrc)) == reverse(v)

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -201,6 +201,25 @@ end
             dest = CategoricalVector{Union{String, Null}}(3)
             dest[1] = src[1]
             @test levels(copy!(dest, 2, src[2:end])) == reverse(v)
+
+            src = levels!(CategoricalVector{Union{String, Null}}(v), reverse(v))
+            dest = CategoricalVector{Union{String, Null}}(3)
+            @test levels(copy!(dest, src)) == reverse(v)
+
+            src = levels!(CategoricalVector{Union{String, Null}}(v), reverse(v))
+            dest = CategoricalVector{String}(3)
+            @test levels(copy!(dest, src)) == reverse(v)
+
+            # incorrectly leaves #undef in 1st entry of dest
+            src = levels!(CategoricalVector{Union{String, Null}}(v), reverse(v))
+            src[1] = null
+            dest = CategoricalVector{String}(3)
+            @test levels(copy!(dest, src)) == reverse(v)
+
+            # does not dispatch correctly
+            dest = CategoricalVector{Union{String, Null}}(3)
+            vsrc = view(src, 1:length(src))
+            @test levels(copy!(dest, vsrc)) == reverse(v)
         end
     end
 

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -184,6 +184,24 @@ end
             @test_throws BoundsError copy!(x, 1, y, 4, 2)
             @test x ≅ a
         end
+
+        @testset "level preservation with copy!" begin
+            v = ["a", "b", "c"]
+            src = CategoricalVector(v)
+            dest = CategoricalVector{String}(3)
+            @test levels(copy!(dest, src)) == v
+
+            src = levels!(CategoricalVector(v), reverse(v))
+            dest = CategoricalVector{String}(3)
+            @test levels(copy!(dest, src)) == reverse(v)
+
+            dest = CategoricalVector{Union{String, Null}}(3)
+            @test levels(copy!(dest, src)) == reverse(v)
+
+            dest = CategoricalVector{Union{String, Null}}(3)
+            dest[1] = src[1]
+            @test levels(copy!(dest, 2, src[2:end])) == reverse(v)
+        end
     end
 
     @testset "resize!()" begin


### PR DESCRIPTION
This is needed in order to use `copy!` in joins in DataFrames in PR https://github.com/JuliaData/DataFrames.jl/pull/1266. The restriction that source and destination have the same element type `T` doesn't allow for copying `T` into `Union{T, Null}`. In all joins but inner joins we automatically promote the returned columns to be `Union{T, Null}`, and so using `copy!` in those cases currently defaults to calling the `Base.copy!` version that doesn't handle levels appropriately

before
```julia
julia> using CategoricalArrays, Base.Test
INFO: Recompiling stale cache file /Users/Cameron/.julia/lib/v0.6/CategoricalArrays.ji for module CategoricalArrays.

julia> v = ["a", "b", "c"]
3-element Array{String,1}:
 "a"
 "b"
 "c"

julia> src = levels!(CategoricalVector(v), reverse(v))
3-element CategoricalArrays.CategoricalArray{String,1,UInt32}:
 "a"
 "b"
 "c"

julia> dest = CategoricalVector{String}(3);

julia> @test levels(copy!(dest, src)) == reverse(v)
Test Passed

julia> dest = CategoricalVector{Union{String, Null}}(3);

julia> @test levels(copy!(dest, src)) == reverse(v)
Test Failed
  Expression: levels(copy!(dest, src)) == reverse(v)
   Evaluated: String["a", "b", "c"] == String["c", "b", "a"]
ERROR: There was an error during testing

```

after
```julia
julia> using CategoricalArrays, Base.Test

julia> v = ["a", "b", "c"]
3-element Array{String,1}:
 "a"
 "b"
 "c"

julia> src = levels!(CategoricalVector(v), reverse(v))
3-element CategoricalArrays.CategoricalArray{String,1,UInt32}:
 "a"
 "b"
 "c"

julia> dest = CategoricalVector{String}(3);

julia> @test levels(copy!(dest, src)) == reverse(v)
Test Passed

julia> dest = CategoricalVector{Union{String, Null}}(3);

julia> @test levels(copy!(dest, src)) == reverse(v)
Test Passed

```