### PR TITLE
Provide formatter for labeling categories in `cut` function

### DIFF
--- a/src/extras.jl
+++ b/src/extras.jl
@@ -73,11 +73,7 @@ also accept them.
   
 # Examples
 ```jldoctest
-julia> using CategoricalArrays
-
-julia> x = -1:0.5:1;
-
-julia> cut(x, [0, 1], extend=true)
+julia> cut(-1:0.5:1, [0, 1], extend=true)
 5-element CategoricalArray{String,1,UInt32}:
  "[-1.0, 0.0)"
  "[-1.0, 0.0)"
@@ -85,9 +81,7 @@ julia> cut(x, [0, 1], extend=true)
  "[0.0, 1.0]" 
  "[0.0, 1.0]" 
 
-julia> x = -1:0.5:1;
-
-julia> cut(x, 2)
+julia> cut(-1:0.5:1, 2)
 5-element CategoricalArray{String,1,UInt32}:
  "[-1.0, 0.0)"
  "[-1.0, 0.0)"
@@ -95,9 +89,7 @@ julia> cut(x, 2)
  "[0.0, 1.0]" 
  "[0.0, 1.0]" 
 
-julia> x = -1:0.5:1;
-
-julia> cut(x, 2, labels=["A", "B"])
+julia> cut(-1:0.5:1, 2, labels=["A", "B"])
 5-element CategoricalArray{String,1,UInt32}:
  "A"
  "A"
@@ -108,7 +100,7 @@ julia> cut(x, 2, labels=["A", "B"])
 julia> fmt(from, to, i; closed) = "grp $i ($from//$to)"
 fmt (generic function with 1 method)
 
-julia> cut(x, 3, labels=fmt)
+julia> cut(-1:0.5:1, 3, labels=fmt)
 5-element CategoricalArray{String,1,UInt32}:
  "grp 1 (-1.0//-0.333333)"    
  "grp 1 (-1.0//-0.333333)"    
@@ -121,7 +113,6 @@ function cut(x::AbstractArray{T, N}, breaks::AbstractVector;
              extend::Bool=false,
              labels::Union{AbstractVector{<:AbstractString},Function}=default_formatter,
              allow_missing::Bool=false) where {T, N}
-    
     if !issorted(breaks)
         breaks = sort(breaks)
     end

--- a/src/extras.jl
+++ b/src/extras.jl
@@ -134,7 +134,7 @@ end
 
 """
     cut(x::AbstractArray, ngroups::Integer;
-        labels::AbstractVector=String[])
+        labels::Union{AbstractVector{<:AbstractString},Function})
 
 Cut a numeric array into `ngroups` quantiles, determined using
 [`quantile`](@ref).

--- a/src/extras.jl
+++ b/src/extras.jl
@@ -42,11 +42,11 @@ function fill_refs!(refs::AbstractArray, X::AbstractArray{>: Missing},
 end
 
 """
-    _default_formatter_
+    default_formatter(from, to, i; closed=false)
     
 Provide the default label format for the `cut` function.
 """
-default_formatter(from, to, i; extend=false) = string("[", from, ", ", to, extend ? "]" : ")")
+default_formatter(from, to, i; closed=false) = string("[", from, ", ", to, closed ? "]" : ")")
 
 """
     cut(x::AbstractArray, breaks::AbstractVector;
@@ -114,13 +114,9 @@ function cut(x::AbstractArray{T, N}, breaks::AbstractVector;
         end
         levs = Vector{String}(undef, n-1)
         for i in 1:n-2
-            levs[i] = labels(from[i], to[i], i)
+            levs[i] = labels(from[i], to[i], i, closed=false)
         end
-        if extend
-            levs[end] = labels(from[end], to[end], n-1, extend=extend)
-        else
-            levs[end] = labels(from[end], to[end], n-1)
-        end
+        levs[end] = labels(from[end], to[end], n-1, closed=extend)
     else
         length(labels) == n-1 || throw(ArgumentError("labels must be of length $(n-1), but got length $(length(labels))"))
         # Levels must have element type String for type stability of the result

--- a/src/extras.jl
+++ b/src/extras.jl
@@ -46,7 +46,7 @@ end
     
 Provide the default label format for the `cut` function.
 """
-default_formatter(from, to, i; closed=false) = string("[", from, ", ", to, closed ? "]" : ")")
+default_formatter(from, to, i; closed) = string("[", from, ", ", to, closed ? "]" : ")")
 
 @doc raw"""
     cut(x::AbstractArray, breaks::AbstractVector;

--- a/src/extras.jl
+++ b/src/extras.jl
@@ -65,9 +65,9 @@ also accept them.
   outside of the breaks; when `true`, breaks are automatically added to include all
   values in `x`, and the upper bound is included in the last interval.
 * `labels::Union{AbstractVector,Function}: a vector of strings giving the names to use for
-  the intervals; or a function `f(from, to, i; extend)` that generates the labels from the
+  the intervals; or a function `f(from, to, i; closed)` that generates the labels from the
   left and right interval boundaries and the group index. Defaults to 
-  `string("[", from, ", ", to, extend ? "]" : ")")`, e.g. `"[1, 5)"`.
+  `"[from, to)"` (or `"[from, to]"` for the rightmost interval if `extend == true`).
 * `allow_missing::Bool=true`: when `true`, values outside of breaks result in missing values.
   only supported when `x` accepts missing values.
   
@@ -75,7 +75,7 @@ also accept them.
 ```jldoctest
 julia> using CategoricalArrays
 
-julia> x = collect(-1:0.5:1);
+julia> x = -1:0.5:1;
 
 julia> cut(x, [0, 1], extend=true)
 5-element CategoricalArray{String,1,UInt32}:
@@ -85,6 +85,8 @@ julia> cut(x, [0, 1], extend=true)
  "[0.0, 1.0]" 
  "[0.0, 1.0]" 
 
+julia> x = -1:0.5:1;
+
 julia> cut(x, 2)
 5-element CategoricalArray{String,1,UInt32}:
  "[-1.0, 0.0)"
@@ -92,6 +94,8 @@ julia> cut(x, 2)
  "[0.0, 1.0]" 
  "[0.0, 1.0]" 
  "[0.0, 1.0]" 
+
+julia> x = -1:0.5:1;
 
 julia> cut(x, 2, labels=["A", "B"])
 5-element CategoricalArray{String,1,UInt32}:
@@ -111,22 +115,6 @@ julia> cut(x, 3, labels=fmt)
  "grp 2 (-0.333333//0.333333)"
  "grp 3 (0.333333//1.0)"      
  "grp 3 (0.333333//1.0)"      
-
-julia> using StatsBase: ecdf
-
-julia> percentile(x) = round(Int,100*parse(Float64,x))
-percentile (generic function with 1 method)
-
-julia> fmt2(from, to, i; closed) = "P$(percentile(from))P$(percentile(to))"
-fmt2 (generic function with 1 method)
-
-julia> cut(ecdf(x)(x), 3, labels=fmt2)
-5-element CategoricalArray{String,1,UInt32}:
- "P20P47" 
- "P20P47" 
- "P47P73" 
- "P73P100"
- "P73P100"
 ```
 """
 function cut(x::AbstractArray{T, N}, breaks::AbstractVector;

--- a/src/extras.jl
+++ b/src/extras.jl
@@ -46,11 +46,12 @@ end
     
 Provide the default label format for the `cut` function.
 """
-_default_formatter_(from, to, i; extend=false) = string("[", from, ", ", to, extend ? "]" : ")")
+default_formatter(from, to, i; extend=false) = string("[", from, ", ", to, extend ? "]" : ")")
 
 """
     cut(x::AbstractArray, breaks::AbstractVector;
-        extend::Bool=false, labels::AbstractVector=[], allow_missing::Bool=false)
+        labels::Union{AbstractVector{<:AbstractString},Function}, 
+        extend::Bool=false, allow_missing::Bool=false)
 
 Cut a numeric array into intervals and return an ordered `CategoricalArray` indicating
 the interval into which each entry falls. Intervals are of the form `[lower, upper)`,
@@ -63,15 +64,17 @@ also accept them.
 * `extend::Bool=false`: when `false`, an error is raised if some values in `x` fall
   outside of the breaks; when `true`, breaks are automatically added to include all
   values in `x`, and the upper bound is included in the last interval.
-* `labels::Union{AbstractVector,Function}=_default_formatter_`: a vector of strings giving the names to use for the
-  intervals; or a function `f(from,to,i;extend=false)` that generates the labels from the left and right interval boundaries and the group index. Defaults to `string("[", from, ", ", to, extend ? "]" : ")")`, e.g. `"[1, 5)"`.
+* `labels::Union{AbstractVector,Function}: a vector of strings giving the names to use for
+  the intervals; or a function `f(from, to, i; extend)` that generates the labels from the
+  left and right interval boundaries and the group index. Defaults to 
+  `string("[", from, ", ", to, extend ? "]" : ")")`, e.g. `"[1, 5)"`.
 * `allow_missing::Bool=true`: when `true`, values outside of breaks result in missing values.
   only supported when `x` accepts missing values.
 """
 function cut(x::AbstractArray{T, N}, breaks::AbstractVector;
-             extend::Bool=false, labels=_default_formatter_,
-             allow_missing::Bool=false) where {T, N, U<:AbstractString}
-    (labels isa AbstractVector) || (labels isa Function) || throw(ArgumentError("labels must be a formatter function or an AbstractVector"))
+             extend::Bool=false,
+             labels::Union{AbstractVector{<:AbstractString},Function}=default_formatter,
+             allow_missing::Bool=false) where {T, N}
     
     if !issorted(breaks)
         breaks = sort(breaks)
@@ -137,8 +140,5 @@ Cut a numeric array into `ngroups` quantiles, determined using
 [`quantile`](@ref).
 """
 cut(x::AbstractArray, ngroups::Integer;
-    labels=_default_formatter_) =
+    labels::Union{AbstractVector{<:AbstractString},Function}=default_formatter) =
     cut(x, Statistics.quantile(x, (1:ngroups-1)/ngroups); extend=true, labels=labels)
-
-
-

--- a/src/extras.jl
+++ b/src/extras.jl
@@ -48,7 +48,7 @@ Provide the default label format for the `cut` function.
 """
 default_formatter(from, to, i; closed=false) = string("[", from, ", ", to, closed ? "]" : ")")
 
-"""
+@doc raw"""
     cut(x::AbstractArray, breaks::AbstractVector;
         labels::Union{AbstractVector{<:AbstractString},Function}, 
         extend::Bool=false, allow_missing::Bool=false)
@@ -70,6 +70,64 @@ also accept them.
   `string("[", from, ", ", to, extend ? "]" : ")")`, e.g. `"[1, 5)"`.
 * `allow_missing::Bool=true`: when `true`, values outside of breaks result in missing values.
   only supported when `x` accepts missing values.
+  
+# Examples
+```jldoctest
+julia> using CategoricalArrays
+
+julia> x = collect(-1:0.5:1);
+
+julia> cut(x, [0, 1], extend=true)
+5-element CategoricalArray{String,1,UInt32}:
+ "[-1.0, 0.0)"
+ "[-1.0, 0.0)"
+ "[0.0, 1.0]" 
+ "[0.0, 1.0]" 
+ "[0.0, 1.0]" 
+
+julia> cut(x, 2)
+5-element CategoricalArray{String,1,UInt32}:
+ "[-1.0, 0.0)"
+ "[-1.0, 0.0)"
+ "[0.0, 1.0]" 
+ "[0.0, 1.0]" 
+ "[0.0, 1.0]" 
+
+julia> cut(x, 2, labels=["A", "B"])
+5-element CategoricalArray{String,1,UInt32}:
+ "A"
+ "A"
+ "B"
+ "B"
+ "B"
+
+julia> fmt(from, to, i; closed) = "grp $i ($from//$to)"
+fmt (generic function with 1 method)
+
+julia> cut(x, 3, labels=fmt)
+5-element CategoricalArray{String,1,UInt32}:
+ "grp 1 (-1.0//-0.333333)"    
+ "grp 1 (-1.0//-0.333333)"    
+ "grp 2 (-0.333333//0.333333)"
+ "grp 3 (0.333333//1.0)"      
+ "grp 3 (0.333333//1.0)"      
+
+julia> using StatsBase: ecdf
+
+julia> percentile(x) = round(Int,100*parse(Float64,x))
+percentile (generic function with 1 method)
+
+julia> fmt2(from, to, i; closed) = "P$(percentile(from))P$(percentile(to))"
+fmt2 (generic function with 1 method)
+
+julia> cut(ecdf(x)(x), 3, labels=fmt2)
+5-element CategoricalArray{String,1,UInt32}:
+ "P20P47" 
+ "P20P47" 
+ "P47P73" 
+ "P73P100"
+ "P73P100"
+```
 """
 function cut(x::AbstractArray{T, N}, breaks::AbstractVector;
              extend::Bool=false,

--- a/test/15_extras.jl
+++ b/test/15_extras.jl
@@ -109,12 +109,12 @@ end
 end
 
 @testset "formatter function" begin
-  my_formatter(from, to, i; extend) = "$i: $from -- $to"
+  my_formatter(from, to, i; closed) = "$i: $from -- $to"
 
   x = 0.15:0.20:0.95
   p = [0, 0.4, 0.8, 1.0]
 
-  @test cut(x, p, labels=my_formatter2) ==
+  @test cut(x, p, labels=my_formatter) ==
       ["1: 0.0 -- 0.4", "1: 0.0 -- 0.4", "2: 0.4 -- 0.8", "2: 0.4 -- 0.8", "3: 0.8 -- 1.0"]
 end
 

--- a/test/15_extras.jl
+++ b/test/15_extras.jl
@@ -108,7 +108,7 @@ end
     @test levels(x) == ["[2.0, 3.5)", "[3.5, 5.0]"]
 end
 
-@testset "formatter function" begin
+@testset "cut with formatter function" begin
   my_formatter(from, to, i; closed) = "$i: $from -- $to"
 
   x = 0.15:0.20:0.95

--- a/test/15_extras.jl
+++ b/test/15_extras.jl
@@ -109,19 +109,12 @@ end
 end
 
 @testset "formatter function" begin
-  my_formatter1(from, to, i; extend) = "group $i"
-  my_formatter2(from, to, i; extend) = "$i: $from -- $to"
-  function my_formatter3(from, to, i; extend)
-    percentile(x) = Int(round(100 * parse.(Float64,x),digits=0))
-    string("P",percentile(from),"P",percentile(to))
-  end
+  my_formatter(from, to, i; extend) = "$i: $from -- $to"
 
   x = collect(0.15:0.20:0.95)
   p = [0, 0.4, 0.8, 1.0]
 
-  @test cut(x, p, labels=my_formatter1) == ["group 1", "group 1", "group 2", "group 2", "group 3"]
   @test cut(x, p, labels=my_formatter2) == ["1: 0.0 -- 0.4", "1: 0.0 -- 0.4", "2: 0.4 -- 0.8", "2: 0.4 -- 0.8", "3: 0.8 -- 1.0"]
-  @test cut(x, p, labels=my_formatter3) == ["P0P40"  , "P0P40"  , "P40P80" , "P40P80" , "P80P100"]
 end
 
 end

--- a/test/15_extras.jl
+++ b/test/15_extras.jl
@@ -108,4 +108,20 @@ end
     @test levels(x) == ["[2.0, 3.5)", "[3.5, 5.0]"]
 end
 
+@testset "formatter function" begin
+  my_formatter1(from,to,i;extend=false) = "group $i"
+  my_formatter2(from,to,i;extend=false) = "$i: $from -- $to"
+  function my_formatter3(from,to,i;extend=true)
+    percentile(x) = Int(round(100 * parse.(Float64,x),digits=0))
+    string("P",percentile(from),"P",percentile(to))
+  end
+
+  x = collect(0.15:0.20:0.95)
+  p = [0, 0.4, 0.8, 1.0]
+
+  @test cut(x, p, labels=my_formatter1) == ["group 1", "group 1", "group 2", "group 2", "group 3"]
+  @test cut(x, p, labels=my_formatter2) == ["1: 0.0 -- 0.4", "1: 0.0 -- 0.4", "2: 0.4 -- 0.8", "2: 0.4 -- 0.8", "3: 0.8 -- 1.0"]
+  @test cut(x, p, labels=my_formatter3) == ["P0P40"  , "P0P40"  , "P40P80" , "P40P80" , "P80P100"]
+end
+
 end

--- a/test/15_extras.jl
+++ b/test/15_extras.jl
@@ -109,9 +109,9 @@ end
 end
 
 @testset "formatter function" begin
-  my_formatter1(from,to,i;extend=false) = "group $i"
-  my_formatter2(from,to,i;extend=false) = "$i: $from -- $to"
-  function my_formatter3(from,to,i;extend=true)
+  my_formatter1(from, to, i; extend) = "group $i"
+  my_formatter2(from, to, i; extend) = "$i: $from -- $to"
+  function my_formatter3(from, to, i; extend)
     percentile(x) = Int(round(100 * parse.(Float64,x),digits=0))
     string("P",percentile(from),"P",percentile(to))
   end

--- a/test/15_extras.jl
+++ b/test/15_extras.jl
@@ -111,10 +111,11 @@ end
 @testset "formatter function" begin
   my_formatter(from, to, i; extend) = "$i: $from -- $to"
 
-  x = collect(0.15:0.20:0.95)
+  x = 0.15:0.20:0.95
   p = [0, 0.4, 0.8, 1.0]
 
-  @test cut(x, p, labels=my_formatter2) == ["1: 0.0 -- 0.4", "1: 0.0 -- 0.4", "2: 0.4 -- 0.8", "2: 0.4 -- 0.8", "3: 0.8 -- 1.0"]
+  @test cut(x, p, labels=my_formatter2) ==
+      ["1: 0.0 -- 0.4", "1: 0.0 -- 0.4", "2: 0.4 -- 0.8", "2: 0.4 -- 0.8", "3: 0.8 -- 1.0"]
 end
 
 end


### PR DESCRIPTION
This is something I find useful. One could even add the group index as an additional argument.

Is this something that is worth adding?

e.g.
```julia
using Random, CategoricalArrays
data = rand(100)
cut(data, 10, label_formatter = (from,to;extend=true) -> string("P",Int(round(100 * parse(Float64,from),digits=0)),"P",Int(round(100 * parse(Float64,to), digits=0))))
# 100-element CategoricalArray{String,1,UInt32}:
# "P51P57" 
# "P16P26" 
# ...
```

