### PR TITLE
Use nonmissingtype instead of Missings.T

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
 julia = "1"
+Missings = ">= 0.4.2"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/array.jl
+++ b/src/array.jl
@@ -261,15 +261,11 @@ function convert(::Type{CategoricalArray{T, N, R}}, A::CategoricalArray{S, N}) w
         throw(LevelsException{T, R}(levels(A)[typemax(R)+1:end]))
     end
 
-    if T >: Missing
-        U = Missings.T(T)
-    else
-        U = T
-        S >: Missing && any(iszero, A.refs) &&
-            throw(MissingException("cannot convert CategoricalArray with missing values to a CategoricalArray{$T}"))
+    if !(T >: Missing) && S >: Missing && any(iszero, A.refs)
+        throw(MissingException("cannot convert CategoricalArray with missing values to a CategoricalArray{$T}"))
     end
 
-    pool = convert(CategoricalPool{unwrap_catvaluetype(U), R}, A.pool)
+    pool = convert(CategoricalPool{unwrap_catvaluetype(nonmissingtype(T)), R}, A.pool)
     refs = convert(Array{R, N}, A.refs)
     CategoricalArray{unwrap_catvaluetype(T), N}(refs, pool)
 end
@@ -611,7 +607,7 @@ end
     end
 end
 
-catvaluetype(::Type{T}) where {T <: CategoricalArray} = Missings.T(eltype(T))
+catvaluetype(::Type{T}) where {T <: CategoricalArray} = nonmissingtype(eltype(T))
 catvaluetype(A::CategoricalArray) = catvaluetype(typeof(A))
 
 leveltype(::Type{T}) where {T <: CategoricalArray} = leveltype(catvaluetype(T))

--- a/src/recode.jl
+++ b/src/recode.jl
@@ -351,7 +351,7 @@ function recode(a::AbstractArray, default::Any, pairs::Pair...)
     elseif T >: Missing || default isa Missing || (eltype(a) >: Missing && !keytype_hasmissing(pairs...))
         dest = Array{Union{T, Missing}}(undef, size(a))
     else
-        dest = Array{Missings.T(T)}(undef, size(a))
+        dest = Array{nonmissingtype(T)}(undef, size(a))
     end
     recode!(dest, a, default, pairs...)
 end
@@ -374,7 +374,7 @@ function recode(a::CategoricalArray{S, N, R}, default::Any, pairs::Pair...) wher
     elseif T >: Missing || default isa Missing || (eltype(a) >: Missing && !keytype_hasmissing(pairs...))
         dest = CategoricalArray{Union{T, Missing}, N, R}(undef, size(a))
     else
-        dest = CategoricalArray{Missings.T(T), N, R}(undef, size(a))
+        dest = CategoricalArray{nonmissingtype(T), N, R}(undef, size(a))
     end
     recode!(dest, a, default, pairs...)
 end
@@ -386,7 +386,7 @@ function Base.replace(a::CategoricalArray{S, N, R}, pairs::Pair...) where {S, N,
     # Exception: replacing missings
     # Example: replace(categorical([missing,1.5]), missing=>0)
     if keytype_hasmissing(pairs...)
-        dest = CategoricalArray{promote_type(Missings.T(S), T), N, R}(undef, size(a))
+        dest = CategoricalArray{promote_type(nonmissingtype(S), T), N, R}(undef, size(a))
     else
         dest = CategoricalArray{promote_type(S, T), N, R}(undef, size(a))
     end

--- a/src/value.jl
+++ b/src/value.jl
@@ -23,14 +23,14 @@ level(x::CatValue) = x.level
 # extract the type of the original value from array eltype `T`
 unwrap_catvaluetype(::Type{T}) where {T} = T
 unwrap_catvaluetype(::Type{T}) where {T >: Missing} =
-    Union{unwrap_catvaluetype(Missings.T(T)), Missing}
+    Union{unwrap_catvaluetype(nonmissingtype(T)), Missing}
 unwrap_catvaluetype(::Type{Union{}}) = Union{} # prevent incorrect dispatch to T<:CatValue method
 unwrap_catvaluetype(::Type{Any}) = Any # prevent recursion in T>:Missing method
 unwrap_catvaluetype(::Type{T}) where {T <: CatValue} = leveltype(T)
 
 # get the categorical value type given value type `T` and reference type `R`
 catvaluetype(::Type{T}, ::Type{R}) where {T >: Missing, R} =
-    catvaluetype(Missings.T(T), R)
+    catvaluetype(nonmissingtype(T), R)
 catvaluetype(::Type{T}, ::Type{R}) where {T <: CatValue, R} =
     catvaluetype(leveltype(T), R)
 catvaluetype(::Type{Any}, ::Type{R}) where {R} =
@@ -43,7 +43,7 @@ catvaluetype(::Type{<:AbstractString}, ::Type{R}) where {R} =
 catvaluetype(::Type{Union{}}, ::Type{R}) where {R} = CategoricalValue{Union{}, R}
 
 # get the categorical value type given value type `T`
-catvaluetype(::Type{T}) where {T >: Missing} = catvaluetype(Missings.T(T))
+catvaluetype(::Type{T}) where {T >: Missing} = catvaluetype(nonmissingtype(T))
 catvaluetype(::Type{T}) where {T <: CatValue} = catvaluetype(leveltype(T))
 catvaluetype(::Type{Any}) = CategoricalValue{Any}  # prevent recursion in T>:Missing method
 catvaluetype(::Type{T}) where {T} = CategoricalValue{T}
@@ -101,7 +101,7 @@ Base.Broadcast.broadcastable(x::CatValue) = Ref(x)
 
 if VERSION >= v"0.7.0-DEV.2797"
     function Base.show(io::IO, x::CatValue)
-        if Missings.T(get(io, :typeinfo, Any)) === Missings.T(typeof(x))
+        if nonmissingtype(get(io, :typeinfo, Any)) === nonmissingtype(typeof(x))
             print(io, repr(x))
         elseif isordered(pool(x))
             @printf(io, "%s %s (%i/%i)",


### PR DESCRIPTION
The latter is deprecated since Julia now exports `nonmissingtype`.
Missings defines `nonmissingtype` on previous Julia versions.
Also simplify the code a bit: there's no need to check `T >: Missing` before calling `nonmissingtype`, as it is the identity for other types.

Waiting for JuliaRegistries/General#3224.