### PR TITLE
Fix similar() to respect requested element type, implement float() and complex()

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -467,14 +467,26 @@ copyto!(dest::CatArrOrSub, src::CatArrOrSub) =
 copyto!(dest::CatArrOrSub, dstart::Integer, src::CatArrOrSub) =
     copyto!(dest, dstart, src, 1, length(src))
 
-similar(A::CategoricalArray{S, M, R}, ::Type{T}, dims::NTuple{N, Int}) where {T, N, S, M, R} =
+similar(A::CategoricalArray{S, M, R}, ::Type{T},
+        dims::NTuple{N, Int}) where {T, N, S, M, R} =
     Array{T, N}(undef, dims)
-similar(A::CategoricalArray{S, M, R}, ::Type{Missing}, dims::NTuple{N, Int}) where {N, S, M, R} =
+similar(A::CategoricalArray{S, M, R}, ::Type{Missing},
+        dims::NTuple{N, Int}) where {N, S, M, R} =
     Array{Missing, N}(missing, dims)
-similar(A::CategoricalArray{S, M, Q}, ::Type{T}, dims::NTuple{N, Int}) where {R, T<:Union{CatValue{R}, Missing}, N, S, M, Q} =
+similar(A::CategoricalArray{S, M, Q}, ::Type{T},
+        dims::NTuple{N, Int}) where {R, T<:CatValue{R}, N, S, M, Q} =
     CategoricalArray{T, N, R}(undef, dims)
-similar(A::CategoricalArray{S, M, R}, ::Type{T}, dims::NTuple{N, Int}) where {S, T<:Union{CatValue, Missing}, M, N, R} =
+similar(A::CategoricalArray{S, M, R}, ::Type{T},
+        dims::NTuple{N, Int}) where {S, T<:CatValue, M, N, R} =
     CategoricalArray{T, N, R}(undef, dims)
+# Union{T, Missing} is repeated even if theoretically redundant because of JuliaLang/julia#26405
+# Once that bug is fixed, Union{T, Missing} can be replaced with T and the two definitions above can be removed
+similar(A::CategoricalArray{S, M, Q}, ::Type{T},
+        dims::NTuple{N, Int}) where {R, T<:Union{CatValue{R}, Missing}, N, S, M, Q} =
+    CategoricalArray{Union{T, Missing}, N, R}(undef, dims)
+similar(A::CategoricalArray{S, M, R}, ::Type{T},
+        dims::NTuple{N, Int}) where {S, T<:Union{CatValue, Missing}, M, N, R} =
+    CategoricalArray{Union{T, Missing}, N, R}(undef, dims)
 
 """
     compress(A::CategoricalArray)

--- a/src/array.jl
+++ b/src/array.jl
@@ -1,7 +1,7 @@
 ## Code for CategoricalArray
 
 import Base: Array, convert, collect, copy, getindex, setindex!, similar, size,
-             unique, vcat, in, summary
+             unique, vcat, in, summary, float, complex
 import Compat: copyto!
 
 # Used for keyword argument default value
@@ -467,13 +467,14 @@ copyto!(dest::CatArrOrSub, src::CatArrOrSub) =
 copyto!(dest::CatArrOrSub, dstart::Integer, src::CatArrOrSub) =
     copyto!(dest, dstart, src, 1, length(src))
 
-"""
-    similar(A::CategoricalArray, element_type=eltype(A), dims=size(A))
-
-For `CategoricalArray`, preserves the ordered property of `A` (see [`isordered`](@ref)).
-"""
-similar(A::CategoricalArray{S, M, R}, ::Type{T}, dims::NTuple{N, Int}) where {S, T, M, N, R} =
-    CategoricalArray{T, N, R}(undef, dims; ordered=isordered(A))
+similar(A::CategoricalArray{S, M, R}, ::Type{T}, dims::NTuple{N, Int}) where {T, N, S, M, R} =
+    Array{T, N}(undef, dims)
+similar(A::CategoricalArray{S, M, R}, ::Type{Missing}, dims::NTuple{N, Int}) where {N, S, M, R} =
+    Array{Missing, N}(missing, dims)
+similar(A::CategoricalArray{S, M, Q}, ::Type{T}, dims::NTuple{N, Int}) where {R, T<:Union{CatValue{R}, Missing}, N, S, M, Q} =
+    CategoricalArray{T, N, R}(undef, dims)
+similar(A::CategoricalArray{S, M, R}, ::Type{T}, dims::NTuple{N, Int}) where {S, T<:Union{CatValue, Missing}, M, N, R} =
+    CategoricalArray{T, N, R}(undef, dims)
 
 """
     compress(A::CategoricalArray)
@@ -744,6 +745,19 @@ end
 
 Array(A::CategoricalArray{T}) where {T} = Array{T}(A)
 collect(A::CategoricalArray{T}) where {T} = Array{T}(A)
+
+function float(A::CategoricalArray{T}) where T
+    if !isconcretetype(T)
+        error("`float` not defined on abstractly-typed arrays; please convert to a more specific type")
+    end
+    convert(AbstractArray{typeof(float(zero(T)))}, A)
+end
+function complex(A::CategoricalArray{T}) where T
+    if !isconcretetype(T)
+        error("`complex` not defined on abstractly-typed arrays; please convert to a more specific type")
+    end
+    convert(AbstractArray{typeof(complex(zero(T)))}, A)
+end
 
 # Override AbstractArray method to avoid printing useless type parameters
 summary(A::CategoricalArray{T, N, R}) where {T, N, R} =

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -855,45 +855,50 @@ end
     @test z ≅ x
 end
 
-@testset "Array{T} and AbstractArray{T} constructors and convert" for A in (Array, AbstractArray)
+@testset "Array{T} constructors and convert" begin
     x = [1,1,2,2]
     y = categorical(x)
-    z = A{Int}(y)
+    z = Array{Int}(y)
     @test typeof(x) == typeof(z)
     @test z == x
-    z = convert(A{Int}, y)
+    z = convert(Array{Int}, y)
     @test typeof(x) == typeof(z)
     @test z == x
 
     x = [1,1,2,missing]
     y = categorical(x)
-    z = A{Union{Int, Missing}}(y)
+    z = Array{Union{Int, Missing}}(y)
     @test typeof(x) == typeof(z)
     @test z ≅ x
-    z = convert(A{Union{Int, Missing}}, y)
+    z = convert(Array{Union{Int, Missing}}, y)
     @test typeof(x) == typeof(z)
     @test z ≅ x
 end
 
-@testset "AbstractArray{T} constructors and convert are no-ops" for
-    x in (categorical([1,1,2,2]), categorical([1,1,2,missing]))
-    y = AbstractArray(x)
-    @test x === y
-    y = AbstractVector(x)
-    @test x === y
-    y = AbstractArray{eltype(x)}(x)
-    @test x === y
-    y = AbstractArray{eltype(x), 1}(x)
-    @test x === y
+@testset "convert(AbstractArray{T}, x)" begin
+    x = [1,1,2,2]
+    y = categorical(x)
+    z = convert(AbstractArray{Int}, y)
+    @test typeof(x) == typeof(z)
+    @test z == x
 
-    y = convert(AbstractArray, x)
-    @test x === y
-    y = convert(AbstractVector, x)
-    @test x === y
-    y = convert(AbstractArray{eltype(x)}, x)
-    @test x === y
-    y = convert(AbstractArray{eltype(x), 1}, x)
-    @test x === y
+    x = [1,1,2,missing]
+    y = categorical(x)
+    z = convert(AbstractArray{Union{Int, Missing}}, y)
+    @test typeof(x) == typeof(z)
+    @test z ≅ x
+
+    # Check that convert is a no-op when appropriate
+    for x in (categorical([1,1,2,2]), categorical([1,1,2,missing]))
+        y = convert(AbstractArray, x)
+        @test x === y
+        y = convert(AbstractVector, x)
+        @test x === y
+        y = convert(AbstractArray{eltype(x)}, x)
+        @test x === y
+        y = convert(AbstractArray{eltype(x), 1}, x)
+        @test x === y
+    end
 end
 
 @testset "new levels can't be added through assignment when levels are ordered" begin


### PR DESCRIPTION
`similar(::CategoricalArray, T)` used to return a `CategoricalArray{T}`, which is not a correct implementation of the `AbstractArray` interface. Change it to return `Array{T}`, except when `T <: Union{CatValue,Missing}`. This also fixes the behavior of `AbstractArray` constructors and convert methods, whose fallback definitions use `similar()`.

With these fixes, implementing `float` and `complex` is trivial, which should fix https://github.com/JuliaStats/GLM.jl/issues/218.

This also mostly fixes the behavior of `map` (https://github.com/JuliaData/CategoricalArrays.jl/issues/126), though a full set of tests should be added for that.