### PR TITLE
Adhere to Base.copy!(x, i, y, j, n) behaviour for n <= 0

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -398,12 +398,12 @@ CatArrOrSub{T, N} = Union{CategoricalArray{T, N},
 
 function copy!(dest::CatArrOrSub{T, N}, dstart::Integer,
                src::CatArrOrSub{<:Any, N}, sstart::Integer,
-               n::Integer=length(src)-sstart+1) where {T, N}
+               n::Integer) where {T, N}
     n == 0 && return dest
+    n < 0 && throw(ArgumentError(string("tried to copy n=", n, " elements, but n should be nonnegative")))
     destinds, srcinds = linearindices(dest), linearindices(src)
     (dstart ∈ destinds && dstart+n-1 ∈ destinds) || throw(BoundsError(dest, dstart:dstart+n-1))
     (sstart ∈ srcinds  && sstart+n-1 ∈ srcinds)  || throw(BoundsError(src,  sstart:sstart+n-1))
-    n < 0 && throw(ArgumentError(string("tried to copy n=", n, " elements, but n should be nonnegative")))
 
     drefs = refs(dest)
     srefs = refs(src)

--- a/src/array.jl
+++ b/src/array.jl
@@ -399,10 +399,10 @@ CatArrOrSub{T, N} = Union{CategoricalArray{T, N},
 function copy!(dest::CatArrOrSub{T, N}, dstart::Integer,
                src::CatArrOrSub{<:Any, N}, sstart::Integer,
                n::Integer=length(src)-sstart+1) where {T, N}
+    n == 0 && return dest
     destinds, srcinds = linearindices(dest), linearindices(src)
     (dstart ∈ destinds && dstart+n-1 ∈ destinds) || throw(BoundsError(dest, dstart:dstart+n-1))
     (sstart ∈ srcinds  && sstart+n-1 ∈ srcinds)  || throw(BoundsError(src,  sstart:sstart+n-1))
-    n == 0 && return dest
     n < 0 && throw(ArgumentError(string("tried to copy n=", n, " elements, but n should be nonnegative")))
 
     drefs = refs(dest)

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -168,6 +168,37 @@ end
         @test levels(x) == ["Young", "Middle", "Old", "X", "Y", "Z"]
         @test !isordered(x)
 
+        @testset "0-length copy! does nothing (including bounds checks)" begin
+            u = x[1:0]
+            v = y[1:0]
+
+            @test copy!(x, 1, y, 3, 0) === x
+            @test x ≅ a
+            @test copy!(x, 1, y, 5, 0) === x
+            @test x ≅ a
+
+            @test copy!(u, -5, v, 2, 0) === u
+            @test u ≅ v
+            @test copy!(x, -5, v, 2, 0) === x
+            @test x ≅ a
+            @test copy!(u, v) === u
+            @test u ≅ v
+            @test copy!(x, v) === x
+            @test x ≅ a
+        end
+
+        @testset "nonzero-length copy! into/from empty array throws bounds error" begin
+            u = x[1:0]
+            v = y[1:0]
+
+            @test_throws BoundsError copy!(u, x)
+            @test u ≅ v
+            @test_throws BoundsError copy!(u, 1, v, 1, 1)
+            @test u ≅ v
+            @test_throws BoundsError copy!(x, 1, v, 1, 1)
+            @test x ≅ a
+        end
+
         @testset "no corruption happens in case of bounds error" begin
             @test_throws BoundsError copy!(x, 10, y, 2)
             @test x ≅ a


### PR DESCRIPTION
This is consistent with Base `copy!(x, i, y, j, 0)`: no checks for `i` or `j` are done.
IRL it's observed during `join(df1, df2, kind=:inner)` when the result contains no rows.