### PR TITLE
Add optimized method for broacasting ismissing

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -790,3 +790,7 @@ refs(A::CategoricalArray) = A.refs
 pool(A::CategoricalArray) = A.pool
 
 Base.deleteat!(A::CategoricalArray, inds) = (deleteat!(A.refs, inds); A)
+
+Base.Broadcast.broadcasted(::typeof(ismissing), A::CategoricalArray{T}) where {T} =
+    T >: Missing ? Base.Broadcast.broadcasted(==, A.refs, 0) :
+                   Base.Broadcast.broadcasted(_ -> false, A)

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -1208,4 +1208,14 @@ end
     @test DataAPI.defaultarray(Union{Missing, CategoricalValue{Int, UInt32}}, 1) <: CategoricalArray{Union{Missing, Int},1,UInt32}
 end
 
+@testset "optimized broadcasting with ismissing" begin
+    x = categorical([1, missing, 3, 4, missing])
+    @test ismissing.(x) == [false, true, false, false, true]
+    @test ismissing.(view(x, 2:4)) == [true, false, false]
+
+    x = categorical([1, 0, 3, 4, 0])
+    @test ismissing.(x) == [false, false, false, false, false]
+    @test ismissing.(view(x, 2:4)) == [false, false, false]
+end
+
 end


### PR DESCRIPTION
This will allow StatsModel to get rid of the dependency on CategoricalArrays (https://github.com/JuliaStats/StatsModels.jl/pull/157), and more generally provide much improved performance for this common operation.

Also clean some uses of internal `SubArray` fields.

Cc: @kleinschmidt

```julia
using BenchmarkTools, CategoricalArrays

x = categorical(rand([1:10; missing], 10_000));
nonmissing!(mask, x) = mask .|= ismissing.(x)
mask = similar(x, Bool);

# Before
julia> @btime ismissing.(x);
  36.188 μs (5 allocations: 5.58 KiB)

julia> @btime nonmissing!(mask, x);
  25.366 μs (0 allocations: 0 bytes)

# After
julia> @btime ismissing.(x);
  15.578 μs (5 allocations: 5.59 KiB)

julia> @btime nonmissing!(mask, x);
  1.723 μs (0 allocations: 0 bytes)