### PR TITLE
Change behavior of eltype()

### DIFF
--- a/src/value.jl
+++ b/src/value.jl
@@ -12,9 +12,6 @@ leveltype(::Type{<:CategoricalValue{T}}) where {T} = T
 leveltype(::Type{<:CategoricalString}) = String
 leveltype(::Type) = throw(ArgumentError("Not a categorical value type"))
 leveltype(x::Any) = leveltype(typeof(x))
-# eltype() is a synonym of leveltype() for categorical values
-Base.eltype(::Type{T}) where {T <: CatValue} = leveltype(T)
-Base.eltype(x::CatValue) = eltype(typeof(x))
 
 # integer type of category reference codes used by categorical value
 reftype(::Type{<:CatValue{R}}) where {R} = R
@@ -151,6 +148,7 @@ end
 
 # AbstractString interface for CategoricalString
 Base.string(x::CategoricalString) = get(x)
+Base.eltype(x::CategoricalString) = Char
 Base.length(x::CategoricalString) = length(get(x))
 Base.endof(x::CategoricalString) = endof(get(x))
 Base.sizeof(x::CategoricalString) = sizeof(get(x))

--- a/test/01_typedef.jl
+++ b/test/01_typedef.jl
@@ -52,8 +52,8 @@ using CategoricalArrays: DefaultRefType, level,  reftype, leveltype, catvalue, i
 
         @test iscatvalue(x)
         @test iscatvalue(typeof(x))
-        @test eltype(x) === String
-        @test eltype(typeof(x)) === String
+        @test eltype(x) === Char
+        @test eltype(typeof(x)) === Char
         @test leveltype(x) === String
         @test leveltype(typeof(x)) === String
         @test reftype(x) === DefaultRefType

--- a/test/05_convert.jl
+++ b/test/05_convert.jl
@@ -17,8 +17,8 @@ using CategoricalArrays: DefaultRefType, level, reftype, leveltype, catvalue, is
     v3 = catvalue(3, pool)
     @test iscatvalue(v1)
     @test iscatvalue(typeof(v1))
-    @test eltype(v1) === Int
-    @test eltype(typeof(v1)) === Int
+    @test eltype(v1) === Any
+    @test eltype(typeof(v1)) === Any
     @test leveltype(v1) === Int
     @test leveltype(typeof(v1)) === Int
     @test reftype(v1) === DefaultRefType

--- a/test/08_string.jl
+++ b/test/08_string.jl
@@ -30,6 +30,9 @@ using CategoricalArrays
     @test isempty(v1)
     @test !isempty(v2)
 
+    @test eltype(v1) === Char
+    @test eltype(v2) === Char
+
     @test length(v1) === 0
     @test length(v2) === 4
 


### PR DESCRIPTION
`eltype(CategoricalString)` should return `Char` for consistency with getindex. `eltype(CategoricalValue)` should not be defined, which means it returns `Any` (like any other type by default).

Cf. https://github.com/JuliaData/DataFrames.jl/issues/1282.

Cc: @alyst