### PR TITLE
Remove useless in() methods

### DIFF
--- a/src/value.jl
+++ b/src/value.jl
@@ -115,8 +115,6 @@ Base.isequal(x::Any, y::CatValue) = isequal(y, x)
 Base.isequal(::CatValue, ::Missing) = false
 Base.isequal(::Missing, ::CatValue) = false
 
-Base.in(x::CatValue, y::Any) = get(x) in y
-Base.in(x::CatValue, y::Set) = get(x) in y
 Base.in(x::CatValue, y::AbstractRange{T}) where {T<:Integer} = get(x) in y
 
 Base.hash(x::CatValue, h::UInt) = hash(get(x), h)


### PR DESCRIPTION
These are not actually needed for standard collections, which rely on `isequal` or `==` and `hash`. They create ambiguities and can even be incorrect, e.g. for `ObjectIdDict`. They could even be less efficient than the default if we stored hashes and implemented optimized `hash(::CatValue, ::UInt)` methods (#61). For reference, they have been introduced in 9638d31 (#66).

Fixes #127.