### PR TITLE
Stop reexporting Missings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,6 @@ Future = "9fa8497b-333b-5362-9e8d-4d0656e87820"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Missings = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
-Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
@@ -17,7 +16,6 @@ Compat = "1.0, 2.0, 3.0"
 DataAPI = "1.1"
 JSON = "0.15, 0.16, 0.17, 0.18, 0.19, 0.20, 0.21"
 Missings = "0.4.3"
-Reexport = "0.1, 0.2"
 julia = "1"
 
 [extras]

--- a/src/CategoricalArrays.jl
+++ b/src/CategoricalArrays.jl
@@ -13,14 +13,8 @@ module CategoricalArrays
     using Compat
     using JSON
     using DataAPI
-    using Reexport
-
-    # TODO: cannot @reexport in conditional, the below should be removed when 0.6 is deprecated
-    @reexport using Missings
-
-    if VERSION >= v"0.7.0-DEV.3052"
-        using Printf
-    end
+    using Missings
+    using Printf
 
     include("typedefs.jl")
 

--- a/test/12_missingarray.jl
+++ b/test/12_missingarray.jl
@@ -3,6 +3,7 @@ using Compat
 using Compat.Test
 using CategoricalArrays
 using CategoricalArrays: DefaultRefType, catvaluetype, leveltype
+using Missings
 
 const ≅ = isequal
 


### PR DESCRIPTION
We used to reexport Missings when `missing` was not defined in Base, but it doesn't make sense anymore.

To be merged before a breaking release, as it's low priority and it might break code.