### PR TITLE
Add function to get integer code from CategoricalValue

### DIFF
--- a/src/CategoricalArrays.jl
+++ b/src/CategoricalArrays.jl
@@ -2,12 +2,10 @@ module CategoricalArrays
     export CategoricalPool, CategoricalValue
     export AbstractCategoricalArray, AbstractCategoricalVector, AbstractCategoricalMatrix,
            CategoricalArray, CategoricalVector, CategoricalMatrix
-    export AbstractMissingCategoricalArray, AbstractMissingCategoricalVector,
-           AbstractMissingCategoricalMatrix,
-           MissingCategoricalArray, MissingCategoricalVector, MissingCategoricalMatrix
     export LevelsException, OrderedLevelsException
 
-    export categorical, compress, decompress, droplevels!, levels, levels!, isordered, ordered!
+    export categorical, compress, decompress, droplevels!, levels, levels!, levelindex,
+           isordered, ordered!
     export cut, recode, recode!
 
     using JSON

--- a/src/CategoricalArrays.jl
+++ b/src/CategoricalArrays.jl
@@ -4,7 +4,7 @@ module CategoricalArrays
            CategoricalArray, CategoricalVector, CategoricalMatrix
     export LevelsException, OrderedLevelsException
 
-    export categorical, compress, decompress, droplevels!, levels, levels!, levelindex,
+    export categorical, compress, decompress, droplevels!, levels, levels!, levelcode,
            isordered, ordered!
     export cut, recode, recode!
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -775,7 +775,7 @@ Base.Broadcast.broadcasted(::typeof(!ismissing), A::CategoricalArray{T}) where {
     T >: Missing ? Base.Broadcast.broadcasted(>, A.refs, 0) :
                    Base.Broadcast.broadcasted(_ -> true, A.refs)
 
-function Base.Broadcast.broadcasted(::typeof(levelindex), A::CategoricalArray{T}) where {T}
+function Base.Broadcast.broadcasted(::typeof(levelcode), A::CategoricalArray{T}) where {T}
     ord = order(A.pool)
     if T >: Missing
         Base.Broadcast.broadcasted(i -> i > 0 ? Signed(widen(ord[i])) : missing, A.refs)

--- a/src/array.jl
+++ b/src/array.jl
@@ -530,10 +530,12 @@ end
 leveltype(::Type{T}) where {T <: CategoricalArray} = leveltype(nonmissingtype(eltype(T)))
 
 """
-    levels(A::CategoricalArray)
+    levels(x::CategoricalArray)
+    levels(x::CategoricalValue)
 
-Return the levels of categorical array `A`. This may include levels which do not actually appear
-in the data (see [`droplevels!`](@ref)).
+Return the levels of categorical array or value `x`.
+This may include levels which do not actually appear in the data
+(see [`droplevels!`](@ref)).
 """
 DataAPI.levels(A::CategoricalArray) = levels(A.pool)
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -773,6 +773,15 @@ Base.Broadcast.broadcasted(::typeof(!ismissing), A::CategoricalArray{T}) where {
     T >: Missing ? Base.Broadcast.broadcasted(>, A.refs, 0) :
                    Base.Broadcast.broadcasted(_ -> true, A.refs)
 
+function Base.Broadcast.broadcasted(::typeof(levelindex), A::CategoricalArray{T}) where {T}
+    ord = order(A.pool)
+    if T >: Missing
+        Base.Broadcast.broadcasted(i -> i > 0 ? Signed(widen(ord[i])) : missing, A.refs)
+    else
+        Base.Broadcast.broadcasted(i -> Signed(widen(ord[i])), A.refs)
+    end
+end
+
 function Base.sort!(v::CategoricalVector;
                     # alg is ignored since counting sort is more efficient
                     alg::Base.Algorithm=Base.Sort.defalg(v),

--- a/src/value.jl
+++ b/src/value.jl
@@ -39,6 +39,8 @@ Return `missing`.
 """
 levelindex(x::Missing) = missing
 
+DataAPI.levels(x::CategoricalValue) = levels(pool(x))
+
 Base.promote_rule(::Type{C}, ::Type{T}) where {C <: CategoricalValue, T} = promote_type(leveltype(C), T)
 Base.promote_rule(::Type{C1}, ::Type{Union{C2, Missing}}) where {C1 <: CategoricalValue, C2 <: CategoricalValue} =
     Union{promote_type(C1, C2), Missing}

--- a/src/value.jl
+++ b/src/value.jl
@@ -25,19 +25,19 @@ unwrap_catvaluetype(::Type{T}) where {T <: CategoricalValue} = leveltype(T)
 Base.get(x::CategoricalValue) = index(pool(x))[level(x)]
 
 """
-    levelindex(x::CategoricalValue)
+    levelcode(x::CategoricalValue)
 
-Get the index of categorical value `x` in the set of possible values
-returned by [`levels(x)`](@ref).
+Get the code of categorical value `x`, i.e. its index in the set
+of possible values returned by [`levels(x)`](@ref).
 """
-levelindex(x::CategoricalValue) = Signed(widen(order(pool(x))[level(x)]))
+levelcode(x::CategoricalValue) = Signed(widen(order(pool(x))[level(x)]))
 
 """
-    levelindex(x::Missing)
+    levelcode(x::Missing)
 
 Return `missing`.
 """
-levelindex(x::Missing) = missing
+levelcode(x::Missing) = missing
 
 DataAPI.levels(x::CategoricalValue) = levels(pool(x))
 
@@ -81,7 +81,7 @@ function Base.show(io::IO, x::CategoricalValue)
     elseif isordered(pool(x))
         @printf(io, "%s %s (%i/%i)",
                 typeof(x), repr(x),
-                levelindex(x), length(pool(x)))
+                levelcode(x), length(pool(x)))
     else
         @printf(io, "%s %s", typeof(x), repr(x))
     end
@@ -134,13 +134,13 @@ function Base.isless(x::CategoricalValue, y::CategoricalValue)
     if pool(x) !== pool(y)
         throw(ArgumentError("CategoricalValue objects with different pools cannot be tested for order"))
     else
-        return levelindex(x) < levelindex(y)
+        return levelcode(x) < levelcode(y)
     end
 end
 
-Base.isless(x::CategoricalValue, y) = levelindex(x) < levelindex(x.pool[get(x.pool, y)])
+Base.isless(x::CategoricalValue, y) = levelcode(x) < levelcode(x.pool[get(x.pool, y)])
 Base.isless(::CategoricalValue, ::Missing) = true
-Base.isless(y, x::CategoricalValue) = levelindex(x.pool[get(x.pool, y)]) < levelindex(x)
+Base.isless(y, x::CategoricalValue) = levelcode(x.pool[get(x.pool, y)]) < levelcode(x)
 Base.isless(::Missing, ::CategoricalValue) = false
 
 function Base.:<(x::CategoricalValue, y::CategoricalValue)
@@ -149,7 +149,7 @@ function Base.:<(x::CategoricalValue, y::CategoricalValue)
     elseif !isordered(pool(x)) # !isordered(pool(y)) is implied by pool(x) === pool(y)
         throw(ArgumentError("Unordered CategoricalValue objects cannot be tested for order using <. Use isless instead, or call the ordered! function on the parent array to change this"))
     else
-        return levelindex(x) < levelindex(y)
+        return levelcode(x) < levelcode(y)
     end
 end
 
@@ -157,7 +157,7 @@ function Base.:<(x::CategoricalValue, y)
     if !isordered(pool(x))
         throw(ArgumentError("Unordered CategoricalValue objects cannot be tested for order using <. Use isless instead, or call the ordered! function on the parent array to change this"))
     else
-        return levelindex(x) < levelindex(x.pool[get(x.pool, y)])
+        return levelcode(x) < levelcode(x.pool[get(x.pool, y)])
     end
 end
 
@@ -165,7 +165,7 @@ function Base.:<(y, x::CategoricalValue)
     if !isordered(pool(x))
         throw(ArgumentError("Unordered CategoricalValue objects cannot be tested for order using <. Use isless instead, or call the ordered! function on the parent array to change this"))
     else
-        return levelindex(x.pool[get(x.pool, y)]) < levelindex(x)
+        return levelcode(x.pool[get(x.pool, y)]) < levelcode(x)
     end
 end
 

--- a/test/05_convert.jl
+++ b/test/05_convert.jl
@@ -124,5 +124,17 @@ end
     @test convert(Union{Float64, Nothing}, v2) === 2.0
 end
 
+@testset "levelindex" begin
+    pool = CategoricalPool{Int,UInt8}([3, 1, 2])
+    levels!(pool, [2, 1, 3])
+    for i in 1:3
+        v = CategoricalValue(i, pool)
+        @test levelindex(v) isa Int16
+        @test levels(pool)[levelindex(v)] == v
+    end
+
+    @test levelindex(missing) === missing
+end
+
 
 end

--- a/test/05_convert.jl
+++ b/test/05_convert.jl
@@ -124,16 +124,16 @@ end
     @test convert(Union{Float64, Nothing}, v2) === 2.0
 end
 
-@testset "levelindex" begin
+@testset "levelcode" begin
     pool = CategoricalPool{Int,UInt8}([3, 1, 2])
     levels!(pool, [2, 1, 3])
     for i in 1:3
         v = CategoricalValue(i, pool)
-        @test levelindex(v) isa Int16
-        @test levels(pool)[levelindex(v)] == v
+        @test levelcode(v) isa Int16
+        @test levels(pool)[levelcode(v)] == v
     end
 
-    @test levelindex(missing) === missing
+    @test levelcode(missing) === missing
 end
 
 

--- a/test/07_levels.jl
+++ b/test/07_levels.jl
@@ -9,6 +9,7 @@ using CategoricalArrays: DefaultRefType, levels!
     @test isa(levels(pool), Vector{Int})
     @test length(levels(pool)) === 3
     @test levels(pool) == pool.index == [2, 1, 3]
+    @test all([levels(CategoricalValue(i, pool)) for i in 1:3] .=== Ref(levels(pool)))
     @test pool.invindex == Dict(1=>2, 2=>1, 3=>3)
     @test pool.order == [1, 2, 3]
     @test pool.valindex == [CategoricalValue(i, pool) for i in 1:3]

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -1298,7 +1298,7 @@ end
     @test DataAPI.defaultarray(Union{Missing, CategoricalValue{Int, UInt32}}, 1) <: CategoricalArray{Union{Missing, Int},1,UInt32}
 end
 
-@testset "optimized broadcasting with ismissing" begin
+@testset "optimized broadcasting with ismissing and levelindex" begin
     x = categorical([1, missing, 3, 4, missing])
     @test ismissing.(x) == [false, true, false, false, true]
     @test ismissing.(view(x, 2:4)) == [true, false, false]
@@ -1310,6 +1310,27 @@ end
     @test ismissing.(view(x, 2:4)) == [false, false, false]
     @test (!ismissing).(x) == [true, true, true, true, true]
     @test (!ismissing).(view(x, 2:4)) == [true, true, true]
+end
+
+@testset "optimized broadcasting with levelindex" begin
+    x = categorical([3, missing, 1, 4, missing])
+    levels!(x, [4, 1, 3])
+    @test levelindex.(x) ≅ [3, missing, 2, 1, missing]
+    @test levelindex.(x) isa Vector{Union{Missing,Int}}
+
+    replace!(x, missing=>1)
+    @test levelindex.(x) ≅ [3, 2, 2, 1, 2]
+    @test levelindex.(x) isa Vector{Int}
+
+    x = CategoricalVector{Int,UInt8}([3, 0, 1, 4, 0])
+    levels!(x, [4, 1, 3, 0])
+    @test levelindex.(x) ≅ [3, 4, 2, 1, 4]
+    @test levelindex.(x) isa Vector{Int16}
+
+    x = CategoricalVector{Union{Missing,Int},UInt8}([3, missing, 1, 4, missing])
+    levels!(x, [4, 1, 3])
+    @test levelindex.(x) ≅ [3, missing, 2, 1, missing]
+    @test levelindex.(x) isa Vector{Union{Missing,Int16}}
 end
 
 end

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -1312,25 +1312,25 @@ end
     @test (!ismissing).(view(x, 2:4)) == [true, true, true]
 end
 
-@testset "optimized broadcasting with levelindex" begin
+@testset "optimized broadcasting with levelcode" begin
     x = categorical([3, missing, 1, 4, missing])
     levels!(x, [4, 1, 3])
-    @test levelindex.(x) ≅ [3, missing, 2, 1, missing]
-    @test levelindex.(x) isa Vector{Union{Missing,Int}}
+    @test levelcode.(x) ≅ [3, missing, 2, 1, missing]
+    @test levelcode.(x) isa Vector{Union{Missing,Int}}
 
     replace!(x, missing=>1)
-    @test levelindex.(x) ≅ [3, 2, 2, 1, 2]
-    @test levelindex.(x) isa Vector{Int}
+    @test levelcode.(x) ≅ [3, 2, 2, 1, 2]
+    @test levelcode.(x) isa Vector{Int}
 
     x = CategoricalVector{Int,UInt8}([3, 0, 1, 4, 0])
     levels!(x, [4, 1, 3, 0])
-    @test levelindex.(x) ≅ [3, 4, 2, 1, 4]
-    @test levelindex.(x) isa Vector{Int16}
+    @test levelcode.(x) ≅ [3, 4, 2, 1, 4]
+    @test levelcode.(x) isa Vector{Int16}
 
     x = CategoricalVector{Union{Missing,Int},UInt8}([3, missing, 1, 4, missing])
     levels!(x, [4, 1, 3])
-    @test levelindex.(x) ≅ [3, missing, 2, 1, missing]
-    @test levelindex.(x) isa Vector{Union{Missing,Int16}}
+    @test levelcode.(x) ≅ [3, missing, 2, 1, missing]
+    @test levelcode.(x) isa Vector{Union{Missing,Int16}}
 end
 
 end

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -1298,7 +1298,7 @@ end
     @test DataAPI.defaultarray(Union{Missing, CategoricalValue{Int, UInt32}}, 1) <: CategoricalArray{Union{Missing, Int},1,UInt32}
 end
 
-@testset "optimized broadcasting with ismissing and levelindex" begin
+@testset "optimized broadcasting with ismissing" begin
     x = categorical([1, missing, 3, 4, missing])
     @test ismissing.(x) == [false, true, false, false, true]
     @test ismissing.(view(x, 2:4)) == [true, false, false]

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -1316,11 +1316,11 @@ end
     x = categorical([3, missing, 1, 4, missing])
     levels!(x, [4, 1, 3])
     @test levelcode.(x) ≅ [3, missing, 2, 1, missing]
-    @test levelcode.(x) isa Vector{Union{Missing,Int}}
+    @test levelcode.(x) isa Vector{Union{Missing,Int64}}
 
     replace!(x, missing=>1)
     @test levelcode.(x) ≅ [3, 2, 2, 1, 2]
-    @test levelcode.(x) isa Vector{Int}
+    @test levelcode.(x) isa Vector{Int64}
 
     x = CategoricalVector{Int,UInt8}([3, 0, 1, 4, 0])
     levels!(x, [4, 1, 3, 0])


### PR DESCRIPTION
Return a `Signed` integer for convenience. This requires widening the type to avoid the risk of overflow, which has the advantage of giving `Int` by default. Also propagate `missing` for convenience.

Closes #228.