### PR TITLE
Make sure that new CategoricalArray allocates new pool and refs

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -158,15 +158,8 @@ function CategoricalArray{T, N, R}(A::CategoricalArray{S, N, Q};
                                    ordered=_isordered(A)) where {S, T, N, Q, R}
     V = unwrap_catvaluetype(T)
     res = convert(CategoricalArray{V, N, R}, A)
-    needs_copy = false
-    if res.refs === A.refs # convert() only makes a copy when necessary
-        refs = deepcopy(res.refs)
-        needs_copy = true
-    end
-    if res.pool === A.pool
-        pool = deepcopy(res.pool)
-        needs_copy = true
-    end
+    refs = res.refs === A.refs ? deepcopy(res.refs) : res.refs
+    pool = res.pool === A.pool ? deepcopy(res.pool) : res.pool
     ordered!(CategoricalArray{V, N}(refs, pool), ordered)
 end
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -154,8 +154,6 @@ CategoricalMatrix{T}(m::Int, n::Int; ordered=false) where {T} =
 
 ## Constructors from arrays
 
-# This method is needed to ensure that a copy of the refs and pool is always made
-# so that ordered!() does not affect the original array
 function CategoricalArray{T, N, R}(A::CategoricalArray{S, N, Q};
                                    ordered=_isordered(A)) where {S, T, N, Q, R}
     V = unwrap_catvaluetype(T)
@@ -169,10 +167,7 @@ function CategoricalArray{T, N, R}(A::CategoricalArray{S, N, Q};
         pool = deepcopy(res.pool)
         needs_copy = true
     end
-    if needs_copy
-        res = CategoricalArray{V, N}(refs, pool)
-    end
-    ordered!(res, ordered)
+    ordered!(CategoricalArray{V, N}(refs, pool), ordered)
 end
 
 function CategoricalArray{T, N, R}(A::AbstractArray; ordered=_isordered(A)) where {T, N, R}

--- a/test/11_array.jl
+++ b/test/11_array.jl
@@ -638,4 +638,14 @@ end
     @test unique(x) == collect(1500:-1:1)
 end
 
+@testset "categorical() makes a copy of pool and refs" begin
+    x = categorical(1:10)
+    y = categorical(x)
+    @test !(x.refs === y.refs)
+    @test !(x.pool === y.pool)
+    y = categorical(x, ordered=true)
+    @test !(x.refs === y.refs)
+    @test !(x.pool === y.pool)
+end
+
 end

--- a/test/11_array.jl
+++ b/test/11_array.jl
@@ -638,14 +638,4 @@ end
     @test unique(x) == collect(1500:-1:1)
 end
 
-@testset "categorical() makes a copy of pool and refs" begin
-    x = categorical(1:10)
-    y = categorical(x)
-    @test !(x.refs === y.refs)
-    @test !(x.pool === y.pool)
-    y = categorical(x, ordered=true)
-    @test !(x.refs === y.refs)
-    @test !(x.pool === y.pool)
-end
-
 end

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -747,4 +747,18 @@ end
     @test vcat(z1, z2) isa CategoricalVector{Float64}
 end
 
+@testset "categorical() makes a copy of pool and refs" begin
+    xs = Any[Int8[1:10;], [Int8[1:10;]; missing]]
+    for x in xs, o1 in [true, false], o2 in [true, false], T in [Int64, Int8]
+        y = categorical(x, ordered=o1)
+        if x === xs[1]
+            z = CategoricalArray{T}(y, ordered=o2)
+        else
+            z = CategoricalArray{Union{T, Missing}}(y, ordered=o2)
+        end
+        @test z.refs !== y.refs
+        @test z.pool !== y.pool
+    end
+end
+
 end

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -579,7 +579,7 @@ end
         @test y.refs == x.refs
         @test index(y.pool) == index(x.pool)
         @test levels(y) == levels(x)
-        @test (y.refs === x.refs) == (eltype(x.refs) === eltype(y.refs))
+        @test y.refs !== x.refs
         @test y.pool !== x.pool
     end
     for y in (categorical(x),
@@ -591,7 +591,7 @@ end
         @test y.refs == x.refs
         @test index(y.pool) == index(x.pool)
         @test levels(y) == levels(x)
-        @test (y.refs === x.refs) == (eltype(x.refs) === eltype(y.refs))
+        @test y.refs !== x.refs
         @test y.pool !== x.pool
     end
     for y in (CategoricalArray(x, ordered=ordered),
@@ -611,7 +611,7 @@ end
         @test y.refs == x.refs
         @test index(y.pool) == index(x.pool)
         @test levels(y) == levels(x)
-        @test (y.refs === x.refs) == (eltype(x.refs) === eltype(y.refs))
+        @test y.refs !== x.refs
         @test y.pool !== x.pool
     end
     for y in (categorical(x, ordered=ordered),
@@ -623,7 +623,7 @@ end
         @test y.refs == x.refs
         @test index(y.pool) == index(x.pool)
         @test levels(y) == levels(x)
-        @test (y.refs === x.refs) == (eltype(x.refs) === eltype(y.refs))
+        @test y.refs !== x.refs
         @test y.pool !== x.pool
     end
     for y in (convert(CategoricalArray, x),


### PR DESCRIPTION
Following Issue #107.
I test for new `refs` and new `pool` separately as I guess it is safest.