### PR TITLE
Treat CategoricalValue as a scalar in broadcast

### DIFF
--- a/src/value.jl
+++ b/src/value.jl
@@ -88,6 +88,8 @@ Base.convert(::Type{S}, x::T) where {S, T <: CatValue} = # fallback
 
 (::Type{T})(x::T) where {T <: CatValue} = x
 
+Base.Broadcast.broadcastable(x::CatValue) = Ref(x)
+
 if VERSION >= v"0.7.0-DEV.2797"
     function Base.show(io::IO, x::CatValue)
         if Missings.T(get(io, :typeinfo, Any)) === Missings.T(typeof(x))

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -973,4 +973,10 @@ end
          missing"""
 end
 
+@testset "broadcast" for x in (CategoricalArray(1:3),
+                               CategoricalArray{Union{Int,Missing}}(1:3))
+    x[1:2] .= x[3]
+    @test x == [3, 3, 3]
+end
+
 end


### PR DESCRIPTION
It was already the case for `CategoricalString` since it is an `AbstractString`.

Cc: @pdeffebach