### PR TITLE
Add special case for single missing RHS in recode()

### DIFF
--- a/src/recode.jl
+++ b/src/recode.jl
@@ -322,9 +322,14 @@ function recode(a::AbstractArray, default::Any, pairs::Pair...)
     # whether it matters at compile time (all levels recoded or not)
     # and using a wider type than necessary would be annoying
     T = default === nothing ? V : promote_type(typeof(default), V)
-    # Exception: if original array accepted missing values and missing does not appear
+    # Exception 1: if T === Missing and default not missing,
+    # assume the caller wants to recode only some values to missing,
+    # but accept original values
+    if T === Missing && default !== missing
+        dest = Array{Union{eltype(a), Missing}}(size(a))
+    # Exception 2: if original array accepted missing values and missing does not appear
     # in one of the pairs' LHS, result must accept missing values
-    if T >: Missing || default === missing || (eltype(a) >: Missing && !keytype_hasmissing(pairs...))
+    elseif T >: Missing || default === missing || (eltype(a) >: Missing && !keytype_hasmissing(pairs...))
         dest = Array{Union{T, Missing}}(size(a))
     else
         dest = Array{Missings.T(T)}(size(a))
@@ -338,9 +343,14 @@ function recode(a::CategoricalArray{S, N, R}, default::Any, pairs::Pair...) wher
     # whether it matters at compile time (all levels recoded or not)
     # and using a wider type than necessary would be annoying
     T = default === nothing ? V : promote_type(typeof(default), V)
-    # Exception: if original array accepted missing values and missing does not appear
+    # Exception 1: if T === Missing and default not missing,
+    # assume the caller wants to recode only some values to missing,
+    # but accept original values
+    if T === Missing && default !== missing
+        dest = CategoricalArray{Union{S, Missing}, N, R}(size(a))
+    # Exception 2: if original array accepted missing values and missing does not appear
     # in one of the pairs' LHS, result must accept missing values
-    if T >: Missing || default === missing || (eltype(a) >: Missing && !keytype_hasmissing(pairs...))
+    elseif T >: Missing || default === missing || (eltype(a) >: Missing && !keytype_hasmissing(pairs...))
         dest = CategoricalArray{Union{T, Missing}, N, R}(size(a))
     else
         dest = CategoricalArray{Missings.T(T), N, R}(size(a))

--- a/test/16_recode.jl
+++ b/test/16_recode.jl
@@ -335,6 +335,17 @@ end
     else
         @test typeof(y) === Vector{Union{Int, Missing}}
     end
+
+    # Recoding from Int to Union{Int, Missing} with single missing RHS
+    y = @inferred recode(x, 1=>missing)
+    @test y ≅ [missing, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    if isa(x, CategoricalArray)
+        @test isa(y, CategoricalVector{Union{Int, Missing}, DefaultRefType})
+        @test levels(y) == collect(2:10)
+        @test !isordered(y)
+    else
+        @test typeof(y) === Vector{Union{Int, Missing}}
+    end
 end
 
 @testset "Recoding from $(typeof(x)) to $(typeof(x))" for


### PR DESCRIPTION
When a single pair appears and the RHS is `missing`, it is very unlikely
that the caller would want an `Array{Missing}` result. Instead, return
an `Array{Union{T, Missing}}`, with T the original array's eltype.
This is useful to transform some values into missing values.

See https://discourse.julialang.org/t/assignment-of-a-missing-value-fails-in-dataframes-0-11-1/7379/10?u=nalimilan.