### PR TITLE
Improve specialized broadcast method for ismissing

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -793,4 +793,8 @@ Base.deleteat!(A::CategoricalArray, inds) = (deleteat!(A.refs, inds); A)
 
 Base.Broadcast.broadcasted(::typeof(ismissing), A::CategoricalArray{T}) where {T} =
     T >: Missing ? Base.Broadcast.broadcasted(==, A.refs, 0) :
-                   Base.Broadcast.broadcasted(_ -> false, A)
+                   Base.Broadcast.broadcasted(_ -> false, A.refs)
+
+Base.Broadcast.broadcasted(::typeof(!ismissing), A::CategoricalArray{T}) where {T} =
+    T >: Missing ? Base.Broadcast.broadcasted(>, A.refs, 0) :
+                   Base.Broadcast.broadcasted(_ -> true, A.refs)

--- a/src/subarray.jl
+++ b/src/subarray.jl
@@ -30,4 +30,9 @@ Base.fill!(A::SubArray{<:Any, <:Any, <:CategoricalArray{>:Missing}}, ::Missing) 
 Base.Broadcast.broadcasted(::typeof(ismissing),
                            A::SubArray{<:Any, <:Any, <:CategoricalArray{T}}) where {T} =
     T >: Missing ? Base.Broadcast.broadcasted(==, refs(A), 0) :
-                   Base.Broadcast.broadcasted(_ -> false, A)
+                   Base.Broadcast.broadcasted(_ -> false, refs(A))
+
+Base.Broadcast.broadcasted(::typeof(!ismissing),
+                           A::SubArray{<:Any, <:Any, <:CategoricalArray{T}}) where {T} =
+    T >: Missing ? Base.Broadcast.broadcasted(>, refs(A), 0) :
+                   Base.Broadcast.broadcasted(_ -> true, refs(A))

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -1212,10 +1212,14 @@ end
     x = categorical([1, missing, 3, 4, missing])
     @test ismissing.(x) == [false, true, false, false, true]
     @test ismissing.(view(x, 2:4)) == [true, false, false]
+    @test (!ismissing).(x) == [true, false, true, true, false]
+    @test (!ismissing).(view(x, 2:4)) == [false, true, true]
 
     x = categorical([1, 0, 3, 4, 0])
     @test ismissing.(x) == [false, false, false, false, false]
     @test ismissing.(view(x, 2:4)) == [false, false, false]
+    @test (!ismissing).(x) == [true, true, true, true, true]
+    @test (!ismissing).(view(x, 2:4)) == [true, true, true]
 end
 
 end


### PR DESCRIPTION
Fix fast path when `!(T >: Missing)`: it was slower than the other branch.
Also add a specialized method for !ismissing.