### PR TITLE
Fix promotion rules for CatValue

### DIFF
--- a/src/value.jl
+++ b/src/value.jl
@@ -51,6 +51,32 @@ catvalue(level::Integer, pool::CategoricalPool{T, R, C}) where {T, R, C} =
     C(convert(R, level), pool)
 
 Base.promote_rule(::Type{C}, ::Type{T}) where {C <: CatValue, T} = promote_type(leveltype(C), T)
+Base.promote_rule(::Type{C1}, ::Type{Union{C2, Missing}}) where {C1 <: CatValue, C2 <: CatValue} =
+    Union{promote_type(C1, C2), Missing}
+
+Base.promote_rule(::Type{CategoricalValue{S}},
+                  ::Type{CategoricalValue{T}}) where {S, T} =
+    CategoricalValue{promote_type(S, T)}
+
+Base.promote_rule(::Type{CategoricalValue{S, R1}},
+                  ::Type{CategoricalValue{T, R2}}) where {S, T, R1<:Integer, R2<:Integer} =
+    CategoricalValue{promote_type(S, T), promote_type(R1, R2)}
+Base.promote_rule(::Type{CategoricalString{R1}},
+                  ::Type{CategoricalString{R2}}) where {R1<:Integer, R2<:Integer} =
+    CategoricalString{promote_type(R1, R2)}
+
+Base.promote_rule(::Type{CategoricalValue{S, R}},
+                  ::Type{CategoricalValue{T}}) where {S, T, R<:Integer} =
+    CategoricalValue{promote_type(S, T), R}
+Base.promote_rule(::Type{CategoricalString{R}},
+                  ::Type{CategoricalString}) where {R<:Integer} =
+    CategoricalString{R}
+Base.promote_rule(::Type{CategoricalValue{S}},
+                  ::Type{CategoricalValue{T, R}}) where {S, T, R<:Integer} =
+    CategoricalValue{promote_type(S, T), R}
+Base.promote_rule(::Type{CategoricalString},
+                  ::Type{CategoricalString{R}}) where {R<:Integer} =
+    CategoricalString{R}
 
 # To fix ambiguities with definitions from Base
 Base.promote_rule(::Type{C}, ::Type{T}) where {C <: CategoricalString, T <: AbstractString} =

--- a/src/value.jl
+++ b/src/value.jl
@@ -42,6 +42,15 @@ catvaluetype(::Type{<:AbstractString}, ::Type{R}) where {R} =
 # to prevent incorrect dispatch to T<:CatValue method
 catvaluetype(::Type{Union{}}, ::Type{R}) where {R} = CategoricalValue{Union{}, R}
 
+# get the categorical value type given value type `T`
+catvaluetype(::Type{T}) where {T >: Missing} = catvaluetype(Missings.T(T))
+catvaluetype(::Type{T}) where {T <: CatValue} = catvaluetype(leveltype(T))
+catvaluetype(::Type{Any}) = CategoricalValue{Any}  # prevent recursion in T>:Missing method
+catvaluetype(::Type{T}) where {T} = CategoricalValue{T}
+catvaluetype(::Type{<:AbstractString}) = CategoricalString
+# to prevent incorrect dispatch to T<:CatValue method
+catvaluetype(::Type{Union{}}) where {R} = CategoricalValue{Union{}}
+
 Base.get(x::CatValue) = index(pool(x))[level(x)]
 order(x::CatValue) = order(pool(x))[level(x)]
 
@@ -53,10 +62,9 @@ catvalue(level::Integer, pool::CategoricalPool{T, R, C}) where {T, R, C} =
 Base.promote_rule(::Type{C}, ::Type{T}) where {C <: CatValue, T} = promote_type(leveltype(C), T)
 Base.promote_rule(::Type{C1}, ::Type{Union{C2, Missing}}) where {C1 <: CatValue, C2 <: CatValue} =
     Union{promote_type(C1, C2), Missing}
-
-Base.promote_rule(::Type{CategoricalValue{S}},
-                  ::Type{CategoricalValue{T}}) where {S, T} =
-    CategoricalValue{promote_type(S, T)}
+# To fix ambiguities with definitions from Base
+Base.promote_rule(::Type{C}, ::Type{Missing}) where {C <: CatValue} = Union{C, Missing}
+Base.promote_rule(::Type{C}, ::Type{Any}) where {C <: CatValue} = Any
 
 Base.promote_rule(::Type{CategoricalValue{S, R1}},
                   ::Type{CategoricalValue{T, R2}}) where {S, T, R1<:Integer, R2<:Integer} =
@@ -64,25 +72,11 @@ Base.promote_rule(::Type{CategoricalValue{S, R1}},
 Base.promote_rule(::Type{CategoricalString{R1}},
                   ::Type{CategoricalString{R2}}) where {R1<:Integer, R2<:Integer} =
     CategoricalString{promote_type(R1, R2)}
-
-Base.promote_rule(::Type{CategoricalValue{S, R}},
-                  ::Type{CategoricalValue{T}}) where {S, T, R<:Integer} =
-    CategoricalValue{promote_type(S, T), R}
-Base.promote_rule(::Type{CategoricalString{R}},
-                  ::Type{CategoricalString}) where {R<:Integer} =
-    CategoricalString{R}
-Base.promote_rule(::Type{CategoricalValue{S}},
-                  ::Type{CategoricalValue{T, R}}) where {S, T, R<:Integer} =
-    CategoricalValue{promote_type(S, T), R}
-Base.promote_rule(::Type{CategoricalString},
-                  ::Type{CategoricalString{R}}) where {R<:Integer} =
-    CategoricalString{R}
-
-# To fix ambiguities with definitions from Base
-Base.promote_rule(::Type{C}, ::Type{T}) where {C <: CategoricalString, T <: AbstractString} =
-    promote_type(leveltype(C), T)
-Base.promote_rule(::Type{C}, ::Type{Missing}) where {C <: CatValue} = Union{C, Missing}
-Base.promote_rule(::Type{C}, ::Type{Any}) where {C <: CatValue} = Any
+Base.promote_rule(::Type{C1}, ::Type{C2}) where
+    {R1<:Integer, R2<:Integer, C1<:CatValue{R1}, C2<:CatValue{R2}} =
+    catvaluetype(promote_type(leveltype(C1), leveltype(C2)), promote_type(R1, R2))
+Base.promote_rule(::Type{C1}, ::Type{C2}) where {C1<:CatValue, C2<:CatValue} =
+    catvaluetype(promote_type(leveltype(C1), leveltype(C2)))
 
 Base.convert(::Type{Ref}, x::CatValue) = RefValue{leveltype(x)}(x)
 Base.convert(::Type{String}, x::CatValue) = convert(String, get(x))

--- a/test/05_convert.jl
+++ b/test/05_convert.jl
@@ -56,30 +56,30 @@ using CategoricalArrays: DefaultRefType, level, reftype, leveltype, catvalue, is
     @test promote(1.0, v1) === (1.0, 1.0)
     @test promote(0x1, v1) === (1, 1)
 
-    # Broken tests are due to JuliaLang/julia#29348
+    # Tests that return Any are due to JuliaLang/julia#29348
+    # It is not clear what would be the most appropriate promotion type for them,
+    # but at least they should not throw an error
     @test promote_type(CategoricalValue{Int}, CategoricalValue{Float64}) ===
         CategoricalValue{Float64}
     @test promote_type(CategoricalValue{Int, UInt8}, CategoricalValue{Float64, UInt32}) ===
         CategoricalValue{Float64, UInt32}
     @test promote_type(CategoricalValue{Int, UInt8}, CategoricalValue{Float64}) ===
-        CategoricalValue{Float64, UInt8}
-    @test promote_type(CategoricalValue{Int}, CategoricalValue{Float64, UInt8}) ===
-        CategoricalValue{Float64, UInt8}
-    @test_broken promote_type(CategoricalValue{Int},
-                              Union{CategoricalValue{Float64}, Missing}) ===
-        Union{CategoricalValue{Float64}, Missing}
+        CategoricalValue{Float64}
+    @test promote_type(CategoricalValue{Int},
+                       Union{CategoricalValue{Float64}, Missing}) ===
+        Any
     @test promote_type(CategoricalValue{Int, UInt8},
                        Union{CategoricalValue{Float64, UInt32}, Missing}) ===
         Union{CategoricalValue{Float64, UInt32}, Missing}
-    @test_broken promote_type(Union{CategoricalValue{Int}, Missing},
-                              CategoricalValue{Float64}) ===
-        Union{CategoricalValue{Float64}, Missing}
+    @test promote_type(Union{CategoricalValue{Int}, Missing},
+                       CategoricalValue{Float64}) ===
+        Any
     @test promote_type(Union{CategoricalValue{Int, UInt8}, Missing},
                        CategoricalValue{Float64, UInt32}) ===
         Union{CategoricalValue{Float64, UInt32}, Missing}
-    @test_broken promote_type(Union{CategoricalValue{Int}, Missing},
-                              Union{CategoricalValue{Float64}, Missing}) ===
-        Union{CategoricalValue{Float64}, Missing}
+    @test promote_type(Union{CategoricalValue{Int}, Missing},
+                       Union{CategoricalValue{Float64}, Missing}) ===
+        Any
     @test promote_type(Union{CategoricalValue{Int, UInt8}, Missing},
                        Union{CategoricalValue{Float64, UInt32}, Missing}) ===
         Union{CategoricalValue{Float64, UInt32}, Missing}
@@ -93,15 +93,16 @@ using CategoricalArrays: DefaultRefType, level, reftype, leveltype, catvalue, is
     @test promote_type(CategoricalString{UInt8}, CategoricalString{UInt32}) ===
         CategoricalString{UInt32}
     @test promote_type(CategoricalString, CategoricalString{UInt32}) ===
-        CategoricalString{UInt32}
-    @test promote_type(CategoricalString{UInt32}, CategoricalString) ===
-        CategoricalString{UInt32}
+        CategoricalString
     @test promote_type(Union{CategoricalString{UInt8}, Missing}, CategoricalString{UInt32}) ===
-        Union{CategoricalString{UInt32}, Missing}
-    @test promote_type(CategoricalString{UInt8}, Union{CategoricalString{UInt32}, Missing}) ===
         Union{CategoricalString{UInt32}, Missing}
     @test promote_type(Union{CategoricalString{UInt8}, Missing}, Union{CategoricalString{UInt32}, Missing}) ===
         Union{CategoricalString{UInt32}, Missing}
+
+    @test promote_type(CategoricalString{UInt8}, CategoricalValue{Int, UInt32}) ===
+        CategoricalValue{Any, UInt32}
+    @test promote_type(Union{CategoricalString{UInt8}, Missing}, CategoricalValue{Int, UInt32}) ===
+        Union{CategoricalValue{Any, UInt32}, Missing}
 end
 
 @testset "convert() preserves `ordered`" begin

--- a/test/05_convert.jl
+++ b/test/05_convert.jl
@@ -56,11 +56,52 @@ using CategoricalArrays: DefaultRefType, level, reftype, leveltype, catvalue, is
     @test promote(1.0, v1) === (1.0, 1.0)
     @test promote(0x1, v1) === (1, 1)
 
+    # Broken tests are due to JuliaLang/julia#29348
+    @test promote_type(CategoricalValue{Int}, CategoricalValue{Float64}) ===
+        CategoricalValue{Float64}
+    @test promote_type(CategoricalValue{Int, UInt8}, CategoricalValue{Float64, UInt32}) ===
+        CategoricalValue{Float64, UInt32}
+    @test promote_type(CategoricalValue{Int, UInt8}, CategoricalValue{Float64}) ===
+        CategoricalValue{Float64, UInt8}
+    @test promote_type(CategoricalValue{Int}, CategoricalValue{Float64, UInt8}) ===
+        CategoricalValue{Float64, UInt8}
+    @test_broken promote_type(CategoricalValue{Int},
+                              Union{CategoricalValue{Float64}, Missing}) ===
+        Union{CategoricalValue{Float64}, Missing}
+    @test promote_type(CategoricalValue{Int, UInt8},
+                       Union{CategoricalValue{Float64, UInt32}, Missing}) ===
+        Union{CategoricalValue{Float64, UInt32}, Missing}
+    @test_broken promote_type(Union{CategoricalValue{Int}, Missing},
+                              CategoricalValue{Float64}) ===
+        Union{CategoricalValue{Float64}, Missing}
+    @test promote_type(Union{CategoricalValue{Int, UInt8}, Missing},
+                       CategoricalValue{Float64, UInt32}) ===
+        Union{CategoricalValue{Float64, UInt32}, Missing}
+    @test_broken promote_type(Union{CategoricalValue{Int}, Missing},
+                              Union{CategoricalValue{Float64}, Missing}) ===
+        Union{CategoricalValue{Float64}, Missing}
+    @test promote_type(Union{CategoricalValue{Int, UInt8}, Missing},
+                       Union{CategoricalValue{Float64, UInt32}, Missing}) ===
+        Union{CategoricalValue{Float64, UInt32}, Missing}
+
     @test promote_type(CategoricalValue, Missing) === Union{CategoricalValue, Missing}
     @test promote_type(CategoricalValue{Int}, Missing) === Union{CategoricalValue{Int}, Missing}
     @test promote_type(CategoricalValue{Int, UInt32}, Missing) ===
         Union{CategoricalValue{Int, UInt32}, Missing}
     @test promote_type(CategoricalValue{Int, UInt32}, Any) === Any
+
+    @test promote_type(CategoricalString{UInt8}, CategoricalString{UInt32}) ===
+        CategoricalString{UInt32}
+    @test promote_type(CategoricalString, CategoricalString{UInt32}) ===
+        CategoricalString{UInt32}
+    @test promote_type(CategoricalString{UInt32}, CategoricalString) ===
+        CategoricalString{UInt32}
+    @test promote_type(Union{CategoricalString{UInt8}, Missing}, CategoricalString{UInt32}) ===
+        Union{CategoricalString{UInt32}, Missing}
+    @test promote_type(CategoricalString{UInt8}, Union{CategoricalString{UInt32}, Missing}) ===
+        Union{CategoricalString{UInt32}, Missing}
+    @test promote_type(Union{CategoricalString{UInt8}, Missing}, Union{CategoricalString{UInt32}, Missing}) ===
+        Union{CategoricalString{UInt32}, Missing}
 end
 
 @testset "convert() preserves `ordered`" begin


### PR DESCRIPTION
These rules weren't really used previously since concatenation of arrays was used, but packages can now use `Tables.allocatecolumns` to get a `CategoricalArray` from a `CatValue`, and use promotion rules to get the right eltype from various input values.

Some promotion rules involving `Missing` with a `CatValue` with the reftype unspecified fail due to what appears to be a Julia bug (JuliaLang/julia#29348). Anyway they should be very rare in practice.