### PR TITLE
More Julia 0.7 fixes

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.6
 Missings
 Reexport
-Compat 0.59.0
+Compat 0.60.0
 JSON

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.6
 Missings
 Reexport
-Compat 0.58.0
+Compat 0.59.0
 JSON

--- a/src/array.jl
+++ b/src/array.jl
@@ -378,11 +378,11 @@ function mergelevels(ordered, levels...)
 
     # Check that result is ordered
     if ordered
-        levelsmaps = [indexin(res, l) for l in levels]
+        levelsmaps = [Compat.indexin(res, l) for l in levels]
 
         # Check that each original order is preserved
         for m in levelsmaps
-            issorted(m[m .!= 0]) || return res, false
+            issorted(Iterators.filter(x -> x != nothing, m)) || return res, false
         end
 
         # Check that all order relations between pairs of subsequent elements
@@ -390,7 +390,7 @@ function mergelevels(ordered, levels...)
         pairs = fill(false, length(res)-1)
         for m in levelsmaps
             @inbounds for i in eachindex(pairs)
-                pairs[i] |= (m[i] != 0) & (m[i+1] != 0)
+                pairs[i] |= (m[i] != nothing) & (m[i+1] != nothing)
             end
             all(pairs) && return res, true
         end

--- a/src/extras.jl
+++ b/src/extras.jl
@@ -26,7 +26,7 @@ function fill_refs!(refs::AbstractArray, X::AbstractArray{>: Missing},
     @inbounds for i in eachindex(X)
         ismissing(X[i]) && continue
 
-        x = unsafe_get(X[i])
+        x = X[i]
 
         if extend && x == upper
             refs[i] = n-1

--- a/src/recode.jl
+++ b/src/recode.jl
@@ -54,7 +54,7 @@ function recode!(dest::AbstractArray{T}, src::AbstractArray, default::Any, pairs
                 throw(MissingException("missing value found, but dest does not support them: " *
                                        "recode them to a supported value"))
             dest[i] = missing
-        elseif default === nothing
+        elseif default isa Nothing
             try
                 dest[i] = x
             catch err
@@ -332,15 +332,15 @@ function recode(a::AbstractArray, default::Any, pairs::Pair...)
     # T cannot take into account eltype(src), since we can't know
     # whether it matters at compile time (all levels recoded or not)
     # and using a wider type than necessary would be annoying
-    T = default === nothing ? V : promote_type(typeof(default), V)
+    T = default isa Nothing ? V : promote_type(typeof(default), V)
     # Exception 1: if T === Missing and default not missing,
     # assume the caller wants to recode only some values to missing,
     # but accept original values
-    if T === Missing && default !== missing
+    if T === Missing && !isa(default, Missing)
         dest = Array{Union{eltype(a), Missing}}(size(a))
     # Exception 2: if original array accepted missing values and missing does not appear
     # in one of the pairs' LHS, result must accept missing values
-    elseif T >: Missing || default === missing || (eltype(a) >: Missing && !keytype_hasmissing(pairs...))
+    elseif T >: Missing || default isa Missing || (eltype(a) >: Missing && !keytype_hasmissing(pairs...))
         dest = Array{Union{T, Missing}}(uninitialized, size(a))
     else
         dest = Array{Missings.T(T)}(uninitialized, size(a))
@@ -353,15 +353,15 @@ function recode(a::CategoricalArray{S, N, R}, default::Any, pairs::Pair...) wher
     # T cannot take into account eltype(src), since we can't know
     # whether it matters at compile time (all levels recoded or not)
     # and using a wider type than necessary would be annoying
-    T = default === nothing ? V : promote_type(typeof(default), V)
+    T = default isa Nothing ? V : promote_type(typeof(default), V)
     # Exception 1: if T === Missing and default not missing,
     # assume the caller wants to recode only some values to missing,
     # but accept original values
-    if T === Missing && default !== missing
+    if T === Missing && !isa(default, Missing)
         dest = CategoricalArray{Union{S, Missing}, N, R}(uninitialized, size(a))
     # Exception 2: if original array accepted missing values and missing does not appear
     # in one of the pairs' LHS, result must accept missing values
-    elseif T >: Missing || default === missing || (eltype(a) >: Missing && !keytype_hasmissing(pairs...))
+    elseif T >: Missing || default isa Missing || (eltype(a) >: Missing && !keytype_hasmissing(pairs...))
         dest = CategoricalArray{Union{T, Missing}, N, R}(uninitialized, size(a))
     else
         dest = CategoricalArray{Missings.T(T), N, R}(uninitialized, size(a))

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -332,7 +332,7 @@ end
             vdest = view(dest, 1:2)
             res = @test_throws ArgumentError copy!(vdest, src)
             @test res.value.msg == "cannot set ordered=false on dest SubArray as it would affect the parent. " *
-                "Found when trying to set levels to String[\"e\", \"f\", \"g\", \"b\", \"a\"]."
+                "Found when trying to set levels to $(["e", "f", "g", "b", "a"])."
             @test dest[1:2] ==  ["e", "f"]
             @test levels(dest) == levels(vdest) == ["e", "f", "g"]
             @test isordered(dest) && isordered(vdest)
@@ -341,7 +341,7 @@ end
             vdest = view(dest, 1:2)
             res = @test_throws ArgumentError copy!(vdest, src)
             @test res.value.msg == "cannot set ordered=false on dest SubArray as it would affect the parent. " *
-                "Found when trying to set levels to String[\"e\", \"f\", \"b\", \"a\"]."
+                "Found when trying to set levels to $(["e", "f", "b", "a"])."
             @test dest == ["e", "f"]
             @test levels(dest) == levels(vdest) == ["e", "f"]
             @test isordered(dest) && isordered(vdest)
@@ -750,11 +750,9 @@ end
 
 @testset "summary()" begin
     @test summary(CategoricalArray([1, 2, 3])) ==
-        "3-element CategoricalArrays.CategoricalArray{$Int,1,UInt32}"
-    # Ordering changed in Julia 0.7
-    @test summary(CategoricalArray{Union{Int, Missing}}([1 2 3])) in
-        ("1×3 CategoricalArrays.CategoricalArray{Union{Missings.Missing, $Int},2,UInt32}",
-         "1×3 CategoricalArrays.CategoricalArray{Union{$Int, Missings.Missing},2,UInt32}")
+        "3-element $CategoricalArray{$Int,1,UInt32}"
+    @test summary(CategoricalArray{Union{Int, Missing}}([1 2 3])) ==
+        "1×3 $CategoricalArray{$(Union{Missing, Int}),2,UInt32}"
 end
 
 @testset "vcat() takes into account element type even when array is empty" begin


### PR DESCRIPTION
Use `isa` instead of `===` to work an inference regression (JuliaLang/julia#26417).

This should pass the tests on 0.7 once https://github.com/JuliaLang/Compat.jl/pull/515 is merged and tagged. Some deprecation warnings remain, though (in particular about `uninitialized`).