### PR TITLE
Define JSON.lower(CatValue) if JSON is available

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.6
 Missings
 Reexport
 Compat 0.39.0
+JSON

--- a/src/CategoricalArrays.jl
+++ b/src/CategoricalArrays.jl
@@ -18,6 +18,7 @@ module CategoricalArrays
     if VERSION >= v"0.7.0-DEV.3052"
         using Printf
     end
+    using JSON # FIXME make JSON optional dependency when core Julia will support that
 
     include("typedefs.jl")
 

--- a/src/value.jl
+++ b/src/value.jl
@@ -160,3 +160,6 @@ Base.match(r::Regex, s::CategoricalString,
 Base.matchall(r::Regex, s::CategoricalString, overlap::Bool=false) =
     matchall(r, get(s), overlap)
 Base.collect(x::CategoricalString) = collect(get(x))
+
+# JSON of CatValue is JSON of the value it refers to
+JSON.lower(x::CatValue) = get(x)


### PR DESCRIPTION
Uses Requires.jl to define `JSON.json(::CatValue)` if JSON is present.

Fixes #95