### PR TITLE
Define another method for similar to fix broadcasting

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -494,6 +494,11 @@ similar(A::CategoricalArray{S, M, R}, ::Type{T},
         dims::NTuple{N, Int}) where {S, T<:Union{CatValue, Missing}, M, N, R} =
     CategoricalArray{Union{T, Missing}, N, R}(undef, dims)
 
+similar(::Type{T}, dims::Dims) where {T<:AbstractArray{<:Union{CatValue,Missing}}} =
+    CategoricalArray{eltype(T)}(undef, dims)
+similar(::Type{T}, dims::Dims) where {T<:AbstractArray{Missing}} =
+    T(undef, dims)
+
 """
     compress(A::CategoricalArray)
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -124,6 +124,9 @@ end
 
 CategoricalArray{T, N}(::UndefInitializer, dims::NTuple{N,Int}; ordered=false) where {T, N} =
     CategoricalArray{T, N, DefaultRefType}(undef, dims, ordered=ordered)
+CategoricalArray{T, N}(::UndefInitializer, dims::NTuple{N,Int}; ordered=false) where
+    {R, T <: Union{Missing, CatValue{R}}, N} =
+    CategoricalArray{T, N, R}(undef, dims, ordered=ordered)
 CategoricalArray{T}(::UndefInitializer, dims::NTuple{N,Int}; ordered=false) where {T, N} =
     CategoricalArray{T, N}(undef, dims, ordered=ordered)
 CategoricalArray{T, 1}(::UndefInitializer, m::Int; ordered=false) where {T} =
@@ -494,11 +497,19 @@ similar(A::CategoricalArray{S, M, R}, ::Type{T},
         dims::NTuple{N, Int}) where {S, T<:Union{CatValue, Missing}, M, N, R} =
     CategoricalArray{Union{T, Missing}, N, R}(undef, dims)
 
-similar(::Type{T}, dims::Dims) where {T<:AbstractArray{<:CategoricalValue}} =
+similar(::Type{T}, dims::Dims) where {U, R, T<:AbstractArray{CategoricalValue{U, R}}} =
+    CategoricalArray{eltype(T)}(undef, dims)
+similar(::Type{T}, dims::Dims) where {U, T<:AbstractArray{CategoricalValue{U}}} =
+    CategoricalArray{eltype(T)}(undef, dims)
+similar(::Type{T}, dims::Dims) where {U, R, T<:AbstractArray{Union{CategoricalValue{U, R}, Missing}}} =
     CategoricalArray{eltype(T)}(undef, dims)
 similar(::Type{T}, dims::Dims) where {U, T<:AbstractArray{Union{CategoricalValue{U}, Missing}}} =
     CategoricalArray{eltype(T)}(undef, dims)
-similar(::Type{T}, dims::Dims) where {T<:AbstractArray{<:CategoricalString}} =
+similar(::Type{T}, dims::Dims) where {R, T<:AbstractArray{CategoricalString{R}}} =
+    CategoricalArray{eltype(T)}(undef, dims)
+similar(::Type{T}, dims::Dims) where {T<:AbstractArray{CategoricalString}} =
+    CategoricalArray{eltype(T)}(undef, dims)
+similar(::Type{T}, dims::Dims) where {R, T<:AbstractArray{Union{<:CategoricalString{R}, Missing}}} =
     CategoricalArray{eltype(T)}(undef, dims)
 similar(::Type{T}, dims::Dims) where {T<:AbstractArray{Union{<:CategoricalString, Missing}}} =
     CategoricalArray{eltype(T)}(undef, dims)

--- a/src/array.jl
+++ b/src/array.jl
@@ -494,10 +494,14 @@ similar(A::CategoricalArray{S, M, R}, ::Type{T},
         dims::NTuple{N, Int}) where {S, T<:Union{CatValue, Missing}, M, N, R} =
     CategoricalArray{Union{T, Missing}, N, R}(undef, dims)
 
-similar(::Type{T}, dims::Dims) where {T<:AbstractArray{<:Union{CatValue,Missing}}} =
+similar(::Type{T}, dims::Dims) where {T<:AbstractArray{<:CategoricalValue}} =
     CategoricalArray{eltype(T)}(undef, dims)
-similar(::Type{T}, dims::Dims) where {T<:AbstractArray{Missing}} =
-    T(undef, dims)
+similar(::Type{T}, dims::Dims) where {U, T<:AbstractArray{Union{CategoricalValue{U}, Missing}}} =
+    CategoricalArray{eltype(T)}(undef, dims)
+similar(::Type{T}, dims::Dims) where {T<:AbstractArray{<:CategoricalString}} =
+    CategoricalArray{eltype(T)}(undef, dims)
+similar(::Type{T}, dims::Dims) where {T<:AbstractArray{Union{<:CategoricalString, Missing}}} =
+    CategoricalArray{eltype(T)}(undef, dims)
 
 """
     compress(A::CategoricalArray)

--- a/src/array.jl
+++ b/src/array.jl
@@ -482,20 +482,59 @@ similar(A::CategoricalArray{S, M, R}, ::Type{T},
 similar(A::CategoricalArray{S, M, R}, ::Type{Missing},
         dims::NTuple{N, Int}) where {N, S, M, R} =
     Array{Missing, N}(missing, dims)
-similar(A::CategoricalArray{S, M, Q}, ::Type{T},
-        dims::NTuple{N, Int}) where {R, T<:CatValue{R}, N, S, M, Q} =
+similar(A::CategoricalArray{S, M, Q}, ::Type{CategoricalValue{T, R}},
+        dims::NTuple{N, Int}) where {R, T, N, S, M, Q} =
     CategoricalArray{T, N, R}(undef, dims)
-similar(A::CategoricalArray{S, M, R}, ::Type{T},
-        dims::NTuple{N, Int}) where {S, T<:CatValue, M, N, R} =
-    CategoricalArray{T, N, R}(undef, dims)
-# Union{T, Missing} is repeated even if theoretically redundant because of JuliaLang/julia#26405
-# Once that bug is fixed, Union{T, Missing} can be replaced with T and the two definitions above can be removed
-similar(A::CategoricalArray{S, M, Q}, ::Type{T},
-        dims::NTuple{N, Int}) where {R, T<:Union{CatValue{R}, Missing}, N, S, M, Q} =
+similar(A::CategoricalArray{S, M, Q}, ::Type{CategoricalValue{T}},
+        dims::NTuple{N, Int}) where {T, N, S, M, Q} =
+    CategoricalArray{T, N}(undef, dims)
+similar(A::CategoricalArray{S, M, Q}, ::Type{CategoricalString{R}},
+        dims::NTuple{N, Int}) where {R, N, S, M, Q} =
+    CategoricalArray{String, N, R}(undef, dims)
+similar(A::CategoricalArray{S, M, Q}, ::Type{CategoricalString},
+        dims::NTuple{N, Int}) where {N, S, M, Q} =
+    CategoricalArray{String, N, Q}(undef, dims)
+similar(A::CategoricalArray{S, M, Q}, ::Type{Union{CategoricalValue{T, R}, Missing}},
+        dims::NTuple{N, Int}) where {R, T, N, S, M, Q} =
     CategoricalArray{Union{T, Missing}, N, R}(undef, dims)
-similar(A::CategoricalArray{S, M, R}, ::Type{T},
-        dims::NTuple{N, Int}) where {S, T<:Union{CatValue, Missing}, M, N, R} =
-    CategoricalArray{Union{T, Missing}, N, R}(undef, dims)
+similar(A::CategoricalArray{S, M, Q}, ::Type{Union{CategoricalValue{T}, Missing}},
+        dims::NTuple{N, Int}) where {T, N, S, M, Q} =
+    CategoricalArray{Union{T, Missing}, N, Q}(undef, dims)
+similar(A::CategoricalArray{S, M, Q}, ::Type{Union{CategoricalString{R}, Missing}},
+        dims::NTuple{N, Int}) where {R, N, S, M, Q} =
+    CategoricalArray{Union{String, Missing}, N, R}(undef, dims)
+similar(A::CategoricalArray{S, M, Q}, ::Type{Union{CategoricalString, Missing}},
+        dims::NTuple{N, Int}) where {N, S, M, Q} =
+    CategoricalArray{Union{String, Missing}, N, Q}(undef, dims)
+
+for A in (:AbstractArray, :Array, :Vector, :Matrix) # to fix ambiguities
+    @eval begin
+        similar(A::$A, ::Type{CategoricalValue{T, R}},
+                dims::NTuple{N, Int}=size(A)) where {T, R, N} =
+            CategoricalArray{T, N, R}(undef, dims)
+        similar(A::$A, ::Type{CategoricalValue{T}},
+                dims::NTuple{N, Int}=size(A)) where {T, N} =
+            CategoricalArray{T, N}(undef, dims)
+        similar(A::$A, ::Type{CategoricalString{R}},
+                dims::NTuple{N, Int}=size(A)) where {R, N} =
+            CategoricalArray{String, N, R}(undef, dims)
+        similar(A::$A, ::Type{CategoricalString},
+                dims::NTuple{N, Int}=size(A)) where {N} =
+            CategoricalArray{String, N}(undef, dims)
+        similar(A::$A, ::Type{Union{CategoricalValue{T, R}, Missing}},
+                dims::NTuple{N, Int}=size(A)) where {T, R, N} =
+            CategoricalArray{Union{T, Missing}, N, R}(undef, dims)
+        similar(A::$A, ::Type{Union{CategoricalValue{T}, Missing}},
+                dims::NTuple{N, Int}=size(A)) where {T, N} =
+            CategoricalArray{Union{T, Missing}, N}(undef, dims)
+        similar(A::$A, ::Type{Union{CategoricalString{R}, Missing}},
+                dims::NTuple{N, Int}=size(A)) where {R, N} =
+            CategoricalArray{Union{String, Missing}, N, R}(undef, dims)
+        similar(A::$A, ::Type{Union{CategoricalString, Missing}},
+                dims::NTuple{N, Int}=size(A)) where {N} =
+            CategoricalArray{Union{String, Missing}, N}(undef, dims)
+    end
+end
 
 similar(::Type{T}, dims::Dims) where {U, R, T<:AbstractArray{CategoricalValue{U, R}}} =
     CategoricalArray{eltype(T)}(undef, dims)

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -190,6 +190,22 @@ end
         @test isa(y, CategoricalVector{Int, UInt32})
         @test size(y) == size(x)
 
+        y = similar([], Union{CategoricalValue{Int}, T}, (3,))
+        @test isa(y, CategoricalVector{Union{Int, T}, UInt32})
+        @test size(y) == (3,)
+
+        y = similar([], Union{CategoricalString, T}, (3,))
+        @test isa(y, CategoricalVector{Union{String, T}, UInt32})
+        @test size(y) == (3,)
+
+        y = similar([], Union{CategoricalValue{Int, UInt8}, T}, (3,))
+        @test isa(y, CategoricalVector{Union{Int, T}, UInt8})
+        @test size(y) == (3,)
+
+        y = similar([], Union{CategoricalString{UInt8}, T}, (3,))
+        @test isa(y, CategoricalVector{Union{String, T}, UInt8})
+        @test size(y) == (3,)
+
         y = similar(Vector{Union{CategoricalValue{Int}, T}}, (3,))
         @test isa(y, CategoricalVector{Union{Int, T}, UInt32})
         @test size(y) == (3,)

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -190,6 +190,14 @@ end
         @test isa(y, CategoricalVector{Union{Int, Missing}, UInt32})
         @test size(y) == (3,)
 
+        y = similar(Vector{CategoricalString}, (3,))
+        @test isa(y, CategoricalVector{String, UInt32})
+        @test size(y) == (3,)
+
+        y = similar(Vector{Union{CategoricalString, Missing}}, (3,))
+        @test isa(y, CategoricalVector{Union{String, Missing}, UInt32})
+        @test size(y) == (3,)
+
         y = similar(Vector{Missing}, (3,))
         @test isa(y, Vector{Missing})
         @test size(y) == (3,)

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -181,6 +181,18 @@ end
         y = similar(x, CategoricalValue{Int, UInt32})
         @test isa(y, CategoricalVector{Int, UInt32})
         @test size(y) == size(x)
+
+        y = similar(Vector{CategoricalValue{Int}}, (3,))
+        @test isa(y, CategoricalVector{Int, UInt32})
+        @test size(y) == (3,)
+
+        y = similar(Vector{Union{CategoricalValue{Int}, Missing}}, (3,))
+        @test isa(y, CategoricalVector{Union{Int, Missing}, UInt32})
+        @test size(y) == (3,)
+
+        y = similar(Vector{Missing}, (3,))
+        @test isa(y, Vector{Missing})
+        @test size(y) == (3,)
     end
 
     @testset "copy! and copyto!" begin
@@ -992,6 +1004,20 @@ end
                                CategoricalArray(["a", "b", "c"]))
     x[1:2] .= x[3]
     @test x == fill(get(x[3]), 3)
+
+    y = identity.(x)
+    @test x ≅ y
+    @test x !== y
+    @test y isa CategoricalArray
+
+    y = broadcast(v->v, x)
+    @test x ≅ y
+    @test x !== y
+    @test y isa CategoricalArray
+
+    y = broadcast(v->1, x)
+    @test y == [1, 1, 1]
+    @test y isa Vector{Int}
 end
 
 @testset "append! ordered=$ordered" for ordered in (false, true)

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -1035,7 +1035,8 @@ end
 @testset "broadcast" for x in (CategoricalArray(1:3),
                                CategoricalArray{Union{Int,Missing}}(1:3),
                                CategoricalArray(["a", "b", "c"]),
-                               CategoricalArray{Union{String,Missing}}(["b", missing, "c"]))
+                               CategoricalArray(["a", missing, "c"]),
+                               CategoricalArray([missing, "b", "c"]))
     y = identity.(x)
     @test x ≅ y
     @test x !== y
@@ -1046,7 +1047,7 @@ end
     @test x !== y
     @test y isa CategoricalArray
 
-    y = broadcast(v->x[1], x)
+    y = broadcast(v->x[3], x)
     @test x !== y
     @test y isa CategoricalArray
 

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -1015,6 +1015,10 @@ end
     @test x !== y
     @test y isa CategoricalArray
 
+    y = broadcast(v->x[1], x)
+    @test x !== y
+    @test y isa CategoricalArray
+
     y = broadcast(v->1, x)
     @test y == [1, 1, 1]
     @test y isa Vector{Int}

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -210,9 +210,10 @@ end
         @test isa(y, CategoricalVector{Union{Int, T}, UInt32})
         @test size(y) == (3,)
 
-        y = similar(Vector{Union{CategoricalString, T}}, (3,))
-        @test isa(y, CategoricalVector{Union{String, T}, UInt32})
-        @test size(y) == (3,)
+        # Disabled due to JuliaLang/julia#32262
+        # y = similar(Vector{Union{CategoricalString, T}}, (3,))
+        # @test isa(y, CategoricalVector{Union{String, T}, UInt32})
+        # @test size(y) == (3,)
 
         y = similar(Vector{Union{CategoricalValue{Int, UInt8}, T}}, (3,))
         @test isa(y, CategoricalVector{Union{Int, T}, UInt8})


### PR DESCRIPTION
Categorical values are never supposed to be stored in `Array` objects, so `similar(Array{CategoricalValue}, ...)` should return a `CategoricalArray`. This incidentally fixes broadcast when the function returns a categorical value.

See also https://github.com/JuliaData/CategoricalArrays.jl/pull/133.

CI failure on Julia 1.0 is unrelated.