### PR TITLE
Julia 0.7 fixes

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.6
 Missings
 Reexport
-Compat 0.61.0
+Compat 0.67.0
 JSON

--- a/src/array.jl
+++ b/src/array.jl
@@ -677,7 +677,7 @@ function Base.resize!(A::CategoricalVector, n::Integer)
     n_orig = length(A)
     resize!(A.refs, n)
     if n > n_orig
-        A.refs[n_orig+1:end] = 0
+        A.refs[n_orig+1:end] .= 0
     end
     A
 end

--- a/src/array.jl
+++ b/src/array.jl
@@ -467,6 +467,12 @@ copyto!(dest::CatArrOrSub, src::CatArrOrSub) =
 copyto!(dest::CatArrOrSub, dstart::Integer, src::CatArrOrSub) =
     copyto!(dest, dstart, src, 1, length(src))
 
+@static if VERSION >= v"0.7.0-DEV.3208"
+    using Future
+    Future.copy!(dest::CatArrOrSub, src::CatArrOrSub) =
+        copyto!(dest, 1, src, 1, length(src))
+end
+
 similar(A::CategoricalArray{S, M, R}, ::Type{T},
         dims::NTuple{N, Int}) where {T, N, S, M, R} =
     Array{T, N}(undef, dims)

--- a/src/extras.jl
+++ b/src/extras.jl
@@ -91,8 +91,13 @@ function cut(x::AbstractArray{T, N}, breaks::AbstractVector;
 
     n = length(breaks)
     if isempty(labels)
-        from = map(x -> sprint(showcompact, x), breaks[1:n-1])
-        to = map(x -> sprint(showcompact, x), breaks[2:n])
+        @static if VERSION >= v"0.7.0-DEV.4524"
+            from = map(x -> sprint(show, x, context=:compact=>true), breaks[1:n-1])
+            to = map(x -> sprint(show, x, context=:compact=>true), breaks[2:n])
+        else
+            from = map(x -> sprint(showcompact, x), breaks[1:n-1])
+            to = map(x -> sprint(showcompact, x), breaks[2:n])
+        end
         levs = Vector{String}(undef, n-1)
         for i in 1:n-2
             levs[i] = string("[", from[i], ", ", to[i], ")")

--- a/src/recode.jl
+++ b/src/recode.jl
@@ -337,7 +337,7 @@ function recode(a::AbstractArray, default::Any, pairs::Pair...)
     # assume the caller wants to recode only some values to missing,
     # but accept original values
     if T === Missing && !isa(default, Missing)
-        dest = Array{Union{eltype(a), Missing}}(size(a))
+        dest = Array{Union{eltype(a), Missing}}(undef, size(a))
     # Exception 2: if original array accepted missing values and missing does not appear
     # in one of the pairs' LHS, result must accept missing values
     elseif T >: Missing || default isa Missing || (eltype(a) >: Missing && !keytype_hasmissing(pairs...))

--- a/src/subarray.jl
+++ b/src/subarray.jl
@@ -27,3 +27,12 @@ else
 end
 
 pool(A::SubArray{<:Any, <:Any, <:CategoricalArray}) = A.parent.pool
+
+function Base.fill!(A::SubArray{<:Any, <:Any, <:CategoricalArray}, v::Any)
+    r = get!(A.parent.pool, convert(leveltype(A.parent), v))
+    fill!(refs(A), r)
+    A
+end
+
+Base.fill!(A::SubArray{<:Any, <:Any, <:CategoricalArray{>:Missing}}, ::Missing) =
+    (fill!(refs(A), 0); A)

--- a/src/value.jl
+++ b/src/value.jl
@@ -160,14 +160,18 @@ Compat.lastindex(x::CategoricalString) = lastindex(get(x))
 Base.sizeof(x::CategoricalString) = sizeof(get(x))
 Base.nextind(x::CategoricalString, i::Int) = nextind(get(x), i)
 Base.prevind(x::CategoricalString, i::Int) = prevind(get(x), i)
-Base.next(x::CategoricalString, i::Int) = next(get(x), i)
+if VERSION > v"0.7.0-DEV.5126"
+    Base.iterate(x::CategoricalString, i::Int) = iterate(get(x), i)
+else
+    Base.next(x::CategoricalString, i::Int) = next(get(x), i)
+end
 Base.getindex(x::CategoricalString, i::Int) = getindex(get(x), i)
 Base.codeunit(x::CategoricalString, i::Integer) = codeunit(get(x), i)
 Base.ascii(x::CategoricalString) = ascii(get(x))
 Base.isvalid(x::CategoricalString) = isvalid(get(x))
 Base.isvalid(x::CategoricalString, i::Integer) = isvalid(get(x), i)
 Base.match(r::Regex, s::CategoricalString,
-           idx::Integer=start(s), add_opts::UInt32=UInt32(0)) =
+           idx::Integer=firstindex(s), add_opts::UInt32=UInt32(0)) =
     match(r, get(s), idx, add_opts)
 if VERSION > v"0.7.0-DEV.3526"
     Base.matchall(r::Regex, s::CategoricalString; overlap::Bool=false) =

--- a/test/08_string.jl
+++ b/test/08_string.jl
@@ -165,12 +165,12 @@ using CategoricalArrays
     @test Compat.findlast(==('a'), v2) === 2
     @test Compat.findprev(==('a'), v2, 1) === nothing
 
-    @test !contains(v1, "a")
-    @test contains(v1, "")
-    @test contains(v2, "fé")
+    @test !occursin("a", v1)
+    @test occursin("", v1)
+    @test occursin("fé", v2)
 
-    @test !contains(v1, r"af")
-    @test contains(v2, r"af")
+    @test !occursin(r"af", v1)
+    @test occursin(r"af", v2)
 
     @test startswith(v1, "")
     @test !startswith(v1, "a")

--- a/test/11_array.jl
+++ b/test/11_array.jl
@@ -149,7 +149,7 @@ using CategoricalArrays: DefaultRefType, catvaluetype, leveltype
     @test x[3] === x.pool.valindex[3]
     @test levels(x) == ["a", "b", "c"]
 
-    x[2:3] = "b"
+    x[2:3] .= "b"
     @test x[1] === x.pool.valindex[2]
     @test x[2] === x.pool.valindex[1]
     @test x[3] === x.pool.valindex[1]
@@ -360,10 +360,10 @@ using CategoricalArrays: DefaultRefType, catvaluetype, leveltype
         @test unique(x) == unique(collect(x))
 
         if ordered
-            @test_throws OrderedLevelsException x[1:2] = -1
+            @test_throws OrderedLevelsException x[1:2] .= -1
             levels!(x, [levels(x); -1])
         end
-        x[1:2] = -1
+        x[1:2] .= -1
         @test x[1] === x.pool.valindex[5]
         @test x[2] === x.pool.valindex[5]
         @test x[3] === x.pool.valindex[3]
@@ -547,7 +547,7 @@ using CategoricalArrays: DefaultRefType, catvaluetype, leveltype
         @test x[6] === x.pool.valindex[3]
         @test levels(x) == ["a", "b", "c", "z"]
 
-        x[1,:] = "a"
+        x[1,:] .= "a"
         @test x[1] === x.pool.valindex[1]
         @test x[2] === x.pool.valindex[2]
         @test x[3] === x.pool.valindex[1]
@@ -556,7 +556,7 @@ using CategoricalArrays: DefaultRefType, catvaluetype, leveltype
         @test x[6] === x.pool.valindex[3]
         @test levels(x) == ["a", "b", "c", "z"]
 
-        x[1,1:2] = "z"
+        x[1,1:2] .= "z"
         @test x[1] === x.pool.valindex[4]
         @test x[2] === x.pool.valindex[2]
         @test x[3] === x.pool.valindex[4]

--- a/test/12_missingarray.jl
+++ b/test/12_missingarray.jl
@@ -159,7 +159,7 @@ const ≅ = isequal
                 @test x[3] === x.pool.valindex[3]
                 @test levels(x) == ["a", "b", "c"]
 
-                x[2:3] = "b"
+                x[2:3] .= "b"
                 @test x[1] === x.pool.valindex[2]
                 @test x[2] === x.pool.valindex[1]
                 @test x[3] === x.pool.valindex[1]
@@ -383,7 +383,7 @@ const ≅ = isequal
             @test x[3] === x.pool.valindex[3]
             @test levels(x) == ["a", "b", "c"]
 
-            x[2:3] = missing
+            x[2:3] .= missing
             @test x[1] === missing
             @test x[2] === missing
             @test x[3] === missing
@@ -541,10 +541,10 @@ const ≅ = isequal
         @test unique(x) == unique(collect(x))
 
         if ordered
-            @test_throws OrderedLevelsException x[1:2] = -1
+            @test_throws OrderedLevelsException x[1:2] .= -1
             levels!(x, [levels(x); -1])
         end
-        x[1:2] = -1
+        x[1:2] .= -1
         @test x[1] === x.pool.valindex[5]
         @test x[2] === x.pool.valindex[5]
         @test x[3] === x.pool.valindex[3]
@@ -711,7 +711,7 @@ const ≅ = isequal
         @test x[6] === x.pool.valindex[3]
         @test levels(x) == ["a", "b", "c", "z"]
 
-        x[1,:] = "a"
+        x[1,:] .= "a"
         @test x[1] === x.pool.valindex[1]
         @test x[2] === x.pool.valindex[2]
         @test x[3] === x.pool.valindex[1]
@@ -720,7 +720,7 @@ const ≅ = isequal
         @test x[6] === x.pool.valindex[3]
         @test levels(x) == ["a", "b", "c", "z"]
 
-        x[1,1:2] = "z"
+        x[1,1:2] .= "z"
         @test x[1] === x.pool.valindex[4]
         @test x[2] === x.pool.valindex[2]
         @test x[3] === x.pool.valindex[4]
@@ -871,7 +871,7 @@ const ≅ = isequal
         @test x[6] === missing
         @test levels(x) == ["a", "b", "c", "z"]
 
-        x[1,:] = "a"
+        x[1,:] .= "a"
         @test x[1] === x.pool.valindex[1]
         @test x[2] === x.pool.valindex[2]
         @test x[3] === x.pool.valindex[1]
@@ -880,7 +880,7 @@ const ≅ = isequal
         @test x[6] === missing
         @test levels(x) == ["a", "b", "c", "z"]
 
-        x[1,1:2] = "z"
+        x[1,1:2] .= "z"
         @test x[1] === x.pool.valindex[4]
         @test x[2] === x.pool.valindex[2]
         @test x[3] === x.pool.valindex[4]
@@ -898,7 +898,7 @@ const ≅ = isequal
         @test x[6] === missing
         @test levels(x) == ["a", "b", "c", "z"]
 
-        x[1,1:2] = missing
+        x[1,1:2] .= missing
         @test x[1] === missing
         @test x[2] === x.pool.valindex[2]
         @test x[3] === missing
@@ -907,7 +907,7 @@ const ≅ = isequal
         @test x[6] === missing
         @test levels(x) == ["a", "b", "c", "z"]
 
-        x[:,2] = missing
+        x[:,2] .= missing
         @test x[1] === missing
         @test x[2] === x.pool.valindex[2]
         @test x[3] === missing

--- a/test/12_missingarray.jl
+++ b/test/12_missingarray.jl
@@ -1034,7 +1034,7 @@ end
 end
 
 @testset "vcat with all empty array" begin
-    ca1 = CategoricalArray(0)
+    ca1 = CategoricalArray(undef, 0)
     ca2 = CategoricalArray([missing, "b"])
     r = vcat(ca1, ca2)
     @test r ≅ [missing, "b"]
@@ -1043,7 +1043,7 @@ end
 end
 
 @testset "vcat with all missings and empty" begin
-    ca1 = CategoricalArray(0)
+    ca1 = CategoricalArray(undef, 0)
     ca2 = CategoricalArray([missing, missing])
     r = vcat(ca1, ca2)
     @test r ≅ [missing, missing]
@@ -1056,7 +1056,7 @@ end
     @test isordered(r)
 
     ca1 = CategoricalArray(["a", missing])
-    ca2 = CategoricalArray{Union{String, Missing}}(2)
+    ca2 = CategoricalArray{Union{String, Missing}}(undef, 2)
     ordered!(ca1, true)
     @test isempty(levels(ca2))
     r = vcat(ca1, ca2)

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -270,7 +270,7 @@ end
         @testset "copy src not supporting missings into dest not supporting missings" begin
             v = ["a", "b", "c"]
             src = levels!(CategoricalVector(v), reverse(v))
-            dest = CategoricalVector{String}(3)
+            dest = CategoricalVector{String}(undef, 3)
             copyf!(dest, src)
             @test dest == src
             @test levels(dest) == levels(src) == reverse(v)
@@ -279,7 +279,7 @@ end
         @testset "copy src supporting missings into dest not supporting missings" begin
             v = ["a", "b", "c"]
             src = levels!(CategoricalVector{Union{Missing, String}}(v), reverse(v))
-            dest = CategoricalVector{String}(3)
+            dest = CategoricalVector{String}(undef, 3)
             copyf!(dest, src)
             @test dest == src
             @test levels(dest) == levels(src) == reverse(v)
@@ -288,7 +288,7 @@ end
         @testset "copy src not supporting missings into dest supporting missings" begin
             v = ["a", "b", "c"]
             src = levels!(CategoricalVector(v), reverse(v))
-            dest = CategoricalVector{Union{String, Missing}}(3)
+            dest = CategoricalVector{Union{String, Missing}}(undef, 3)
             copyf!(dest, src)
             @test dest == src
             @test levels(dest) == levels(src) == reverse(v)
@@ -297,7 +297,7 @@ end
         @testset "copy src supporting missings into dest supporting missings" begin
             v = ["a", "b", "c"]
             src = levels!(CategoricalVector{Union{String, Missing}}(v), reverse(v))
-            dest = CategoricalVector{Union{String, Missing}}(3)
+            dest = CategoricalVector{Union{String, Missing}}(undef, 3)
             copyf!(dest, src)
             @test dest == src
             @test levels(dest) == levels(src) == reverse(v)
@@ -307,7 +307,7 @@ end
             v = ["a", "b", "c"]
             src = levels!(CategoricalVector(v), reverse(v))
             vsrc = view(src, 1:length(src))
-            dest = CategoricalVector{String}(3)
+            dest = CategoricalVector{String}(undef, 3)
             copyf!(dest, vsrc)
             @test dest == src
             @test levels(dest) == levels(src) == reverse(v)
@@ -317,7 +317,7 @@ end
             v = ["a", "b", "c"]
             src = levels!(CategoricalVector{Union{String, Missing}}(v), reverse(v))
             vsrc = view(src, 1:length(src))
-            dest = CategoricalVector{String}(3)
+            dest = CategoricalVector{String}(undef, 3)
             copyf!(dest, vsrc)
             @test dest == src
             @test levels(dest) == levels(src) == reverse(v)
@@ -327,7 +327,7 @@ end
             v = ["a", "b", "c"]
             src = levels!(CategoricalVector(v), reverse(v))
             vsrc = view(src, 1:length(src))
-            dest = CategoricalVector{Union{String, Missing}}(3)
+            dest = CategoricalVector{Union{String, Missing}}(undef, 3)
             copyf!(dest, vsrc)
             @test dest == src
             @test levels(dest) == levels(src) == reverse(v)
@@ -337,7 +337,7 @@ end
             v = ["a", "b", "c"]
             src = levels!(CategoricalVector{Union{String, Missing}}(v), reverse(v))
             vsrc = view(src, 1:length(src))
-            dest = CategoricalVector{Union{String, Missing}}(3)
+            dest = CategoricalVector{Union{String, Missing}}(undef, 3)
             copyf!(dest, vsrc)
             @test dest == src
             @test levels(dest) == levels(src) == reverse(v)
@@ -347,13 +347,13 @@ end
             v = ["a", "b", "c"]
             src = levels!(CategoricalVector(v), reverse(v))
             vsrc = view(src, 1:2)
-            dest = CategoricalVector{String}(3)
+            dest = CategoricalVector{String}(undef, 3)
             copyf!(dest, vsrc)
             @test dest[1:2] == src[1:2]
             @test levels(dest) == levels(src)
 
             vsrc = view(src, 1:2)
-            dest = CategoricalVector{String}(2)
+            dest = CategoricalVector{String}(undef, 2)
             copyf!(dest, vsrc)
             @test dest == src[1:2]
             @test levels(dest) == levels(src)
@@ -401,7 +401,7 @@ end
             v = ["a", "b", "c"]
             src = CategoricalVector{Union{eltype(v), Missing}}(v)
             levels!(src, reverse(v))
-            dest = CategoricalVector{String}(3)
+            dest = CategoricalVector{String}(undef, 3)
             copyf!(dest, src)
             @test dest == src
             @test levels(dest) == levels(src) == reverse(v)
@@ -413,14 +413,14 @@ end
 
             src = CategoricalVector{AbstractString}(v)
             levels!(src, reverse(v))
-            dest = CategoricalVector{String}(3)
+            dest = CategoricalVector{String}(undef, 3)
             copyf!(dest, src)
             @test dest == src
             @test levels(dest) == levels(src) == reverse(v)
 
             src = CategoricalVector{String}(v)
             levels!(src, reverse(v))
-            dest = CategoricalVector{AbstractString}(3)
+            dest = CategoricalVector{AbstractString}(undef, 3)
             copyf!(dest, src)
             @test dest == src
             @test levels(dest) == levels(src) == reverse(v)
@@ -429,7 +429,7 @@ end
         @testset "inviable mixed src and dest types" begin
             v = ["a", "b", missing]
             src = CategoricalVector(v)
-            dest = CategoricalVector{String}(3)
+            dest = CategoricalVector{String}(undef, 3)
             @test_throws MissingException copyf!(dest, src)
 
             vsrc = view(src, 1:length(src))
@@ -437,7 +437,7 @@ end
 
             v = Integer[-1, -2, -3]
             src = CategoricalVector(v)
-            dest = CategoricalVector{UInt}(3)
+            dest = CategoricalVector{UInt}(undef, 3)
             @test_throws InexactError copyf!(dest, src)
         end
     end
@@ -532,7 +532,7 @@ end
             @test x2 == x
         end
 
-        fill!(x2, :c)
+        fill!(x2, "c")
         @test x2 == ["c", "c", "c"]
         @test levels(x2) == ["a", "b", "c"]
 
@@ -727,7 +727,7 @@ end
 end
 
 @testset "converting from array with missings to array without missings CategoricalArray fails with missings" begin
-    x = CategoricalArray{Union{String, Missing}}(1)
+    x = CategoricalArray{Union{String, Missing}}(undef, 1)
     @test_throws MissingException CategoricalArray{String}(x)
     @test_throws MissingException convert(CategoricalArray{String}, x)
 end
@@ -808,8 +808,8 @@ end
 
 @testset "vcat() takes into account element type even when array is empty" begin
     # or when both arrays have the same levels but of different types
-    x = CategoricalVector{String}(0)
-    y = CategoricalVector{Int}(0)
+    x = CategoricalVector{String}(undef, 0)
+    y = CategoricalVector{Int}(undef, 0)
     z1 = CategoricalVector{Float64}([1.0])
     z2 = CategoricalVector{Int}([1])
     @inferred vcat(x, y)

--- a/test/14_view.jl
+++ b/test/14_view.jl
@@ -3,6 +3,8 @@ using Compat
 using Compat.Test
 using CategoricalArrays
 
+const ≅ = isequal
+
 @testset "view($(CategoricalArray{Union{T, eltype(a)}}), $inds), ordered=$order construction" for
     T in (Union{}, Missing), order in (true, false),
     a in (1:10, 10:-1:1, ["a", "c", "b", "b", "a"]),
@@ -28,6 +30,19 @@ end
     @test view(ca1, 1:2) == view(ca3, 1:2)
     @test view(ca1, 1:2) != view(ca2, 1:3)
     @test view(ca1, 1:2) != view(ca5, 1:2, 1:1)
+end
+
+@testset "fill! on view" for
+    a in (categorical(["c", "a", "b"]), categorical(["c", "a", missing]))
+    v = view(a, 1:2)
+    @test fill!(v, a[1]) == ["c", "c"]
+    @test fill!(v, "a") == ["a", "a"]
+    @test fill!(v, "d") == ["d", "d"]
+    if eltype(a) >: Missing
+        @test fill!(v, missing) ≅ [missing, missing]
+    else
+        @test_throws MethodError fill!(v, missing)
+    end
 end
 
 end

--- a/test/16_recode.jl
+++ b/test/16_recode.jl
@@ -14,7 +14,8 @@ const ≅ = isequal
 @testset "Recoding from $(typeof(x)) to $(typeof(y))" for
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10)),
     y in (similar(x), Array{Int}(undef, size(x)),
-          CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)), x)
+          CategoricalArray{Int}(undef, size(x)),
+          CategoricalArray{Union{Int, Missing}}(undef, size(x)), x)
 
     z = @inferred recode!(y, x, 1=>100, 2:4=>0, [5; 9:10]=>-1)
     @test y === z
@@ -28,7 +29,8 @@ end
 @testset "Recoding from $(typeof(x)) to $(typeof(y)) with duplicate recoded values" for
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10)),
     y in (similar(x), Array{Int}(undef, size(x)),
-          CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)), x)
+          CategoricalArray{Int}(undef, size(x)),
+          CategoricalArray{Union{Int, Missing}}(undef, size(x)), x)
 
     z = @inferred recode!(y, x, 1=>100, 2:4=>100, [5; 9:10]=>-1)
     @test y === z
@@ -42,7 +44,8 @@ end
 @testset "Recoding from $(typeof(x)) to $(typeof(y)) with unused level" for
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10)),
     y in (similar(x), Array{Int}(undef, size(x)),
-          CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)), x)
+          CategoricalArray{Int}(undef, size(x)),
+          CategoricalArray{Union{Int, Missing}}(undef, size(x)), x)
 
     z = @inferred recode!(y, x, 1=>100, 2:4=>0, [5; 9:10]=>-1, 100=>1)
     @test y === z
@@ -56,7 +59,8 @@ end
 @testset "Recoding from $(typeof(x)) to $(typeof(y)) with duplicate default" for
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10)),
     y in (similar(x), Array{Int}(undef, size(x)),
-          CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)), x)
+          CategoricalArray{Int}(undef, size(x)),
+          CategoricalArray{Union{Int, Missing}}(undef, size(x)), x)
 
     z = @inferred recode!(y, x, 100, 1=>100, 2:4=>100, [5; 9:10]=>-1)
     @test y === z
@@ -70,7 +74,8 @@ end
 @testset "Recoding from $(typeof(x)) to $(typeof(y)) with default" for
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10)),
     y in (similar(x), Array{Int}(undef, size(x)),
-          CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)), x)
+          CategoricalArray{Int}(undef, size(x)),
+          CategoricalArray{Union{Int, Missing}}(undef, size(x)), x)
 
     z = @inferred recode!(y, x, -10, 1=>100, 2:4=>0, [5; 9:10]=>-1)
     @test y === z
@@ -84,7 +89,8 @@ end
 @testset "Recoding from $(typeof(x)) to $(typeof(y)) with first value being Float64" for
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10)),
     y in (similar(x), Array{Int}(undef, size(x)),
-          CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)), x)
+          CategoricalArray{Int}(undef, size(x)),
+          CategoricalArray{Union{Int, Missing}}(undef, size(x)), x)
 
     z = @inferred recode!(y, x, 1.0=>100, 2:4=>0, [5; 9:10]=>-1)
     @test y == [100, 0, 0, 0, -1, 6, 7, 8, -1, -1]
@@ -97,7 +103,8 @@ end
 @testset "Recoding from $(typeof(x)) to $(typeof(y)) with overlapping pairs" for
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10)),
     y in (similar(x), Array{Int}(undef, size(x)),
-          CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)), x)
+          CategoricalArray{Int}(undef, size(x)),
+          CategoricalArray{Union{Int, Missing}}(undef, size(x)), x)
 
     z = @inferred recode!(y, x, 1=>100, 2:4=>0, [5; 9:10]=>-1, 1:10=>0)
     @test y === z
@@ -111,7 +118,8 @@ end
 @testset "Recoding from $(typeof(x)) to $(typeof(y)) with changes to levels order" for
     x in ([1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10)),
     y in (similar(x), Array{Int}(undef, size(x)),
-          CategoricalArray{Int}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)), x)
+          CategoricalArray{Int}(undef, size(x)),
+          CategoricalArray{Union{Int, Missing}}(undef, size(x)), x)
 
     z = @inferred recode!(y, x, 1=>100, 2:4=>0, [5; 9:10]=>-1)
     @test y === z
@@ -129,14 +137,14 @@ end
     y = Vector{String}(undef, 4)
     @test_throws MissingException recode!(y, x, "a", "c"=>"b")
 
-    y = CategoricalVector{String}(4)
+    y = CategoricalVector{String}(undef, 4)
     @test_throws MissingException recode!(y, x, "a", "c"=>"b")
 end
 
 @testset "Recoding array with missings and default from $(typeof(x)) to $(typeof(y))" for
     x in (["a", missing, "c", "d"], CategoricalArray(["a", missing, "c", "d"])),
-    y in (similar(x), Array{Union{String, Missing}}(size(x)),
-          CategoricalArray{Union{String, Missing}}(size(x)), x)
+    y in (similar(x), Array{Union{String, Missing}}(undef, size(x)),
+          CategoricalArray{Union{String, Missing}}(undef, size(x)), x)
 
     z = @inferred recode!(y, x, "a", "c"=>"b")
     @test y === z
@@ -149,8 +157,8 @@ end
 
 @testset "Recoding array with missings and no default from $(typeof(x)) to $(typeof(y))" for
     x in (["a", missing, "c", "d"], CategoricalArray(["a", missing, "c", "d"])),
-    y in (similar(x), Array{Union{String, Missing}}(size(x)),
-          CategoricalArray{Union{String, Missing}}(size(x)), x)
+    y in (similar(x), Array{Union{String, Missing}}(undef, size(x)),
+          CategoricalArray{Union{String, Missing}}(undef, size(x)), x)
 
     z = @inferred recode!(y, x, "c"=>"b")
     @test y === z
@@ -163,8 +171,8 @@ end
 
 @testset "Collection in LHS recoding array with missings and no default from $(typeof(x)) to $(typeof(y))" for
     x in (["1", missing, "3", "4", "5"], CategoricalArray(["1", missing, "3", "4", "5"])),
-    y in (similar(x), Array{Union{String, Missing}}(size(x)),
-          CategoricalArray{Union{String, Missing}}(size(x)), x)
+    y in (similar(x), Array{Union{String, Missing}}(undef, size(x)),
+          CategoricalArray{Union{String, Missing}}(undef, size(x)), x)
 
     z = @inferred recode!(y, x, ["3","4"]=>"2")
     @test y === z
@@ -177,8 +185,8 @@ end
 
 @testset "Recoding array with missings, default and with missing as a key pair from $(typeof(x)) to $(typeof(y))" for
     x in (["a", missing, "c", "d"], CategoricalArray(["a", missing, "c", "d"])),
-    y in (similar(x), Array{Union{String, Missing}}(size(x)),
-          CategoricalArray{Union{String, Missing}}(size(x)), x)
+    y in (similar(x), Array{Union{String, Missing}}(undef, size(x)),
+          CategoricalArray{Union{String, Missing}}(undef, size(x)), x)
 
     z = @inferred recode!(y, x, "a", "c"=>"b", missing=>"d")
     @test y === z
@@ -191,8 +199,8 @@ end
 
 @testset "Collection with missing in LHS recoding array with missings, default from $(typeof(x)) to $(typeof(y))" for
     x in (["a", missing, "c", "d"], CategoricalArray(["a", missing, "c", "d"])),
-    y in (similar(x), Array{Union{String, Missing}}(size(x)),
-          CategoricalArray{Union{String, Missing}}(size(x)), x)
+    y in (similar(x), Array{Union{String, Missing}}(undef, size(x)),
+          CategoricalArray{Union{String, Missing}}(undef, size(x)), x)
 
     z = @inferred recode!(y, x, "a", [missing, "c"]=>"b")
     @test y === z
@@ -205,8 +213,8 @@ end
 
 @testset "Recoding array with missings, no default and with missing as a key pair from $(typeof(x)) to $(typeof(y))" for
     x in (["a", missing, "c", "d"], CategoricalArray(["a", missing, "c", "d"])),
-    y in (similar(x), Array{Union{String, Missing}}(size(x)),
-          CategoricalArray{Union{String, Missing}}(size(x)), x)
+    y in (similar(x), Array{Union{String, Missing}}(undef, size(x)),
+          CategoricalArray{Union{String, Missing}}(undef, size(x)), x)
 
     z = @inferred recode!(y, x, "c"=>"b", missing=>"d")
     @test y === z
@@ -219,8 +227,8 @@ end
 
 @testset "Collection with missing in LHS recoding array with missings, no default from $(typeof(x)) to $(typeof(y))" for
     x in (["a", missing, "c", "d"], CategoricalArray(["a", missing, "c", "d"])),
-    y in (similar(x), Array{Union{String, Missing}}(size(x)),
-          CategoricalArray{Union{String, Missing}}(size(x)), x)
+    y in (similar(x), Array{Union{String, Missing}}(undef, size(x)),
+          CategoricalArray{Union{String, Missing}}(undef, size(x)), x)
 
     z = @inferred recode!(y, x, ["c", missing]=>"b")
     @test y === z
@@ -233,22 +241,24 @@ end
 
 @testset "Recoding into an array of incompatible size from $(typeof(x)) to $(typeof(y))" for
     x in (["a", missing, "c", "d"], CategoricalArray(["a", missing, "c", "d"])),
-    y in (similar(x, 0), Array{Union{String, Missing}}(0),
-          CategoricalArray{Union{String, Missing}}(0))
+    y in (similar(x, 0), Array{Union{String, Missing}}(undef, 0),
+          CategoricalArray{Union{String, Missing}}(undef, 0))
 
     @test_throws DimensionMismatch recode!(y, x, "c"=>"b", missing=>"d")
 end
 
 @testset "Recoding into an array with incompatible eltype from $(typeof(x)) to $(typeof(y))" for
     x in ([1:10;], CategoricalArray(1:10)),
-    y in (similar(x, String), Array{String}(undef, size(x)), CategoricalArray{String}(size(x)))
+    y in (similar(x, String), Array{String}(undef, size(x)),
+          CategoricalArray{String}(undef, size(x)))
 
     @test_throws ArgumentError recode!(y, x, 1=>"a", 2:4=>"b", [5; 9:10]=>"c")
 end
 
 @testset "Recoding into an array with incompatible eltype from $(typeof(x)) to $(typeof(y))" for
     x in ((Union{Int, Missing})[1:10;], CategoricalArray{Union{Int, Missing}}(1:10)),
-    y in (similar(x), Array{Union{Int, Missing}}(size(x)), CategoricalArray{Union{Int, Missing}}(size(x)))
+    y in (similar(x), Array{Union{Int, Missing}}(undef, size(x)),
+          CategoricalArray{Union{Int, Missing}}(undef, size(x)))
 
     @test_throws MethodError recode!(y, x, 1=>"a", 2:4=>"b", [5; 9:10]=>"c")
 end
@@ -279,7 +289,8 @@ end
     end
 end
 
-@testset "recode() promotion for $(typeof(x))" for x in (1:10, [1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10))
+@testset "recode() promotion for $(typeof(x))" for
+    x in (1:10, [1:10;], CategoricalArray(1:10), CategoricalArray{Union{Int, Missing}}(1:10))
     T = eltype(x) >: Missing ? Missing : Union{}
 
     # Recoding from Int to Float64 due to a second value being Float64


### PR DESCRIPTION
Use new iteration protocol on 0.7, which in particular fixes `escape_string`.
Also fix a remaining deprecations.

Fixes https://github.com/JuliaData/DataFrames.jl/issues/1423.

(Failures on 0.7 are due to other remaining issues.)