### PR TITLE
Mark arrays with no levels as ordered when assigning ordered value

### DIFF
--- a/src/pool.jl
+++ b/src/pool.jl
@@ -199,6 +199,10 @@ end
             throw(OrderedLevelsException(level, pool.levels))
         end
         newlevs, ordered = mergelevels(isordered(pool), pool.levels, level.pool.levels)
+        # Exception: empty pool marked as ordered if new value is ordered
+        if length(pool) == 0 && isordered(level.pool)
+            ordered!(pool, true)
+        end
         levels!(pool, newlevs)
     end
     get!(pool, get(level))

--- a/test/07_levels.jl
+++ b/test/07_levels.jl
@@ -283,6 +283,17 @@ using CategoricalArrays: DefaultRefType, levels!
     p2 = CategoricalPool(Any['a', 'b', 'x'])
     @test get!(p1, p2[1]) === UInt32(1)
     @test get!(p1, p2[3]) === UInt32(4)
+
+    # get! with ordered CategoricalValue marks unordered empty pool as ordered
+    p1 = CategoricalPool(['b', 'c', 'a'])
+    ordered!(p1, true)
+    p2 = CategoricalPool(Char[])
+    @test get!(p2, p1[1]) === UInt32(1)
+    @test isordered(p2)
+    # But push! does not
+    p2 = CategoricalPool(Char[])
+    @test push!(p2, p1[1]) === p2
+    @test !isordered(p2)
 end
 
 @testset "overflow of reftype is detected and doesn't corrupt levels" begin


### PR DESCRIPTION
Adding this special case ensures that `copy!(similar(x), x)` gives an ordered array
when `x` is ordered. This is consistent with what `vcat` already does when one of the
inputs has no levels.

This is needed in particular by the DataFrames `vcat` method, which cannot use our `vcat`.

Fixes https://github.com/JuliaData/DataFrames.jl/issues/2002.