### PR TITLE
Make `collect(::CategoricalArray)` return a `CategoricalArray`

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -443,7 +443,8 @@ similar(A::CategoricalArray{S, M, Q}, ::Type{Union{CategoricalValue{T}, Missing}
         dims::NTuple{N, Int}) where {T, N, S, M, Q} =
     CategoricalArray{Union{T, Missing}, N, Q}(undef, dims)
 
-for A in (:Array, :Vector, :Matrix) # to fix ambiguities
+# AbstractRange methods are needed since collect uses 1:1 as dummy array
+for A in (:Array, :Vector, :Matrix, :AbstractRange)
     @eval begin
         similar(A::$A, ::Type{CategoricalValue{T, R}},
                 dims::NTuple{N, Int}=size(A)) where {T, R, N} =
@@ -738,7 +739,7 @@ function in(x::CategoricalValue, y::CategoricalArray{T, N, R}) where {T, N, R}
 end
 
 Array(A::CategoricalArray{T}) where {T} = Array{T}(A)
-collect(A::CategoricalArray{T}) where {T} = Array{T}(A)
+collect(A::CategoricalArray) = copy(A)
 
 function float(A::CategoricalArray{T}) where T
     if !isconcretetype(T)

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -222,6 +222,14 @@ end
         y = similar(Vector{T}, (3,))
         @test isa(y, Vector{T})
         @test size(y) == (3,)
+
+        y = similar(1:1, Union{CategoricalValue{String, UInt8}, T})
+        @test isa(y, CategoricalVector{Union{String, T}, UInt8})
+        @test size(y) == (1,)
+
+        y = similar(1:1, Union{CategoricalValue{String, UInt8}, T}, (3,))
+        @test isa(y, CategoricalVector{Union{String, T}, UInt8})
+        @test size(y) == (3,)
     end
 
     @testset "copy" begin
@@ -1023,18 +1031,20 @@ end
     end
 end
 
-@testset "collect of CategoricalArray produces Array" begin
+@testset "collect of CategoricalArray produces CategoricalArray" begin
     x = [1,1,2,2]
     y = categorical(x)
-    z = collect(y)
-    @test typeof(x) == typeof(z)
-    @test z == x
+    for z in (collect(y), collect(eltype(y), y), collect(Iterators.take(y, 4)))
+        @test typeof(y) == typeof(z)
+        @test z == y == x
+    end
 
     x = [1,1,2,missing]
     y = categorical(x)
-    z = collect(y)
-    @test typeof(x) == typeof(z)
-    @test z ≅ x
+    for z in (collect(y), collect(eltype(y), y), collect(Iterators.take(y, 4)))
+        @test typeof(y) == typeof(z)
+        @test z ≅ y ≅ x
+    end
 end
 
 @testset "Array(::CategoricalArray{T}) produces Array{T}" begin


### PR DESCRIPTION
This fixes an inconsistency, as currently `collect(::Type{<:CategoricalValue}, ::AbstractArray)` returns a `CategoricalArray` but not `collect(::CategoricalArray)`. This is due to the fact that we define `similar` methods for `Array` but not for ranges, which is what `collect` uses internally.

This goes against the `collect` docstring which says that it returns an `Array`, but we need to override some `similar` methods anyway for broadcasting to work (https://github.com/JuliaData/CategoricalArrays.jl/pull/193). This PR is also needed for `NamedArray` to return a `CategoricalArray` from `names`, as it calls `collect(keys(n.dicts[i]))` (https://github.com/nalimilan/FreqTables.jl/pull/46). `collect` seems to be the right abstraction here, but requiring it to return an `Array` is not appropriate in all situations.