### PR TITLE
Correctly handle recoding pair with value range and source containing missings

### DIFF
--- a/src/recode.jl
+++ b/src/recode.jl
@@ -42,7 +42,7 @@ function recode!(dest::AbstractArray{T}, src::AbstractArray, default::Any, pairs
         for j in 1:length(pairs)
             p = pairs[j]
             if ((isa(p.first, Union{AbstractArray, Tuple}) && any(x ≅ y for y in p.first)) ||
-                x ≅ p.first)               
+                x ≅ p.first)
                 dest[i] = p.second
                 @goto nextitem
             end
@@ -95,7 +95,7 @@ function recode!(dest::CategoricalArray{T}, src::AbstractArray, default::Any, pa
         for j in 1:length(pairs)
             p = pairs[j]
             if ((isa(p.first, Union{AbstractArray, Tuple}) && any(x ≅ y for y in p.first)) ||
-                x ≅ p.first)               
+                x ≅ p.first)
                 drefs[i] = dupvals ? pairmap[j] : j
                 @goto nextitem
             end
@@ -196,8 +196,7 @@ function recode!(dest::CategoricalArray{T}, src::CategoricalArray, default::Any,
         for j in 1:length(pairs)
             p = pairs[j]
             if ((isa(p.first, Union{AbstractArray, Tuple}) && any(l ≅ y for y in p.first)) ||
-                l ≅ p.first) 
-               
+                l ≅ p.first)
                 indexmap[i+1] = pairmap[j]
                 @goto nextitem
             end

--- a/src/recode.jl
+++ b/src/recode.jl
@@ -42,8 +42,7 @@ function recode!(dest::AbstractArray{T}, src::AbstractArray, default::Any, pairs
         for j in 1:length(pairs)
             p = pairs[j]
             if ((isa(p.first, Union{AbstractArray, Tuple}) && any(x ≅ y for y in p.first)) ||
-                x ≅ p.first)
-               
+                x ≅ p.first)               
                 dest[i] = p.second
                 @goto nextitem
             end
@@ -96,8 +95,7 @@ function recode!(dest::CategoricalArray{T}, src::AbstractArray, default::Any, pa
         for j in 1:length(pairs)
             p = pairs[j]
             if ((isa(p.first, Union{AbstractArray, Tuple}) && any(x ≅ y for y in p.first)) ||
-                x ≅ p.first)
-               
+                x ≅ p.first)               
                 drefs[i] = dupvals ? pairmap[j] : j
                 @goto nextitem
             end

--- a/src/recode.jl
+++ b/src/recode.jl
@@ -41,8 +41,9 @@ function recode!(dest::AbstractArray{T}, src::AbstractArray, default::Any, pairs
 
         for j in 1:length(pairs)
             p = pairs[j]
-            if (!isa(p.first, Union{AbstractArray, Tuple}) && x ≅ p.first) ||
-               (isa(p.first, Union{AbstractArray, Tuple}) && any(x ≅ y for y in p.first))
+            if ((isa(p.first, Union{AbstractArray, Tuple}) && any(x ≅ y for y in p.first)) ||
+                x ≅ p.first)
+               
                 dest[i] = p.second
                 @goto nextitem
             end
@@ -94,8 +95,9 @@ function recode!(dest::CategoricalArray{T}, src::AbstractArray, default::Any, pa
 
         for j in 1:length(pairs)
             p = pairs[j]
-            if (!isa(p.first, Union{AbstractArray, Tuple}) && x ≅ p.first) ||
-               (isa(p.first, Union{AbstractArray, Tuple}) && any(x ≅ y for y in p.first))
+            if ((isa(p.first, Union{AbstractArray, Tuple}) && any(x ≅ y for y in p.first)) ||
+                x ≅ p.first)
+               
                 drefs[i] = dupvals ? pairmap[j] : j
                 @goto nextitem
             end
@@ -181,7 +183,8 @@ function recode!(dest::CategoricalArray{T}, src::CategoricalArray, default::Any,
     # For missing values (0 if no missing in pairs' keys)
     indexmap[1] = 0
     for p in pairs
-        if any(ismissing, p.first)
+        if ((isa(p.first, Union{AbstractArray, Tuple}) && any(ismissing, p.first)) ||
+            ismissing(p.first))
             indexmap[1] = get(dest.pool, p.second)
             break
         end
@@ -194,8 +197,9 @@ function recode!(dest::CategoricalArray{T}, src::CategoricalArray, default::Any,
     @inbounds for (i, l) in enumerate(srcindex)
         for j in 1:length(pairs)
             p = pairs[j]
-            if (!isa(p.first, Union{AbstractArray, Tuple}) && l ≅ p.first) ||
-               (isa(p.first, Union{AbstractArray, Tuple}) && any(l ≅ y for y in p.first))
+            if ((isa(p.first, Union{AbstractArray, Tuple}) && any(l ≅ y for y in p.first)) ||
+                l ≅ p.first) 
+               
                 indexmap[i+1] = pairmap[j]
                 @goto nextitem
             end

--- a/src/recode.jl
+++ b/src/recode.jl
@@ -6,17 +6,20 @@ const ≅ = isequal
 Fill `dest` with elements from `src`, replacing those matching a key of `pairs`
 with the corresponding value.
 
-For each `Pair` in `pairs`, if the element is equal to (according to [`isequal`](@ref))
-or [`in`](@ref) the key (first item of the pair), then the corresponding value
-(second item) is copied to `dest`.
+For each `Pair` in `pairs`, if the element is equal to (according to [`isequal`](@ref)))
+the key (first item of the pair) or to one of its entries if it is a collection,
+then the corresponding value (second item) is copied to `dest`.
 If the element matches no key and `default` is not provided or `nothing`, it is copied as-is;
 if `default` is specified, it is used in place of the original element.
-If `dest` is CategoricalArray and `default` is provided then the ordering of resulting levels
-is determined by the order of passed `pairs` and `default` will be the last level.
 `dest` and `src` must be of the same length, but not necessarily of the same type.
 Elements of `src` as well as values from `pairs` will be `convert`ed when possible
 on assignment.
 If an element matches more than one key, the first match is used.
+
+    recode!(dest::CategoricalArray, src::AbstractArray[, default::Any], pairs::Pair...)
+
+If `dest` is a `CategoricalArray` then the ordering of resulting levels is determined
+by the order of passed `pairs` and `default` will be the last level if provided.
 
     recode!(dest::AbstractArray, src::AbstractArray{>:Missing}[, default::Any], pairs::Pair...)
 
@@ -178,7 +181,7 @@ function recode!(dest::CategoricalArray{T}, src::CategoricalArray, default::Any,
     # For missing values (0 if no missing in pairs' keys)
     indexmap[1] = 0
     for p in pairs
-        if any(ismissing.(p.first))
+        if any(ismissing, p.first)
             indexmap[1] = get(dest.pool, p.second)
             break
         end
@@ -268,9 +271,12 @@ or [`in`](@ref) the key (first item of the pair), then the corresponding value
 (second item) is used.
 If the element matches no key and `default` is not provided or `nothing`, it is copied as-is;
 if `default` is specified, it is used in place of the original element.
-If `a` is CategoricalArray and `default` is provided then the ordering of resulting levels
-is determined by the order of passed `pairs` and `default` will be the last level.
 If an element matches more than one key, the first match is used.
+
+    recode(a::CategoricalArray[, default::Any], pairs::Pair...)
+
+If `a` is a `CategoricalArray` then the ordering of resulting levels is determined
+by the order of passed `pairs` and `default` will be the last level if provided.
 
 # Examples
 ```jldoctest

--- a/test/16_recode.jl
+++ b/test/16_recode.jl
@@ -14,6 +14,7 @@ const ≅ = isequal
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10)),
     y in (similar(x), Array{Int}(size(x)),
           CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)), x)
+
     z = @inferred recode!(y, x, 1=>100, 2:4=>0, [5; 9:10]=>-1)
     @test y === z
     @test y == [100, 0, 0, 0, -1, 6, 7, 8, -1, -1]
@@ -27,6 +28,7 @@ end
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10)),
     y in (similar(x), Array{Int}(size(x)),
           CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)), x)
+
     z = @inferred recode!(y, x, 1=>100, 2:4=>100, [5; 9:10]=>-1)
     @test y === z
     @test y == [100, 100, 100, 100, -1, 6, 7, 8, -1, -1]
@@ -40,6 +42,7 @@ end
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10)),
     y in (similar(x), Array{Int}(size(x)),
           CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)), x)
+
     z = @inferred recode!(y, x, 1=>100, 2:4=>0, [5; 9:10]=>-1, 100=>1)
     @test y === z
     @test y == [100, 0, 0, 0, -1, 6, 7, 8, -1, -1]
@@ -53,6 +56,7 @@ end
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10)),
     y in (similar(x), Array{Int}(size(x)),
           CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)), x)
+
     z = @inferred recode!(y, x, 100, 1=>100, 2:4=>100, [5; 9:10]=>-1)
     @test y === z
     @test y == [100, 100, 100, 100, -1, 100, 100, 100, -1, -1]
@@ -66,6 +70,7 @@ end
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10)),
     y in (similar(x), Array{Int}(size(x)),
           CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)), x)
+
     z = @inferred recode!(y, x, -10, 1=>100, 2:4=>0, [5; 9:10]=>-1)
     @test y === z
     @test y == [100, 0, 0, 0, -1, -10, -10, -10, -1, -1]
@@ -79,6 +84,7 @@ end
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10)),
     y in (similar(x), Array{Int}(size(x)),
           CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)), x)
+
     z = @inferred recode!(y, x, 1.0=>100, 2:4=>0, [5; 9:10]=>-1)
     @test y == [100, 0, 0, 0, -1, 6, 7, 8, -1, -1]
     if isa(y, CategoricalArray)
@@ -91,6 +97,7 @@ end
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10)),
     y in (similar(x), Array{Int}(size(x)),
           CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)), x)
+
     z = @inferred recode!(y, x, 1=>100, 2:4=>0, [5; 9:10]=>-1, 1:10=>0)
     @test y === z
     @test y == [100, 0, 0, 0, -1, 0, 0, 0, -1, -1]
@@ -104,6 +111,7 @@ end
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10)),
     y in (similar(x), Array{Int}(size(x)),
           CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)), x)
+
     z = @inferred recode!(y, x, 1=>100, 2:4=>0, [5; 9:10]=>-1)
     @test y === z
     @test y == [100, 0, 0, 0, -1, 6, 7, 8, -1, -1]
@@ -115,6 +123,7 @@ end
 
 @testset "Recoding from $(typeof(x)) to categorical array with missing values" for
     x in (["a", missing, "c", "d"], CategoricalArray(["a", missing, "c", "d"]))
+
     # check that error is thrown
     y = Vector{String}(4)
     @test_throws MissingException recode!(y, x, "a", "c"=>"b")
@@ -127,6 +136,7 @@ end
     x in (["a", missing, "c", "d"], CategoricalArray(["a", missing, "c", "d"])),
     y in (similar(x), Array{Union{String, Missing}}(size(x)),
           CategoricalArray{Union{String, Missing}}(size(x)), x)
+
     z = @inferred recode!(y, x, "a", "c"=>"b")
     @test y === z
     @test y ≅ ["a", missing, "b", "a"]
@@ -140,6 +150,7 @@ end
     x in (["a", missing, "c", "d"], CategoricalArray(["a", missing, "c", "d"])),
     y in (similar(x), Array{Union{String, Missing}}(size(x)),
           CategoricalArray{Union{String, Missing}}(size(x)), x)
+
     z = @inferred recode!(y, x, "c"=>"b")
     @test y === z
     @test y ≅ ["a", missing, "b", "d"]
@@ -153,6 +164,7 @@ end
     x in (["1", missing, "3", "4", "5"], CategoricalArray(["1", missing, "3", "4", "5"])),
     y in (similar(x), Array{Union{String, Missing}}(size(x)),
           CategoricalArray{Union{String, Missing}}(size(x)), x)
+
     z = @inferred recode!(y, x, ["3","4"]=>"2")
     @test y === z
     @test y ≅ ["1", missing, "2", "2", "5"]
@@ -166,6 +178,7 @@ end
     x in (["a", missing, "c", "d"], CategoricalArray(["a", missing, "c", "d"])),
     y in (similar(x), Array{Union{String, Missing}}(size(x)),
           CategoricalArray{Union{String, Missing}}(size(x)), x)
+
     z = @inferred recode!(y, x, "a", "c"=>"b", missing=>"d")
     @test y === z
     @test y == ["a", "d", "b", "a"]
@@ -179,6 +192,7 @@ end
     x in (["a", missing, "c", "d"], CategoricalArray(["a", missing, "c", "d"])),
     y in (similar(x), Array{Union{String, Missing}}(size(x)),
           CategoricalArray{Union{String, Missing}}(size(x)), x)
+
     z = @inferred recode!(y, x, "a", [missing, "c"]=>"b")
     @test y === z
     @test y == ["a", "b", "b", "a"]
@@ -192,6 +206,7 @@ end
     x in (["a", missing, "c", "d"], CategoricalArray(["a", missing, "c", "d"])),
     y in (similar(x), Array{Union{String, Missing}}(size(x)),
           CategoricalArray{Union{String, Missing}}(size(x)), x)
+
     z = @inferred recode!(y, x, "c"=>"b", missing=>"d")
     @test y === z
     @test y == ["a", "d", "b", "d"]
@@ -205,6 +220,7 @@ end
     x in (["a", missing, "c", "d"], CategoricalArray(["a", missing, "c", "d"])),
     y in (similar(x), Array{Union{String, Missing}}(size(x)),
           CategoricalArray{Union{String, Missing}}(size(x)), x)
+
     z = @inferred recode!(y, x, ["c", missing]=>"b")
     @test y === z
     @test y == ["a", "b", "b", "d"]
@@ -218,18 +234,21 @@ end
     x in (["a", missing, "c", "d"], CategoricalArray(["a", missing, "c", "d"])),
     y in (similar(x, 0), Array{Union{String, Missing}}(0),
           CategoricalArray{Union{String, Missing}}(0))
+
     @test_throws DimensionMismatch recode!(y, x, "c"=>"b", missing=>"d")
 end
 
 @testset "Recoding into an array with incompatible eltype from $(typeof(x)) to $(typeof(y))" for
     x in ([1:10;], CategoricalArray(1:10)),
     y in (similar(x, String), Array{String}(size(x)), CategoricalArray{String}(size(x)))
+
     @test_throws ArgumentError recode!(y, x, 1=>"a", 2:4=>"b", [5; 9:10]=>"c")
 end
 
 @testset "Recoding into an array with incompatible eltype from $(typeof(x)) to $(typeof(y))" for
     x in ((Union{Int, Missing})[1:10;], CategoricalArray{Union{Int, Missing}}(1:10)),
     y in (similar(x), Array{Union{Int, Missing}}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)))
+
     @test_throws MethodError recode!(y, x, 1=>"a", 2:4=>"b", [5; 9:10]=>"c")
 end
 
@@ -237,6 +256,7 @@ end
 
 @testset "Recoding from $(typeof(x)) to $(typeof(x)) without default" for
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10))
+
     z = @inferred recode!(x, 1=>100, 2:4=>0, [5; 9:10]=>-1)
     @test x === z
     @test x == [100, 0, 0, 0, -1, 6, 7, 8, -1, -1]
@@ -248,6 +268,7 @@ end
 
 @testset "Recoding from $(typeof(x)) to $(typeof(x)) without default" for
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10))
+
     z = @inferred recode!(x, 1, 1=>100, 2:4=>0, [5; 9:10]=>-1)
     @test x === z
     @test x == [100, 0, 0, 0, -1, 1, 1, 1, -1, -1]
@@ -372,6 +393,7 @@ end
 
 @testset "Recoding from $(typeof(x)) to $(typeof(x))" for
     x in (["a", "c", "b", "a"], CategoricalArray(["a", "c", "b", "a"]))
+
     y = @inferred recode(x, "c"=>"x", "b"=>"y", "a"=>"z")
     @test y == ["z", "x", "y", "z"]
     if isa(x, CategoricalArray)
@@ -385,6 +407,7 @@ end
 
 @testset "Recoding a matrix $(typeof(x))" for
     x in (['a' 'c'; 'b' 'a'], CategoricalArray(['a' 'c'; 'b' 'a']))
+
     y = @inferred recode(x, 'c'=>'x', 'b'=>'y', 'a'=>'z')
     @test y == ['z' 'x'; 'y' 'z']
     if isa(x, CategoricalArray)
@@ -398,6 +421,7 @@ end
 
 @testset "Recoding from $(typeof(x)) to Int/String (i.e. Any), with index and levels in different orders" for
     x in (10:-1:1, CategoricalArray(10:-1:1))
+
     y = @inferred recode(x, 0, 1=>"a", 2:4=>"c", [5; 9:10]=>"b")
     @test y == ["b", "b", 0, 0, 0, "b", "c", "c", "c", "a"]
     if isa(x, CategoricalArray)

--- a/test/16_recode.jl
+++ b/test/16_recode.jl
@@ -14,7 +14,6 @@ const ≅ = isequal
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10)),
     y in (similar(x), Array{Int}(size(x)),
           CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)), x)
-
     z = @inferred recode!(y, x, 1=>100, 2:4=>0, [5; 9:10]=>-1)
     @test y === z
     @test y == [100, 0, 0, 0, -1, 6, 7, 8, -1, -1]
@@ -28,7 +27,6 @@ end
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10)),
     y in (similar(x), Array{Int}(size(x)),
           CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)), x)
-
     z = @inferred recode!(y, x, 1=>100, 2:4=>100, [5; 9:10]=>-1)
     @test y === z
     @test y == [100, 100, 100, 100, -1, 6, 7, 8, -1, -1]
@@ -42,7 +40,6 @@ end
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10)),
     y in (similar(x), Array{Int}(size(x)),
           CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)), x)
-
     z = @inferred recode!(y, x, 1=>100, 2:4=>0, [5; 9:10]=>-1, 100=>1)
     @test y === z
     @test y == [100, 0, 0, 0, -1, 6, 7, 8, -1, -1]
@@ -56,7 +53,6 @@ end
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10)),
     y in (similar(x), Array{Int}(size(x)),
           CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)), x)
-
     z = @inferred recode!(y, x, 100, 1=>100, 2:4=>100, [5; 9:10]=>-1)
     @test y === z
     @test y == [100, 100, 100, 100, -1, 100, 100, 100, -1, -1]
@@ -70,7 +66,6 @@ end
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10)),
     y in (similar(x), Array{Int}(size(x)),
           CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)), x)
-
     z = @inferred recode!(y, x, -10, 1=>100, 2:4=>0, [5; 9:10]=>-1)
     @test y === z
     @test y == [100, 0, 0, 0, -1, -10, -10, -10, -1, -1]
@@ -84,7 +79,6 @@ end
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10)),
     y in (similar(x), Array{Int}(size(x)),
           CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)), x)
-
     z = @inferred recode!(y, x, 1.0=>100, 2:4=>0, [5; 9:10]=>-1)
     @test y == [100, 0, 0, 0, -1, 6, 7, 8, -1, -1]
     if isa(y, CategoricalArray)
@@ -97,7 +91,6 @@ end
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10)),
     y in (similar(x), Array{Int}(size(x)),
           CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)), x)
-
     z = @inferred recode!(y, x, 1=>100, 2:4=>0, [5; 9:10]=>-1, 1:10=>0)
     @test y === z
     @test y == [100, 0, 0, 0, -1, 0, 0, 0, -1, -1]
@@ -111,7 +104,6 @@ end
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10)),
     y in (similar(x), Array{Int}(size(x)),
           CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)), x)
-
     z = @inferred recode!(y, x, 1=>100, 2:4=>0, [5; 9:10]=>-1)
     @test y === z
     @test y == [100, 0, 0, 0, -1, 6, 7, 8, -1, -1]
@@ -135,7 +127,6 @@ end
     x in (["a", missing, "c", "d"], CategoricalArray(["a", missing, "c", "d"])),
     y in (similar(x), Array{Union{String, Missing}}(size(x)),
           CategoricalArray{Union{String, Missing}}(size(x)), x)
-
     z = @inferred recode!(y, x, "a", "c"=>"b")
     @test y === z
     @test y ≅ ["a", missing, "b", "a"]
@@ -149,7 +140,6 @@ end
     x in (["a", missing, "c", "d"], CategoricalArray(["a", missing, "c", "d"])),
     y in (similar(x), Array{Union{String, Missing}}(size(x)),
           CategoricalArray{Union{String, Missing}}(size(x)), x)
-
     z = @inferred recode!(y, x, "c"=>"b")
     @test y === z
     @test y ≅ ["a", missing, "b", "d"]
@@ -163,7 +153,6 @@ end
     x in (["1", missing, "3", "4", "5"], CategoricalArray(["1", missing, "3", "4", "5"])),
     y in (similar(x), Array{Union{String, Missing}}(size(x)),
           CategoricalArray{Union{String, Missing}}(size(x)), x)
-
     z = @inferred recode!(y, x, ["3","4"]=>"2")
     @test y === z
     @test y ≅ ["1", missing, "2", "2", "5"]
@@ -177,7 +166,6 @@ end
     x in (["a", missing, "c", "d"], CategoricalArray(["a", missing, "c", "d"])),
     y in (similar(x), Array{Union{String, Missing}}(size(x)),
           CategoricalArray{Union{String, Missing}}(size(x)), x)
-
     z = @inferred recode!(y, x, "a", "c"=>"b", missing=>"d")
     @test y === z
     @test y == ["a", "d", "b", "a"]
@@ -187,11 +175,10 @@ end
     end
 end
 
-@testset "Collection with missing in LHS recoding array with missings, default and with missing as a key pair from $(typeof(x)) to $(typeof(y))" for
+@testset "Collection with missing in LHS recoding array with missings, default from $(typeof(x)) to $(typeof(y))" for
     x in (["a", missing, "c", "d"], CategoricalArray(["a", missing, "c", "d"])),
     y in (similar(x), Array{Union{String, Missing}}(size(x)),
           CategoricalArray{Union{String, Missing}}(size(x)), x)
-
     z = @inferred recode!(y, x, "a", [missing, "c"]=>"b")
     @test y === z
     @test y == ["a", "b", "b", "a"]
@@ -205,7 +192,6 @@ end
     x in (["a", missing, "c", "d"], CategoricalArray(["a", missing, "c", "d"])),
     y in (similar(x), Array{Union{String, Missing}}(size(x)),
           CategoricalArray{Union{String, Missing}}(size(x)), x)
-
     z = @inferred recode!(y, x, "c"=>"b", missing=>"d")
     @test y === z
     @test y == ["a", "d", "b", "d"]
@@ -215,11 +201,10 @@ end
     end
 end
 
-@testset "Collection with missing in LHS recoding array with missings, no default and with missing as a key pair from $(typeof(x)) to $(typeof(y))" for
+@testset "Collection with missing in LHS recoding array with missings, no default from $(typeof(x)) to $(typeof(y))" for
     x in (["a", missing, "c", "d"], CategoricalArray(["a", missing, "c", "d"])),
     y in (similar(x), Array{Union{String, Missing}}(size(x)),
           CategoricalArray{Union{String, Missing}}(size(x)), x)
-
     z = @inferred recode!(y, x, ["c", missing]=>"b")
     @test y === z
     @test y == ["a", "b", "b", "d"]
@@ -233,21 +218,18 @@ end
     x in (["a", missing, "c", "d"], CategoricalArray(["a", missing, "c", "d"])),
     y in (similar(x, 0), Array{Union{String, Missing}}(0),
           CategoricalArray{Union{String, Missing}}(0))
-
     @test_throws DimensionMismatch recode!(y, x, "c"=>"b", missing=>"d")
 end
 
 @testset "Recoding into an array with incompatible eltype from $(typeof(x)) to $(typeof(y))" for
     x in ([1:10;], CategoricalArray(1:10)),
     y in (similar(x, String), Array{String}(size(x)), CategoricalArray{String}(size(x)))
-
     @test_throws ArgumentError recode!(y, x, 1=>"a", 2:4=>"b", [5; 9:10]=>"c")
 end
 
 @testset "Recoding into an array with incompatible eltype from $(typeof(x)) to $(typeof(y))" for
     x in ((Union{Int, Missing})[1:10;], CategoricalArray{Union{Int, Missing}}(1:10)),
     y in (similar(x), Array{Union{Int, Missing}}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)))
-
     @test_throws MethodError recode!(y, x, 1=>"a", 2:4=>"b", [5; 9:10]=>"c")
 end
 
@@ -255,7 +237,6 @@ end
 
 @testset "Recoding from $(typeof(x)) to $(typeof(x)) without default" for
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10))
-
     z = @inferred recode!(x, 1=>100, 2:4=>0, [5; 9:10]=>-1)
     @test x === z
     @test x == [100, 0, 0, 0, -1, 6, 7, 8, -1, -1]
@@ -267,7 +248,6 @@ end
 
 @testset "Recoding from $(typeof(x)) to $(typeof(x)) without default" for
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10))
-
     z = @inferred recode!(x, 1, 1=>100, 2:4=>0, [5; 9:10]=>-1)
     @test x === z
     @test x == [100, 0, 0, 0, -1, 1, 1, 1, -1, -1]
@@ -392,7 +372,6 @@ end
 
 @testset "Recoding from $(typeof(x)) to $(typeof(x))" for
     x in (["a", "c", "b", "a"], CategoricalArray(["a", "c", "b", "a"]))
-
     y = @inferred recode(x, "c"=>"x", "b"=>"y", "a"=>"z")
     @test y == ["z", "x", "y", "z"]
     if isa(x, CategoricalArray)
@@ -406,7 +385,6 @@ end
 
 @testset "Recoding a matrix $(typeof(x))" for
     x in (['a' 'c'; 'b' 'a'], CategoricalArray(['a' 'c'; 'b' 'a']))
-
     y = @inferred recode(x, 'c'=>'x', 'b'=>'y', 'a'=>'z')
     @test y == ['z' 'x'; 'y' 'z']
     if isa(x, CategoricalArray)
@@ -420,7 +398,6 @@ end
 
 @testset "Recoding from $(typeof(x)) to Int/String (i.e. Any), with index and levels in different orders" for
     x in (10:-1:1, CategoricalArray(10:-1:1))
-
     y = @inferred recode(x, 0, 1=>"a", 2:4=>"c", [5; 9:10]=>"b")
     @test y == ["b", "b", 0, 0, 0, "b", "c", "c", "c", "a"]
     if isa(x, CategoricalArray)

--- a/test/16_recode.jl
+++ b/test/16_recode.jl
@@ -159,7 +159,21 @@ end
     end
 end
 
-@testset "Recoding array with missings, no default and with missing as a key pair from $(typeof(x)) to $(typeof(y))" for
+@testset "Group recoding array with missings and no default from $(typeof(x)) to $(typeof(y))" for
+    x in (["1", missing, "3", "4", "5"], CategoricalArray(["1", missing, "3", "4", "5"])),
+    y in (similar(x), Array{Union{String, Missing}}(size(x)),
+          CategoricalArray{Union{String, Missing}}(size(x)), x)
+
+    z = @inferred recode!(y, x, ["3","4"]=>"2")
+    @test y === z
+    @test y ≅ ["1", missing, "2", "2", "5"]
+    if isa(y, CategoricalArray)
+        @test levels(y) == ["1", "5", "2"]
+        @test !isordered(y)
+    end
+end
+
+@testset "Recoding array with missings, default and with missing as a key pair from $(typeof(x)) to $(typeof(y))" for
     x in (["a", missing, "c", "d"], CategoricalArray(["a", missing, "c", "d"])),
     y in (similar(x), Array{Union{String, Missing}}(size(x)),
           CategoricalArray{Union{String, Missing}}(size(x)), x)
@@ -169,6 +183,20 @@ end
     @test y == ["a", "d", "b", "a"]
     if isa(y, CategoricalArray)
         @test levels(y) == ["b", "d", "a"]
+        @test !isordered(y)
+    end
+end
+
+@testset "Group recoding array with missings, default and with missing as a key pair from $(typeof(x)) to $(typeof(y))" for
+    x in (["a", missing, "c", "d"], CategoricalArray(["a", missing, "c", "d"])),
+    y in (similar(x), Array{Union{String, Missing}}(size(x)),
+          CategoricalArray{Union{String, Missing}}(size(x)), x)
+
+    z = @inferred recode!(y, x, "a", [missing, "c"]=>"b")
+    @test y === z
+    @test y == ["a", "b", "b", "a"]
+    if isa(y, CategoricalArray)
+        @test levels(y) == ["b", "a"]
         @test !isordered(y)
     end
 end
@@ -183,6 +211,20 @@ end
     @test y == ["a", "d", "b", "d"]
     if isa(y, CategoricalArray)
         @test levels(y) == ["a", "b", "d"]
+        @test !isordered(y)
+    end
+end
+
+@testset "Group recoding array with missings, no default and with missing as a key pair from $(typeof(x)) to $(typeof(y))" for
+    x in (["a", missing, "c", "d"], CategoricalArray(["a", missing, "c", "d"])),
+    y in (similar(x), Array{Union{String, Missing}}(size(x)),
+          CategoricalArray{Union{String, Missing}}(size(x)), x)
+
+    z = @inferred recode!(y, x, ["c", missing]=>"b")
+    @test y === z
+    @test y == ["a", "b", "b", "d"]
+    if isa(y, CategoricalArray)
+        @test levels(y) == ["a", "d", "b"]
         @test !isordered(y)
     end
 end

--- a/test/16_recode.jl
+++ b/test/16_recode.jl
@@ -159,7 +159,7 @@ end
     end
 end
 
-@testset "Group recoding array with missings and no default from $(typeof(x)) to $(typeof(y))" for
+@testset "Collection in LHS recoding array with missings and no default from $(typeof(x)) to $(typeof(y))" for
     x in (["1", missing, "3", "4", "5"], CategoricalArray(["1", missing, "3", "4", "5"])),
     y in (similar(x), Array{Union{String, Missing}}(size(x)),
           CategoricalArray{Union{String, Missing}}(size(x)), x)
@@ -187,7 +187,7 @@ end
     end
 end
 
-@testset "Group recoding array with missings, default and with missing as a key pair from $(typeof(x)) to $(typeof(y))" for
+@testset "Collection with missing in LHS recoding array with missings, default and with missing as a key pair from $(typeof(x)) to $(typeof(y))" for
     x in (["a", missing, "c", "d"], CategoricalArray(["a", missing, "c", "d"])),
     y in (similar(x), Array{Union{String, Missing}}(size(x)),
           CategoricalArray{Union{String, Missing}}(size(x)), x)
@@ -215,7 +215,7 @@ end
     end
 end
 
-@testset "Group recoding array with missings, no default and with missing as a key pair from $(typeof(x)) to $(typeof(y))" for
+@testset "Collection with missing in LHS recoding array with missings, no default and with missing as a key pair from $(typeof(x)) to $(typeof(y))" for
     x in (["a", missing, "c", "d"], CategoricalArray(["a", missing, "c", "d"])),
     y in (similar(x), Array{Union{String, Missing}}(size(x)),
           CategoricalArray{Union{String, Missing}}(size(x)), x)


### PR DESCRIPTION
An attempt to fix #105.
I have used `any(x ≅ y for y in p.first)` condition.

@nalimilan The tests are really mind blowing. I hope I have not mixed up anything.

I have also made a small addition to docstrings about non-obvious handling of levels ordering when using `default` in `recode` that came up during tests.