### PR TITLE
Fix warning due to using Compat.Statistics

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Missings = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CategoricalArrays"
 uuid = "324d7699-5711-5eae-9e2f-1d82baa6b597"
-version = "0.7.4"
+version = "0.7.5"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/extras.jl
+++ b/src/extras.jl
@@ -1,4 +1,4 @@
-using Compat.Statistics
+using Statistics
 
 function fill_refs!(refs::AbstractArray, X::AbstractArray,
                     breaks::AbstractVector, extend::Bool, allow_missing::Bool)


### PR DESCRIPTION
Fixes https://github.com/JuliaData/CategoricalArrays.jl/issues/236.

https://github.com/JuliaData/CategoricalArrays.jl/pull/237 is a more general fix for master.