### PR TITLE
Julia 0.7 printing improvements

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -780,8 +780,13 @@ function complex(A::CategoricalArray{T}) where T
 end
 
 # Override AbstractArray method to avoid printing useless type parameters
-summary(A::CategoricalArray{T, N, R}) where {T, N, R} =
-    string(Base.dims2string(size(A)), " $CategoricalArray{$T,$N,$R}")
+if VERSION >= v"0.7.0-DEV.2657"
+    summary(io::IO, A::CategoricalArray{T, N, R}) where {T, N, R} =
+        print(io, Base.dims2string(size(A)), " $CategoricalArray{$T,$N,$R}")
+else
+    summary(A::CategoricalArray{T, N, R}) where {T, N, R} =
+        string(Base.dims2string(size(A)), " $CategoricalArray{$T,$N,$R}")
+end
 
 refs(A::CategoricalArray) = A.refs
 pool(A::CategoricalArray) = A.pool

--- a/src/value.jl
+++ b/src/value.jl
@@ -68,7 +68,7 @@ Base.convert(::Type{S}, x::CatValue) where {S} = convert(S, get(x)) # fallback
 
 if VERSION >= v"0.7.0-DEV.2797"
     function Base.show(io::IO, x::CatValue)
-        if get(io, :typeinfo, Any) === typeof(x)
+        if Missings.T(get(io, :typeinfo, Any)) === Missings.T(typeof(x))
             print(io, repr(x))
         elseif isordered(pool(x))
             @printf(io, "%s %s (%i/%i)",

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -956,4 +956,21 @@ end
     @test levels(x) == ["c", "a"]
 end
 
+@testset "show" begin
+    x = categorical([2, 1])
+    @test sprint((io,a)->show(io, "text/plain", a), x) ==
+        """
+        2-element $CategoricalArray{$Int,1,UInt32}:
+         2
+         1"""
+
+    x = categorical([2, 1, missing])
+    @test sprint((io,a)->show(io, "text/plain", a), x) ==
+        """
+        3-element $CategoricalArray{$(Union{Missing,Int}),1,UInt32}:
+         2      
+         1      
+         missing"""
+end
+
 end


### PR DESCRIPTION
Use compact `CatValue` representation with `Union{T,Missing}` eltypes. The previous check only worked for arrays which don't support `Missing` on Julia 0.7. Also fix `summary` method, which wasn't called on Julia 0.7 due to a change in signature.

See https://github.com/JuliaLang/julia/issues/26847.