### PR TITLE
Change unique to follow the AbstractArray interface

### DIFF
--- a/test/11_array.jl
+++ b/test/11_array.jl
@@ -17,6 +17,7 @@ using CategoricalArrays: DefaultRefType, catvaluetype, leveltype
     @test catvaluetype(x) === CategoricalArrays.CategoricalString{R}
     @test isordered(x) === ordered
     @test levels(x) == sort(unique(a))
+    @test unique(x) == unique(a)
     @test size(x) === (3,)
     @test length(x) === 3
 
@@ -231,7 +232,7 @@ using CategoricalArrays: DefaultRefType, catvaluetype, leveltype
 
         @test x == collect(a)
         @test isordered(x) === ordered
-        @test levels(x) == unique(a)
+        @test levels(x) == unique(x) == unique(a)
         @test size(x) === (4,)
         @test length(x) === 4
         @test leveltype(x) === Float64
@@ -356,6 +357,7 @@ using CategoricalArrays: DefaultRefType, catvaluetype, leveltype
         @test x[3] === x.pool.valindex[3]
         @test x[4] === x.pool.valindex[4]
         @test levels(x) == unique(a)
+        @test unique(x) == unique(collect(x))
 
         if ordered
             @test_throws OrderedLevelsException x[1:2] = -1
@@ -367,6 +369,7 @@ using CategoricalArrays: DefaultRefType, catvaluetype, leveltype
         @test x[3] === x.pool.valindex[3]
         @test x[4] === x.pool.valindex[4]
         @test levels(x) == vcat(unique(a), -1)
+        @test unique(x) == unique(collect(x))
 
         if ordered
             @test_throws OrderedLevelsException push!(x, 2.0)
@@ -410,7 +413,7 @@ using CategoricalArrays: DefaultRefType, catvaluetype, leveltype
 
         @test x == a
         @test isordered(x) === ordered
-        @test levels(x) == unique(a)
+        @test levels(x) == unique(x) == unique(a)
         @test size(x) === (2, 3)
         @test length(x) === 6
 
@@ -645,13 +648,13 @@ end
     x = CategoricalArray(["Old", "Young", "Middle", "Young"])
     @test levels!(x, ["Young", "Middle", "Old"]) === x
     @test levels(x) == ["Young", "Middle", "Old"]
-    @test unique(x) == levels(x) == ["Young", "Middle", "Old"]
+    @test unique(x) == ["Old", "Young", "Middle"]
     @test levels!(x, ["Young", "Middle", "Old", "Unused"]) === x
     @test levels(x) == ["Young", "Middle", "Old", "Unused"]
-    @test unique(x) == ["Young", "Middle", "Old"]
+    @test unique(x) == ["Old", "Young", "Middle"]
     @test levels!(x, ["Unused1", "Young", "Middle", "Old", "Unused2"]) === x
     @test levels(x) == ["Unused1", "Young", "Middle", "Old", "Unused2"]
-    @test unique(x) == ["Young", "Middle", "Old"]
+    @test unique(x) == ["Old", "Young", "Middle"]
 
     x = CategoricalArray(String[])
     @test isa(levels(x), Vector{String}) && isempty(levels(x))
@@ -660,13 +663,13 @@ end
     @test levels(x) == ["Young", "Middle", "Old"]
     @test isa(unique(x), Vector{String}) && isempty(unique(x))
 
-    # To test short-circuit after 1000 elements
-    x = CategoricalArray(repeat(1:1500, inner=10))
-    @test levels(x) == collect(1:1500)
-    @test unique(x) == collect(1:1500)
-    @test levels!(x, [1600:-1:1; 2000]) === x
-    @test levels(x) == [1600:-1:1; 2000]
-    @test unique(x) == collect(1500:-1:1)
+    # To test short-circuiting
+    x = CategoricalArray(repeat(1:10, inner=10))
+    @test levels(x) == collect(1:10)
+    @test unique(x) == collect(1:10)
+    @test levels!(x, [19:-1:1; 20]) === x
+    @test levels(x) == [19:-1:1; 20]
+    @test unique(x) == collect(1:10)
 end
 
 end

--- a/test/14_view.jl
+++ b/test/14_view.jl
@@ -11,7 +11,7 @@ using CategoricalArrays
     x = CategoricalArray{Union{T, eltype(a)}}(a, ordered=order)
     v = view(x, inds)
     @test levels(v) === levels(x)
-    @test unique(v) == (ndims(v) > 0 ? sort(unique(a[inds])) : [a[inds]])
+    @test unique(v) == (ndims(v) > 0 ? unique(a[inds]) : [a[inds]])
     @test isordered(v) === isordered(x)
 end
 


### PR DESCRIPTION
Return unique values in their order of appearance, just like other arrays. The levels function should be used when one wants the levels in their custom order.

Fixes a problem spotted at https://github.com/JuliaData/CSV.jl/issues/191.