### PR TITLE
Fix tests with Compat 0.58.0

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.6
 Missings
 Reexport
-Compat 0.53.0
+Compat 0.58.0
 JSON

--- a/test/08_string.jl
+++ b/test/08_string.jl
@@ -160,7 +160,7 @@ using CategoricalArrays
     @test Compat.findfirst(equalto('a'), v2) === 2
     @test Compat.findnext(equalto('a'), v2, 3) === nothing
 
-    @test Compat.findlast("a", v1) === 0:-1
+    @test Compat.findlast("a", v1) === nothing
     @test Compat.findlast("a", v2) === 2:2
     @test Compat.findlast(equalto('a'), v2) === 2
     @test Compat.findprev(equalto('a'), v2, 1) === nothing


### PR DESCRIPTION
That version broke backward compatibility by retuning `nothing` rather than `0:-1` from `find*` functions when there is no match, as on recent Julia 0.7.