### PR TITLE
Fix convert with Union{T, Nothing}

### DIFF
--- a/src/value.jl
+++ b/src/value.jl
@@ -87,9 +87,9 @@ Base.convert(::Type{Union{T, Nothing}}, x::T) where {T <: CatValue} = x
 Base.convert(::Type{S}, x::T) where {S, T <: CatValue} =
     T <: S ? x : convert(S, get(x))
 Base.convert(::Type{Union{S, Missing}}, x::T) where {S, T <: CatValue} =
-    T <: S ? x : convert(S, get(x))
+    T <: Union{S, Missing} ? x : convert(Union{S, Missing}, get(x))
 Base.convert(::Type{Union{S, Nothing}}, x::T) where {S, T <: CatValue} =
-    T <: S ? x : convert(S, get(x))
+    T <: Union{S, Nothing} ? x : convert(Union{S, Nothing}, get(x))
 
 (::Type{T})(x::T) where {T <: CatValue} = x
 

--- a/test/05_convert.jl
+++ b/test/05_convert.jl
@@ -179,4 +179,14 @@ end
     @test convert(CategoricalPool{Float64, UInt8}, pool).ordered === true
 end
 
+@testset "convert() with Union{T, Nothing}" begin
+    pool = CategoricalPool([nothing, 2, 3])
+    v1 = catvalue(1, pool)
+    v2 = catvalue(2, pool)
+    @test convert(Union{Int, Nothing}, v1) === nothing
+    @test convert(Union{Int, Nothing}, v2) === 2
+    @test convert(Union{Float64, Nothing}, v2) === 2.0
+end
+
+
 end


### PR DESCRIPTION
Fixes the `append!` problem reported at https://github.com/JuliaData/CategoricalArrays.jl/pull/172#issuecomment-535431981.