### PR TITLE
Add optimized methods

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -335,6 +335,7 @@ Base.IndexStyle(::Type{<:CategoricalArray}) = IndexLinear()
 
 @inline function setindex!(A::CategoricalArray, v::Any, I::Real...)
     @boundscheck checkbounds(A, I...)
+    # get! has an optimized method for v::CatValue
     @inbounds A.refs[I...] = get!(A.pool, v)
 end
 

--- a/src/value.jl
+++ b/src/value.jl
@@ -216,6 +216,8 @@ Base.:<(y::AbstractString, x::CatValue) = invoke(<, Tuple{Any, CatValue}, y, x)
 Base.:<(::Missing, ::CatValue) = missing
 
 # AbstractString interface for CategoricalString
+Base.String(x::CategoricalString) = get(x)
+Base.convert(::Type{String}, x::CategoricalString) = get(x)
 Base.string(x::CategoricalString) = get(x)
 Base.eltype(x::CategoricalString) = Char
 Base.length(x::CategoricalString) = length(get(x))

--- a/test/08_string.jl
+++ b/test/08_string.jl
@@ -21,6 +21,12 @@ using CategoricalArrays
     @test Symbol(v1) === Symbol("")
     @test Symbol(v2) === :café
 
+    @test convert(String, v1)::String == ""
+    @test convert(String, v2)::String == "café"
+
+    @test string(v1)::String == ""
+    @test string(v2)::String == "café"
+
     @test v1 == ""
     @test v2 == "café"
     @test v2 != ""


### PR DESCRIPTION
Define `String` and `string` for `CategoricalString` since the `AbstractString` fallbacks are less efficient. Add `get` and `get!` methods for `CatValues` in a `CategoricalPool` to avoid a dict lookup when the pool is the same.

```julia
x = categorical(rand(["a", "b", "c", "d"], 10000));
f(x) = (y = x[1]; for i in eachindex(x); x[i] = y; end)
v = x[1]

# Before
julia> @btime f(x);
  506.536 μs (10000 allocations: 312.50 KiB)

julia> @btime String($v);
  50.742 ns (3 allocations: 160 bytes)

# After
julia> @btime f(x);
  13.527 μs (0 allocations: 0 bytes)

julia> @btime String($v);
  3.846 ns (0 allocations: 0 bytes)
```

Failures on nightly are unrelated and due to changes in dates printing.