### PR TITLE
Fix droplevels! to preserve levels ordering

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -639,13 +639,23 @@ since it needs to check whether levels are used or not.
 """
 unique(A::CategoricalArray{T}) where {T} = _unique(T, A.refs, A.pool)
 
-"""
-    droplevels!(A::CategoricalArray)
+if VERSION >= v"0.7.0-DEV.4882"
+    """
+        droplevels!(A::CategoricalArray)
 
-Drop levels which do not appear in categorical array `A` (so that they will no longer be
-returned by [`levels`](@ref)).
-"""
-droplevels!(A::CategoricalArray) = levels!(A, filter!(!ismissing, unique(A)))
+    Drop levels which do not appear in categorical array `A` (so that they will no longer be
+    returned by [`levels`](@ref)).
+    """
+    droplevels!(A::CategoricalArray) = levels!(A, intersect!(levels(A), unique(A)))
+else # intersect! method missing on Julia 0.6
+    """
+        droplevels!(A::CategoricalArray)
+
+    Drop levels which do not appear in categorical array `A` (so that they will no longer be
+    returned by [`levels`](@ref)).
+    """
+    droplevels!(A::CategoricalArray) = levels!(A, intersect(levels(A), filter!(!ismissing, unique(A))))
+end
 
 """
     isordered(A::CategoricalArray)

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -931,4 +931,14 @@ end
     @test_throws ErrorException complex(categorical(Union{Int,Missing}[1]))
 end
 
+@testset "droplevels" for a in (["a", "b", "c"], ["a", "b", missing, "c"])
+    x = categorical(a)
+    levels!(x, ["b", "c", "a"])
+    @test droplevels!(x) === x
+    @test levels(x) == ["b", "c", "a"]
+    x[2] = "a"
+    @test droplevels!(x) === x
+    @test levels(x) == ["c", "a"]
+end
+
 end


### PR DESCRIPTION
The recent change to `unique!` (#139) broke this.

Fixes https://github.com/JuliaData/DataFrames.jl/issues/1396.