### PR TITLE
Fix more 0.7 deprecations

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.6
 Missings
 Reexport
-Compat 0.60.0
+Compat 0.61.0
 JSON

--- a/test/02_buildorder.jl
+++ b/test/02_buildorder.jl
@@ -18,7 +18,7 @@ using CategoricalArrays: DefaultRefType
         )
     )
 
-    order = Vector{DefaultRefType}(uninitialized, length(pool.index))
+    order = Vector{DefaultRefType}(undef, length(pool.index))
 
     CategoricalArrays.buildorder!(order, pool.invindex, ["b", "a", "c"])
 

--- a/test/08_string.jl
+++ b/test/08_string.jl
@@ -157,13 +157,13 @@ using CategoricalArrays
 
     @test Compat.findfirst("", v1) === 1:0
     @test Compat.findfirst("a", v2) === 2:2
-    @test Compat.findfirst(equalto('a'), v2) === 2
-    @test Compat.findnext(equalto('a'), v2, 3) === nothing
+    @test Compat.findfirst(==('a'), v2) === 2
+    @test Compat.findnext(==('a'), v2, 3) === nothing
 
     @test Compat.findlast("a", v1) === nothing
     @test Compat.findlast("a", v2) === 2:2
-    @test Compat.findlast(equalto('a'), v2) === 2
-    @test Compat.findprev(equalto('a'), v2, 1) === nothing
+    @test Compat.findlast(==('a'), v2) === 2
+    @test Compat.findprev(==('a'), v2, 1) === nothing
 
     @test !contains(v1, "a")
     @test contains(v1, "")
@@ -216,11 +216,11 @@ using CategoricalArrays
     @test titlecase(v1) == ""
     @test titlecase(v2) == "Café"
 
-    @test ucfirst(v1) == ""
-    @test ucfirst(v2) == "Café"
+    @test uppercasefirst(v1) == ""
+    @test uppercasefirst(v2) == "Café"
 
-    @test lcfirst(v1) == ""
-    @test lcfirst(v2) == "café"
+    @test lowercasefirst(v1) == ""
+    @test lowercasefirst(v2) == "café"
 
     @test join([v1, "a"]) == "a"
     @test join([v1, "a"], v2) == "caféa"

--- a/test/11_array.jl
+++ b/test/11_array.jl
@@ -573,20 +573,20 @@ using CategoricalArrays: DefaultRefType, catvaluetype, leveltype
     end
 
     # Uninitialized array
-    v = Any[CategoricalArray(2, ordered=ordered),
-            CategoricalArray{String}(2, ordered=ordered),
-            CategoricalArray{String, 1}(2, ordered=ordered),
-            CategoricalArray{String, 1, R}(2, ordered=ordered),
-            CategoricalVector(2, ordered=ordered),
-            CategoricalVector{String}(2, ordered=ordered),
-            CategoricalVector{String, R}(2, ordered=ordered),
-            CategoricalArray(2, 3, ordered=ordered),
-            CategoricalArray{String}(2, 3, ordered=ordered),
-            CategoricalArray{String, 2}(2, 3, ordered=ordered),
-            CategoricalArray{String, 2, R}(2, 3, ordered=ordered),
-            CategoricalMatrix(2, 3, ordered=ordered),
-            CategoricalMatrix{String}(2, 3, ordered=ordered),
-            CategoricalMatrix{String, R}(2, 3, ordered=ordered)]
+    v = Any[CategoricalArray(undef, 2, ordered=ordered),
+            CategoricalArray{String}(undef, 2, ordered=ordered),
+            CategoricalArray{String, 1}(undef, 2, ordered=ordered),
+            CategoricalArray{String, 1, R}(undef, 2, ordered=ordered),
+            CategoricalVector(undef, 2, ordered=ordered),
+            CategoricalVector{String}(undef, 2, ordered=ordered),
+            CategoricalVector{String, R}(undef, 2, ordered=ordered),
+            CategoricalArray(undef, 2, 3, ordered=ordered),
+            CategoricalArray{String}(undef, 2, 3, ordered=ordered),
+            CategoricalArray{String, 2}(undef, 2, 3, ordered=ordered),
+            CategoricalArray{String, 2, R}(undef, 2, 3, ordered=ordered),
+            CategoricalMatrix(undef, 2, 3, ordered=ordered),
+            CategoricalMatrix{String}(undef, 2, 3, ordered=ordered),
+            CategoricalMatrix{String, R}(undef, 2, 3, ordered=ordered)]
 
     @testset "compress($(typeof(x))) and setindex!()" for x in v
         @test !isassigned(x, 1) && isdefined(x, 1)

--- a/test/12_missingarray.jl
+++ b/test/12_missingarray.jl
@@ -931,16 +931,16 @@ const ≅ = isequal
         end
 
         # Uninitialized array
-        v = Any[CategoricalArray{Union{String, Missing}}(2, ordered=ordered),
-                CategoricalArray{Union{String, Missing}, 1}(2, ordered=ordered),
-                CategoricalArray{Union{String, Missing}, 1, R}(2, ordered=ordered),
-                CategoricalVector{Union{String, Missing}}(2, ordered=ordered),
-                CategoricalVector{Union{String, Missing}, R}(2, ordered=ordered),
-                CategoricalArray{Union{String, Missing}}(2, 3, ordered=ordered),
-                CategoricalArray{Union{String, Missing}, 2}(2, 3, ordered=ordered),
-                CategoricalArray{Union{String, Missing}, 2, R}(2, 3, ordered=ordered),
-                CategoricalMatrix{Union{String, Missing}}(2, 3, ordered=ordered),
-                CategoricalMatrix{Union{String, Missing}, R}(2, 3, ordered=ordered)]
+        v = Any[CategoricalArray{Union{String, Missing}}(undef, 2, ordered=ordered),
+                CategoricalArray{Union{String, Missing}, 1}(undef, 2, ordered=ordered),
+                CategoricalArray{Union{String, Missing}, 1, R}(undef, 2, ordered=ordered),
+                CategoricalVector{Union{String, Missing}}(undef, 2, ordered=ordered),
+                CategoricalVector{Union{String, Missing}, R}(undef, 2, ordered=ordered),
+                CategoricalArray{Union{String, Missing}}(undef, 2, 3, ordered=ordered),
+                CategoricalArray{Union{String, Missing}, 2}(undef, 2, 3, ordered=ordered),
+                CategoricalArray{Union{String, Missing}, 2, R}(undef, 2, 3, ordered=ordered),
+                CategoricalMatrix{Union{String, Missing}}(undef, 2, 3, ordered=ordered),
+                CategoricalMatrix{Union{String, Missing}, R}(undef, 2, 3, ordered=ordered)]
 
         @testset "Uninitialized $(typeof(x))" for x in v
         @test isordered(x) === ordered

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -82,8 +82,8 @@ end
         @test levels(r) == collect(3:300)
 
         # Test vcat of multidimensional arrays
-        a1 = Array{Int}(uninitialized, 2, 3, 4, 5)
-        a2 = Array{Int}(uninitialized, 3, 3, 4, 5)
+        a1 = Array{Int}(undef, 2, 3, 4, 5)
+        a2 = Array{Int}(undef, 3, 3, 4, 5)
         a1[1:end] = (length(a1):-1:1) + 2
         a2[1:end] = (1:length(a2)) + 10
         ca1 = CategoricalArray{Union{T, Int}}(a1)

--- a/test/16_recode.jl
+++ b/test/16_recode.jl
@@ -13,7 +13,7 @@ const ≅ = isequal
 
 @testset "Recoding from $(typeof(x)) to $(typeof(y))" for
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10)),
-    y in (similar(x), Array{Int}(uninitialized, size(x)),
+    y in (similar(x), Array{Int}(undef, size(x)),
           CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)), x)
 
     z = @inferred recode!(y, x, 1=>100, 2:4=>0, [5; 9:10]=>-1)
@@ -27,7 +27,7 @@ end
 
 @testset "Recoding from $(typeof(x)) to $(typeof(y)) with duplicate recoded values" for
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10)),
-    y in (similar(x), Array{Int}(uninitialized, size(x)),
+    y in (similar(x), Array{Int}(undef, size(x)),
           CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)), x)
 
     z = @inferred recode!(y, x, 1=>100, 2:4=>100, [5; 9:10]=>-1)
@@ -41,7 +41,7 @@ end
 
 @testset "Recoding from $(typeof(x)) to $(typeof(y)) with unused level" for
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10)),
-    y in (similar(x), Array{Int}(uninitialized, size(x)),
+    y in (similar(x), Array{Int}(undef, size(x)),
           CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)), x)
 
     z = @inferred recode!(y, x, 1=>100, 2:4=>0, [5; 9:10]=>-1, 100=>1)
@@ -55,7 +55,7 @@ end
 
 @testset "Recoding from $(typeof(x)) to $(typeof(y)) with duplicate default" for
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10)),
-    y in (similar(x), Array{Int}(uninitialized, size(x)),
+    y in (similar(x), Array{Int}(undef, size(x)),
           CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)), x)
 
     z = @inferred recode!(y, x, 100, 1=>100, 2:4=>100, [5; 9:10]=>-1)
@@ -69,7 +69,7 @@ end
 
 @testset "Recoding from $(typeof(x)) to $(typeof(y)) with default" for
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10)),
-    y in (similar(x), Array{Int}(uninitialized, size(x)),
+    y in (similar(x), Array{Int}(undef, size(x)),
           CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)), x)
 
     z = @inferred recode!(y, x, -10, 1=>100, 2:4=>0, [5; 9:10]=>-1)
@@ -83,7 +83,7 @@ end
 
 @testset "Recoding from $(typeof(x)) to $(typeof(y)) with first value being Float64" for
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10)),
-    y in (similar(x), Array{Int}(uninitialized, size(x)),
+    y in (similar(x), Array{Int}(undef, size(x)),
           CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)), x)
 
     z = @inferred recode!(y, x, 1.0=>100, 2:4=>0, [5; 9:10]=>-1)
@@ -96,7 +96,7 @@ end
 
 @testset "Recoding from $(typeof(x)) to $(typeof(y)) with overlapping pairs" for
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10)),
-    y in (similar(x), Array{Int}(uninitialized, size(x)),
+    y in (similar(x), Array{Int}(undef, size(x)),
           CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)), x)
 
     z = @inferred recode!(y, x, 1=>100, 2:4=>0, [5; 9:10]=>-1, 1:10=>0)
@@ -110,7 +110,7 @@ end
 
 @testset "Recoding from $(typeof(x)) to $(typeof(y)) with changes to levels order" for
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10)),
-    y in (similar(x), Array{Int}(uninitialized, size(x)),
+    y in (similar(x), Array{Int}(undef, size(x)),
           CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)), x)
 
     z = @inferred recode!(y, x, 1=>100, 2:4=>0, [5; 9:10]=>-1)
@@ -126,7 +126,7 @@ end
     x in (["a", missing, "c", "d"], CategoricalArray(["a", missing, "c", "d"]))
 
     # check that error is thrown
-    y = Vector{String}(uninitialized, 4)
+    y = Vector{String}(undef, 4)
     @test_throws MissingException recode!(y, x, "a", "c"=>"b")
 
     y = CategoricalVector{String}(4)
@@ -241,7 +241,7 @@ end
 
 @testset "Recoding into an array with incompatible eltype from $(typeof(x)) to $(typeof(y))" for
     x in ([1:10;], CategoricalArray(1:10)),
-    y in (similar(x, String), Array{String}(uninitialized, size(x)), CategoricalArray{String}(size(x)))
+    y in (similar(x, String), Array{String}(undef, size(x)), CategoricalArray{String}(size(x)))
 
     @test_throws ArgumentError recode!(y, x, 1=>"a", 2:4=>"b", [5; 9:10]=>"c")
 end


### PR DESCRIPTION
Use curried `==` from Compat instead of `equalto`, `uppercasefirst`/`lowercasefirst` instead of `ucfirst`/`lcfirst`, and use `undef` for uninitialized constructors.