### PR TITLE
collect should produce Array

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -1,6 +1,6 @@
 ## Code for CategoricalArray
 
-import Base: convert, copy, copy!, getindex, setindex!, similar, size,
+import Base: convert, collect, copy, copy!, getindex, setindex!, similar, size,
              unique, vcat, in, summary
 
 # Used for keyword argument default value
@@ -728,6 +728,10 @@ function in(x::CategoricalValue, y::CategoricalArray{T, N, R}) where {T, N, R}
         return ref != 0 ? ref in y.refs : false
     end
 end
+
+collect(x::CategoricalArray{T}) where {T} = convert(Array{T}, x)
+collect(x::Array{CategoricalValue{T,R}}) where {T,R} = convert(Array{T}, x)
+collect(x::AbstractArray{Union{Missing,CategoricalValue{T,R}}}) where {T,R} = convert(Array{Union{Missing,T}}, x)
 
 # Override AbstractArray method to avoid printing useless type parameters
 summary(A::CategoricalArray{T, N, R}) where {T, N, R} =

--- a/src/array.jl
+++ b/src/array.jl
@@ -730,8 +730,6 @@ function in(x::CategoricalValue, y::CategoricalArray{T, N, R}) where {T, N, R}
 end
 
 collect(x::CategoricalArray{T}) where {T} = convert(Array{T}, x)
-collect(x::Array{CategoricalValue{T,R}}) where {T,R} = convert(Array{T}, x)
-collect(x::AbstractArray{Union{Missing,CategoricalValue{T,R}}}) where {T,R} = convert(Array{Union{Missing,T}}, x)
 
 # Override AbstractArray method to avoid printing useless type parameters
 summary(A::CategoricalArray{T, N, R}) where {T, N, R} =

--- a/src/array.jl
+++ b/src/array.jl
@@ -1,6 +1,6 @@
 ## Code for CategoricalArray
 
-import Base: convert, collect, copy, copy!, getindex, setindex!, similar, size,
+import Base: Array, convert, collect, copy, copy!, getindex, setindex!, similar, size,
              unique, vcat, in, summary
 
 # Used for keyword argument default value

--- a/src/array.jl
+++ b/src/array.jl
@@ -729,6 +729,7 @@ function in(x::CategoricalValue, y::CategoricalArray{T, N, R}) where {T, N, R}
     end
 end
 
+Array(x::CategoricalArray{T}) where {T} = convert(Array{T}, x)
 collect(x::CategoricalArray{T}) where {T} = convert(Array{T}, x)
 
 # Override AbstractArray method to avoid printing useless type parameters

--- a/src/array.jl
+++ b/src/array.jl
@@ -729,8 +729,8 @@ function in(x::CategoricalValue, y::CategoricalArray{T, N, R}) where {T, N, R}
     end
 end
 
-Array(x::CategoricalArray{T}) where {T} = convert(Array{T}, x)
-collect(x::CategoricalArray{T}) where {T} = convert(Array{T}, x)
+Array(A::CategoricalArray{T}) where {T} = Array{T}(A)
+collect(A::CategoricalArray{T}) where {T} = Array{T}(A)
 
 # Override AbstractArray method to avoid printing useless type parameters
 summary(A::CategoricalArray{T, N, R}) where {T, N, R} =

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -807,4 +807,18 @@ end
     @test z ≅ x
 end
 
+@testset "Array(::CategoricalArray{T}) produces Array{T}" begin
+    x = [1,1,2,2]
+    y = categorical(x)
+    z = Array(y)
+    @test typeof(x) == typeof(z)
+    @test z == x
+
+    x = [1,1,2,missing]
+    y = categorical(x)
+    z = Array(y)
+    @test typeof(x) == typeof(z)
+    @test z ≅ x
+end
+
 end

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -807,18 +807,4 @@ end
     @test z ≅ x
 end
 
-@testset "collect of CategoricalValue produces Array" begin
-    x = [1,1,2,2]
-    y = categorical(x)
-    z = collect(CategoricalValue{Int, UInt32}[v for v in y])
-    @test typeof(x) == typeof(z)
-    @test x == z
-
-    x = [1,1,2,missing]
-    y = categorical(x)
-    z = collect(Union{Missing,CategoricalValue{Int, UInt32}}[v for v in y])
-    @test typeof(x) == typeof(z)
-    @test x ≅ z
-end
-
 end

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -793,4 +793,32 @@ end
     end
 end
 
+@testset "collect of CategoricalArray produces Array" begin
+    x = [1,1,2,2]
+    y = categorical(x)
+    z = collect(y)
+    @test typeof(x) == typeof(z)
+    @test z == x
+
+    x = [1,1,2,missing]
+    y = categorical(x)
+    z = collect(y)
+    @test typeof(x) == typeof(z)
+    @test z ≅ x
+end
+
+@testset "collect of CategoricalValue produces Array" begin
+    x = [1,1,2,2]
+    y = categorical(x)
+    z = collect(CategoricalValue{Int, UInt32}[v for v in y])
+    @test typeof(x) == typeof(z)
+    @test x == z
+
+    x = [1,1,2,missing]
+    y = categorical(x)
+    z = collect(Union{Missing,CategoricalValue{Int, UInt32}}[v for v in y])
+    @test typeof(x) == typeof(z)
+    @test x ≅ z
+end
+
 end


### PR DESCRIPTION
For arrays of `CategoricalValue` we could also do something along the lines of `collect(x::AbstractArray{CategoricalValue}) = CategoricalArray(x)` but I think that `collect` should return an `Array` rather than a `CategoricalArray`.