### PR TITLE
Fix promote_type(CategoricalValue, Any)

### DIFF
--- a/src/value.jl
+++ b/src/value.jl
@@ -56,6 +56,7 @@ Base.promote_rule(::Type{C}, ::Type{T}) where {C <: CatValue, T} = promote_type(
 Base.promote_rule(::Type{C}, ::Type{T}) where {C <: CategoricalString, T <: AbstractString} =
     promote_type(leveltype(C), T)
 Base.promote_rule(::Type{C}, ::Type{Missing}) where {C <: CatValue} = Union{C, Missing}
+Base.promote_rule(::Type{C}, ::Type{Any}) where {C <: CatValue} = Any
 
 Base.convert(::Type{Ref}, x::CatValue) = RefValue{leveltype(x)}(x)
 Base.convert(::Type{String}, x::CatValue) = convert(String, get(x))

--- a/test/05_convert.jl
+++ b/test/05_convert.jl
@@ -55,6 +55,7 @@ using CategoricalArrays: DefaultRefType, level, reftype, leveltype, catvalue, is
     @test promote_type(CategoricalValue{Int}, Missing) === Union{CategoricalValue{Int}, Missing}
     @test promote_type(CategoricalValue{Int, UInt32}, Missing) ===
         Union{CategoricalValue{Int, UInt32}, Missing}
+    @test promote_type(CategoricalValue{Int, UInt32}, Any) === Any
 end
 
 @testset "convert() preserves `ordered`" begin


### PR DESCRIPTION
Fix an ambiguity with a method defined in Missings.

Fixes https://github.com/JuliaData/CSV.jl/issues/216.