### PR TITLE
Explicit ordered levels

### DIFF
--- a/src/CategoricalArrays.jl
+++ b/src/CategoricalArrays.jl
@@ -6,7 +6,7 @@ module CategoricalArrays
     export AbstractMissingCategoricalArray, AbstractMissingCategoricalVector,
            AbstractMissingCategoricalMatrix,
            MissingCategoricalArray, MissingCategoricalVector, MissingCategoricalMatrix
-    export LevelsException
+    export LevelsException, OrderedLevelsException
 
     export categorical, compress, decompress, droplevels!, levels, levels!, isordered, ordered!
     export cut, recode, recode!

--- a/src/array.jl
+++ b/src/array.jl
@@ -656,7 +656,12 @@ end
 
 function Base.push!(A::CategoricalVector, item)
     resize!(A.refs, length(A.refs) + 1)
-    A[end] = item
+    try
+        A[end] = item
+    catch x
+        resize!(A.refs, length(A.refs) - 1)
+        rethrow(x)
+    end
     return A
 end
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -655,14 +655,9 @@ function Base.resize!(A::CategoricalVector, n::Integer)
 end
 
 function Base.push!(A::CategoricalVector, item)
-    resize!(A.refs, length(A.refs) + 1)
-    try
-        A[end] = item
-    catch x
-        resize!(A.refs, length(A.refs) - 1)
-        rethrow(x)
-    end
-    return A
+    r = get!(A.pool, item)
+    push!(A.refs, r)
+    A
 end
 
 function Base.append!(A::CategoricalVector, B::CategoricalArray)

--- a/src/missingarray.jl
+++ b/src/missingarray.jl
@@ -1,4 +1,4 @@
-import Base: getindex, setindex!, similar, in, collect
+import Base: getindex, setindex!, push!, similar, in, collect
 
 @inline function getindex(A::CategoricalArray{T}, I...) where {T>:Missing}
     @boundscheck checkbounds(A, I...)
@@ -20,6 +20,11 @@ end
 @inline function setindex!(A::CategoricalArray{>:Missing}, v::Missing, I::Real...)
     @boundscheck checkbounds(A, I...)
     @inbounds A.refs[I...] = 0
+end
+
+@inline function push!(A::CategoricalVector{>:Missing}, v::Missing)
+    push!(A.refs, 0)
+    A
 end
 
 Base.fill!(A::CategoricalArray{>:Missing}, ::Missing) = (fill!(A.refs, 0); A)

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -92,7 +92,7 @@ Base.get(pool::CategoricalPool, level::Any, default::Any) = get(pool.invindex, l
 add the returned value to pool.invindex, this function doesn't do this itself to
 avoid doing a dict lookup twice
 """
-@inline function push_get!(pool::CategoricalPool{T, R}, level) where {T, R}
+@inline function push_level!(pool::CategoricalPool{T, R}, level) where {T, R}
     x = convert(T, level)
     n = length(pool)
     if n >= typemax(R)
@@ -113,13 +113,13 @@ end
             throw(OrderedLevelsException(level, pool.levels))
         end
 
-        push_get!(pool, level)
+        push_level!(pool, level)
     end
 end
 
 @inline function Base.push!(pool::CategoricalPool, level)
     get!(pool.invindex, level) do
-        push_get!(pool, level)
+        push_level!(pool, level)
     end
     return pool
 end

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -209,5 +209,5 @@ end
 
 # OrderedLevelsException
 function Base.showerror(io::IO, err::OrderedLevelsException)
-    print(io, "cannot add new level $(err.level) since ordered pools cannot be extended implicitly. Use the levels! function to set new levels, or the ordered! function to mark the pool as unordered.")
+    print(io, "cannot add new level $(err.newlevel) since ordered pools cannot be extended implicitly. Use the levels! function to set new levels, or the ordered! function to mark the pool as unordered.")
 end

--- a/src/typedefs.jl
+++ b/src/typedefs.jl
@@ -42,6 +42,11 @@ struct LevelsException{T, R} <: Exception
     levels::Vector{T}
 end
 
+struct OrderedLevelsException{T} <: Exception
+    newlevel::Any
+    levels::Vector{T}
+end
+
 ## Values
 
 """

--- a/src/typedefs.jl
+++ b/src/typedefs.jl
@@ -42,8 +42,8 @@ struct LevelsException{T, R} <: Exception
     levels::Vector{T}
 end
 
-struct OrderedLevelsException{T} <: Exception
-    newlevel::Any
+struct OrderedLevelsException{T, S} <: Exception
+    newlevel::S
     levels::Vector{T}
 end
 

--- a/test/07_levels.jl
+++ b/test/07_levels.jl
@@ -224,4 +224,19 @@ end
     @test levels(pool) == vcat(lev, "az")
 end
 
+@testset "new levels can't be added through assignment when levels are ordered" begin
+    x = categorical([1,2,3])
+    ordered!(x, true)
+    lev = copy(levels(x))
+    res = @test_throws OrderedLevelsException{Int} x[1] = 4
+    @test res.value.newlevel == 4
+    @test sprint(showerror, res.value) == "cannot add new level 4 since ordered pools cannot be extended implicitly. Use the levels! function to set new levels, or the ordered! function to mark the pool as unordered."
+    @test lev == levels(x)
+
+    # Assignment works after adding the level to the pool
+    levels!(x, [3,4,1,2])
+    x[1] = 4
+    @test x == [4,2,3]
+end
+
 end

--- a/test/07_levels.jl
+++ b/test/07_levels.jl
@@ -224,19 +224,4 @@ end
     @test levels(pool) == vcat(lev, "az")
 end
 
-@testset "new levels can't be added through assignment when levels are ordered" begin
-    x = categorical([1,2,3])
-    ordered!(x, true)
-    lev = copy(levels(x))
-    res = @test_throws OrderedLevelsException{Int, Float64} x[1] = 4.0
-    @test res.value.newlevel == 4
-    @test sprint(showerror, res.value) == "cannot add new level 4.0 since ordered pools cannot be extended implicitly. Use the levels! function to set new levels, or the ordered! function to mark the pool as unordered."
-    @test lev == levels(x)
-
-    # Assignment works after adding the level to the pool
-    levels!(x, [3,4,1,2])
-    x[1] = 4
-    @test x == [4,2,3]
-end
-
 end

--- a/test/07_levels.jl
+++ b/test/07_levels.jl
@@ -228,9 +228,9 @@ end
     x = categorical([1,2,3])
     ordered!(x, true)
     lev = copy(levels(x))
-    res = @test_throws OrderedLevelsException{Int} x[1] = 4
+    res = @test_throws OrderedLevelsException{Int, Float64} x[1] = 4.0
     @test res.value.newlevel == 4
-    @test sprint(showerror, res.value) == "cannot add new level 4 since ordered pools cannot be extended implicitly. Use the levels! function to set new levels, or the ordered! function to mark the pool as unordered."
+    @test sprint(showerror, res.value) == "cannot add new level 4.0 since ordered pools cannot be extended implicitly. Use the levels! function to set new levels, or the ordered! function to mark the pool as unordered."
     @test lev == levels(x)
 
     # Assignment works after adding the level to the pool

--- a/test/11_array.jl
+++ b/test/11_array.jl
@@ -200,6 +200,8 @@ using CategoricalArrays: DefaultRefType, catvaluetype, leveltype
     @test x[1] == x[end]
     @test levels(x) == ["e", "a", "b", "c", "zz"]
 
+    @test_throws MethodError push!(x, 1)
+
     append!(x, x)
     @test length(x) == 12
     @test x == ["c", "b", "b", "a", "zz", "c", "c", "b", "b", "a", "zz", "c"]

--- a/test/11_array.jl
+++ b/test/11_array.jl
@@ -358,7 +358,7 @@ using CategoricalArrays: DefaultRefType, catvaluetype, leveltype
         @test levels(x) == unique(a)
 
         if ordered
-            @test_throws ArgumentError x[1:2] = -1
+            @test_throws OrderedLevelsException x[1:2] = -1
             levels!(x, [levels(x); -1])
         end
         x[1:2] = -1
@@ -369,7 +369,7 @@ using CategoricalArrays: DefaultRefType, catvaluetype, leveltype
         @test levels(x) == vcat(unique(a), -1)
 
         if ordered
-            @test_throws ArgumentError push!(x, 2.0)
+            @test_throws OrderedLevelsException push!(x, 2.0)
             levels!(x, [levels(x); 2.0])
         end
         push!(x, 2.0)
@@ -532,7 +532,7 @@ using CategoricalArrays: DefaultRefType, catvaluetype, leveltype
         @test_throws BoundsError x[4, :]
 
         if ordered
-            @test_throws ArgumentError x[1] = "z"
+            @test_throws OrderedLevelsException x[1] = "z"
             levels!(x, [levels(x); "z"])
         end
         x[1] = "z"
@@ -605,7 +605,7 @@ using CategoricalArrays: DefaultRefType, catvaluetype, leveltype
         @test levels(x2) == []
 
         if ordered
-            @test_throws ArgumentError x[1] = "c"
+            @test_throws OrderedLevelsException x[1] = "c"
             levels!(x, [levels(x); "c"])
         end
         x[1] = "c"
@@ -615,7 +615,7 @@ using CategoricalArrays: DefaultRefType, catvaluetype, leveltype
         @test levels(x) == ["c"]
 
         if ordered
-            @test_throws ArgumentError x[1] = "a"
+            @test_throws OrderedLevelsException x[1] = "a"
             levels!(x, [levels(x); "a"])
         end
         x[1] = "a"
@@ -631,7 +631,7 @@ using CategoricalArrays: DefaultRefType, catvaluetype, leveltype
         @test levels(x) == ["c", "a"]
 
         if ordered
-            @test_throws ArgumentError x[1] = "b"
+            @test_throws OrderedLevelsException x[1] = "b"
             levels!(x, [levels(x); "b"])
         end
         x[1] = "b"

--- a/test/11_array.jl
+++ b/test/11_array.jl
@@ -353,6 +353,10 @@ using CategoricalArrays: DefaultRefType, catvaluetype, leveltype
         @test x[4] === x.pool.valindex[4]
         @test levels(x) == unique(a)
 
+        if ordered
+            @test_throws ArgumentError x[1:2] = -1
+            levels!(x, [levels(x); -1])
+        end
         x[1:2] = -1
         @test x[1] === x.pool.valindex[5]
         @test x[2] === x.pool.valindex[5]
@@ -360,6 +364,10 @@ using CategoricalArrays: DefaultRefType, catvaluetype, leveltype
         @test x[4] === x.pool.valindex[4]
         @test levels(x) == vcat(unique(a), -1)
 
+        if ordered
+            @test_throws ArgumentError push!(x, 2.0)
+            levels!(x, [levels(x); 2.0])
+        end
         push!(x, 2.0)
         @test length(x) == 5
         @test x[end] == 2.0
@@ -519,6 +527,10 @@ using CategoricalArrays: DefaultRefType, catvaluetype, leveltype
         @test_throws BoundsError x[1:1, -1:1]
         @test_throws BoundsError x[4, :]
 
+        if ordered
+            @test_throws ArgumentError x[1] = "z"
+            levels!(x, [levels(x); "z"])
+        end
         x[1] = "z"
         @test x[1] === x.pool.valindex[4]
         @test x[2] === x.pool.valindex[2]
@@ -588,12 +600,20 @@ using CategoricalArrays: DefaultRefType, catvaluetype, leveltype
         @test_throws UndefRefError x2[2]
         @test levels(x2) == []
 
+        if ordered
+            @test_throws ArgumentError x[1] = "c"
+            levels!(x, [levels(x); "c"])
+        end
         x[1] = "c"
         @test x[1] === x.pool.valindex[1]
         @test !isassigned(x, 2) && isdefined(x, 2)
         @test_throws UndefRefError x[2]
         @test levels(x) == ["c"]
 
+        if ordered
+            @test_throws ArgumentError x[1] = "a"
+            levels!(x, [levels(x); "a"])
+        end
         x[1] = "a"
         @test x[1] === x.pool.valindex[2]
         @test !isassigned(x, 2) && isdefined(x, 2)
@@ -606,6 +626,10 @@ using CategoricalArrays: DefaultRefType, catvaluetype, leveltype
         @test x[2] === x.pool.valindex[1]
         @test levels(x) == ["c", "a"]
 
+        if ordered
+            @test_throws ArgumentError x[1] = "b"
+            levels!(x, [levels(x); "b"])
+        end
         x[1] = "b"
         @test x[1] === x.pool.valindex[3]
         @test x[2] === x.pool.valindex[1]

--- a/test/11_array.jl
+++ b/test/11_array.jl
@@ -200,7 +200,11 @@ using CategoricalArrays: DefaultRefType, catvaluetype, leveltype
     @test x[1] == x[end]
     @test levels(x) == ["e", "a", "b", "c", "zz"]
 
+    x2 = deepcopy(x)
     @test_throws MethodError push!(x, 1)
+    @test x == x2
+    @test x.pool.index == x2.pool.index
+    @test x.pool.invindex == x2.pool.invindex
 
     append!(x, x)
     @test length(x) == 12

--- a/test/12_missingarray.jl
+++ b/test/12_missingarray.jl
@@ -366,7 +366,7 @@ const ≅ = isequal
             @test x[3] === missing
 
             if ordered
-                @test_throws ArgumentError x[3] = "c"
+                @test_throws OrderedLevelsException x[3] = "c"
                 levels!(x, [levels(x); "c"])
             end
             x[3] = "c"
@@ -538,7 +538,7 @@ const ≅ = isequal
         @test levels(x) == unique(a)
 
         if ordered
-            @test_throws ArgumentError x[1:2] = -1
+            @test_throws OrderedLevelsException x[1:2] = -1
             levels!(x, [levels(x); -1])
         end
         x[1:2] = -1
@@ -549,7 +549,7 @@ const ≅ = isequal
         @test levels(x) == vcat(unique(a), -1)
 
         if ordered
-            @test_throws ArgumentError push!(x, 2.0)
+            @test_throws OrderedLevelsException push!(x, 2.0)
             levels!(x, [levels(x); 2.0])
         end
         push!(x, 2.0)
@@ -695,7 +695,7 @@ const ≅ = isequal
         @test isa(x[1:2,1], CategoricalVector{Union{String, Missing}, R})
 
         if ordered
-            @test_throws ArgumentError x[1] = "z"
+            @test_throws OrderedLevelsException x[1] = "z"
             levels!(x, [levels(x); "z"])
         end
         x[1] = "z"
@@ -854,7 +854,7 @@ const ≅ = isequal
         @test_throws BoundsError x[4, :]
 
         if ordered
-            @test_throws ArgumentError x[1] = "z"
+            @test_throws OrderedLevelsException x[1] = "z"
             levels!(x, [levels(x); "z"])
         end
         x[1] = "z"
@@ -961,7 +961,7 @@ const ≅ = isequal
         @test levels(x2) == []
 
         if ordered
-            @test_throws ArgumentError x[1] = "c"
+            @test_throws OrderedLevelsException x[1] = "c"
             levels!(x, [levels(x); "c"])
         end
         x[1] = "c"
@@ -970,7 +970,7 @@ const ≅ = isequal
         @test levels(x) == ["c"]
 
         if ordered
-            @test_throws ArgumentError x[1] = "a"
+            @test_throws OrderedLevelsException x[1] = "a"
             levels!(x, [levels(x); "a"])
         end
         x[1] = "a"
@@ -984,7 +984,7 @@ const ≅ = isequal
         @test levels(x) == ["c", "a"]
 
         if ordered
-            @test_throws ArgumentError x[1] = "b"
+            @test_throws OrderedLevelsException x[1] = "b"
             levels!(x, [levels(x); "b"])
         end
         x[1] = "b"

--- a/test/12_missingarray.jl
+++ b/test/12_missingarray.jl
@@ -365,6 +365,10 @@ const ≅ = isequal
             @test x[2] === x.pool.valindex[2]
             @test x[3] === missing
 
+            if ordered
+                @test_throws ArgumentError x[3] = "c"
+                levels!(x, [levels(x); "c"])
+            end
             x[3] = "c"
             @test x[1] === x.pool.valindex[2]
             @test x[2] === x.pool.valindex[2]
@@ -533,6 +537,10 @@ const ≅ = isequal
         @test x[4] === x.pool.valindex[4]
         @test levels(x) == unique(a)
 
+        if ordered
+            @test_throws ArgumentError x[1:2] = -1
+            levels!(x, [levels(x); -1])
+        end
         x[1:2] = -1
         @test x[1] === x.pool.valindex[5]
         @test x[2] === x.pool.valindex[5]
@@ -540,6 +548,10 @@ const ≅ = isequal
         @test x[4] === x.pool.valindex[4]
         @test levels(x) == vcat(unique(a), -1)
 
+        if ordered
+            @test_throws ArgumentError push!(x, 2.0)
+            levels!(x, [levels(x); 2.0])
+        end
         push!(x, 2.0)
         @test length(x) == 5
         @test x == [-1.0, -1.0, 1.0, 1.5, 2.0]
@@ -682,6 +694,10 @@ const ≅ = isequal
         @test x[1:2,1] == ["a", "b"]
         @test isa(x[1:2,1], CategoricalVector{Union{String, Missing}, R})
 
+        if ordered
+            @test_throws ArgumentError x[1] = "z"
+            levels!(x, [levels(x); "z"])
+        end
         x[1] = "z"
         @test x[1] === x.pool.valindex[4]
         @test x[2] === x.pool.valindex[2]
@@ -837,6 +853,10 @@ const ≅ = isequal
         @test_throws BoundsError x[1:1, -1:1]
         @test_throws BoundsError x[4, :]
 
+        if ordered
+            @test_throws ArgumentError x[1] = "z"
+            levels!(x, [levels(x); "z"])
+        end
         x[1] = "z"
         @test x[1] === x.pool.valindex[4]
         @test x[2] === x.pool.valindex[2]
@@ -940,11 +960,19 @@ const ≅ = isequal
         @test isordered(x2) === isordered(x)
         @test levels(x2) == []
 
+        if ordered
+            @test_throws ArgumentError x[1] = "c"
+            levels!(x, [levels(x); "c"])
+        end
         x[1] = "c"
         @test x[1] === x.pool.valindex[1]
         @test ismissing(x[2])
         @test levels(x) == ["c"]
 
+        if ordered
+            @test_throws ArgumentError x[1] = "a"
+            levels!(x, [levels(x); "a"])
+        end
         x[1] = "a"
         @test x[1] === x.pool.valindex[2]
         @test ismissing(x[2])
@@ -955,6 +983,10 @@ const ≅ = isequal
         @test x[2] === missing
         @test levels(x) == ["c", "a"]
 
+        if ordered
+            @test_throws ArgumentError x[1] = "b"
+            levels!(x, [levels(x); "b"])
+        end
         x[1] = "b"
         @test x[1] === x.pool.valindex[3]
         @test x[2] === missing

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -821,4 +821,21 @@ end
     @test z ≅ x
 end
 
+@testset "new levels can't be added through assignment when levels are ordered" begin
+    x = categorical([1,2,3])
+    ordered!(x, true)
+    lev = copy(levels(x))
+    res = @test_throws OrderedLevelsException{Int, Float64} x[1] = 4.0
+    @test res.value.newlevel == 4
+    @test sprint(showerror, res.value) ==
+        "cannot add new level 4.0 since ordered pools cannot be extended implicitly. " *
+        "Use the levels! function to set new levels, or the ordered! function to mark the pool as unordered."
+    @test lev == levels(x)
+
+    # Assignment works after adding the level to the pool
+    levels!(x, [3,4,1,2])
+    x[1] = 4
+    @test x == [4,2,3]
+end
+
 end


### PR DESCRIPTION
When using ordered levels I would expect an error when trying to use a value that doesn't match an existing level.

About adding a single new level; I think the preferred way is to use `levels!` but it's not elegant for adding a single level they way it's currently used in the unit tests. `push!(CategoricalArray.pool(x), new_level)` could be used instead of `levels!(x, [levels(x); new_level])`. But I also think that the tests should prefer to use/test the exported API.