### PR TITLE
Silence deprecation warnings from string and escape_string

### DIFF
--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -94,3 +94,7 @@ import Unicode: normalize, graphemes
 @deprecate textwidth(x::CategoricalString) textwidth(String(x))
 @deprecate isascii(x::CategoricalString) isascii(String(x))
 @deprecate escape_string(x::CategoricalString) escape_string(String(x))
+
+# Avoid printing a deprecation until CategoricalString is no longer AbstractString
+Base.string(io::IO, x::CategoricalString) = print(io, get(x))
+Base.escape_string(io::IO, x::CategoricalString, esc) = escape_string(io, get(x), esc)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -96,5 +96,6 @@ import Unicode: normalize, graphemes
 @deprecate escape_string(x::CategoricalString) escape_string(String(x))
 
 # Avoid printing a deprecation until CategoricalString is no longer AbstractString
-Base.string(io::IO, x::CategoricalString) = print(io, get(x))
+Base.write(io::IO, x::CategoricalString) = write(io, get(x))
 Base.escape_string(io::IO, x::CategoricalString, esc) = escape_string(io, get(x), esc)
+Base.tostr_sizehint(x::CategoricalString) = Base.tostr_sizehint(get(x))


### PR DESCRIPTION
These functions print warnings because `CategoricalString` is still an `AbstractString`, but the methods themselves are not deprecated, and the warnings will go away once inheritance is removed. This is particularly visible when working with DataFrames.