### PR TITLE
Merge pools in setindex!(x::CategoricalArray, v::CategoricalValue, i...)

### DIFF
--- a/src/typedefs.jl
+++ b/src/typedefs.jl
@@ -67,6 +67,10 @@ struct CategoricalString{R <: Integer} <: AbstractString
     pool::CategoricalPool{String, R, CategoricalString{R}}
 end
 
+# union of all categorical value types
+const CatValue{R} = Union{CategoricalValue{T, R} where T,
+                          CategoricalString{R}}
+
 ## Arrays
 
 # Type params:

--- a/src/value.jl
+++ b/src/value.jl
@@ -1,7 +1,3 @@
-# union of all categorical value types
-const CatValue{R} = Union{CategoricalValue{T, R} where T,
-                          CategoricalString{R}}
-
 # checks whether the type is categorical value
 iscatvalue(::Type) = false
 iscatvalue(::Type{Union{}}) = false # prevent incorrect dispatch to Type{<:CatValue} method

--- a/test/07_levels.jl
+++ b/test/07_levels.jl
@@ -203,6 +203,76 @@ using CategoricalArrays: DefaultRefType, levels!
         @test_throws KeyError get(pool, 6)
         @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:4]
     end
+
+    # get!
+    ordered!(pool, true)
+    @test_throws OrderedLevelsException get!(pool, 10)
+    ordered!(pool, false)
+
+    @test get!(pool, 10) === DefaultRefType(5)
+
+    @test isa(pool.index, Vector{Int})
+    @test length(pool) == 5
+    @test length(pool.valindex) == 5
+    @test levels(pool) == [5, 2, 3, 4, 10]
+    @test pool.index == [5, 4, 2, 3, 10]
+    @test pool.invindex == Dict(5=>1, 4=>2, 2=>3, 3=>4, 10=>5)
+    @test pool.order == [1, 4, 2, 3, 5]
+    @test pool.levels == [5, 2, 3, 4, 10]
+    @test get(pool, 10) === DefaultRefType(5)
+    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:5]
+
+    # get! with CategoricalValue adding new levels
+    v = CategoricalArrays.catvalue(2, CategoricalPool([100, 99, 5, 2]))
+
+    ordered!(pool, true)
+    @test_throws OrderedLevelsException get!(pool, v)
+    ordered!(pool, false)
+
+    @test get!(pool, v) === DefaultRefType(7)
+
+    @test isa(pool.index, Vector{Int})
+    @test length(pool) == 7
+    @test length(pool.valindex) == 7
+    @test levels(pool) == [100, 99, 5, 2, 3, 4, 10]
+    @test pool.index == [5, 4, 2, 3, 10, 100, 99]
+    @test pool.invindex == Dict(5=>1, 4=>2, 2=>3, 3=>4, 10=>5, 100=>6, 99=>7)
+    @test pool.order == [3, 6, 4, 5, 7, 1, 2]
+    @test pool.levels == [100, 99, 5, 2, 3, 4, 10]
+    @test get(pool, 99) === DefaultRefType(7)
+    @test get(pool, 100) === DefaultRefType(6)
+    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:7]
+
+    # get! with CategoricalValue not adding new levels
+    v = CategoricalArrays.catvalue(1, CategoricalPool([100, 2]))
+    @test get!(pool, v) === DefaultRefType(6)
+
+    @test isa(pool.index, Vector{Int})
+    @test length(pool) == 7
+    @test length(pool.valindex) == 7
+    @test levels(pool) == [100, 99, 5, 2, 3, 4, 10]
+    @test pool.index == [5, 4, 2, 3, 10, 100, 99]
+    @test pool.invindex == Dict(5=>1, 4=>2, 2=>3, 3=>4, 10=>5, 100=>6, 99=>7)
+    @test pool.order == [3, 6, 4, 5, 7, 1, 2]
+    @test pool.levels == [100, 99, 5, 2, 3, 4, 10]
+    @test get(pool, 99) === DefaultRefType(7)
+    @test get(pool, 100) === DefaultRefType(6)
+    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:7]
+
+    # get! with CategoricalValue from same pool
+    @test get!(pool, pool[1]) === DefaultRefType(1)
+
+    @test isa(pool.index, Vector{Int})
+    @test length(pool) == 7
+    @test length(pool.valindex) == 7
+    @test levels(pool) == [100, 99, 5, 2, 3, 4, 10]
+    @test pool.index == [5, 4, 2, 3, 10, 100, 99]
+    @test pool.invindex == Dict(5=>1, 4=>2, 2=>3, 3=>4, 10=>5, 100=>6, 99=>7)
+    @test pool.order == [3, 6, 4, 5, 7, 1, 2]
+    @test pool.levels == [100, 99, 5, 2, 3, 4, 10]
+    @test get(pool, 99) === DefaultRefType(7)
+    @test get(pool, 100) === DefaultRefType(6)
+    @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:7]
 end
 
 @testset "overflow of reftype is detected and doesn't corrupt levels" begin

--- a/test/07_levels.jl
+++ b/test/07_levels.jl
@@ -273,6 +273,10 @@ using CategoricalArrays: DefaultRefType, levels!
     @test get(pool, 99) === DefaultRefType(7)
     @test get(pool, 100) === DefaultRefType(6)
     @test pool.valindex == [CategoricalArrays.catvalue(i, pool) for i in 1:7]
+
+    # get! with CategoricalValue not adding new levels
+    v = CategoricalArrays.catvalue(1, CategoricalPool(["a", "b"]))
+    @test_throws MethodError get!(pool, v)
 end
 
 @testset "overflow of reftype is detected and doesn't corrupt levels" begin

--- a/test/11_array.jl
+++ b/test/11_array.jl
@@ -614,6 +614,16 @@ using CategoricalArrays: DefaultRefType, catvaluetype, leveltype
         @test x[1] === x.pool.valindex[3]
         @test x[2] === x.pool.valindex[1]
         @test levels(x) == ["c", "a", "b"]
+
+        v = CategoricalArrays.catvalue(2, CategoricalPool(["xyz", "b"]))
+        if ordered
+            @test_throws OrderedLevelsException x[1] = v
+            levels!(x, ["c", "a", "xyz", "b"])
+        end
+        x[1] = v
+        @test x[1] === x.pool.valindex[3]
+        @test x[2] === x.pool.valindex[1]
+        @test levels(x) == ["c", "a", "xyz", "b"]
     end
 end
 


### PR DESCRIPTION
If `v`'s levels are not a subset of `x`'s, extend the latter. This prevents a `CategoricalValue` from losing its levels when it is assigned to a `CategoricalArray`, and makes `setindex!` consistent with `copyto!`.

Note that there's is still a small inconsistency with `copyto!`: at #125 we decided that an error should be thrown when adding levels to an ordered pool/array, but `copyto!` currently just marks the array as unordered. That should probably be changed separately unless we can find good reasons not to. That would also make the code simpler.

Fixes #99 and #199.