### PR TITLE
Add isordered for CategoricalValue

### DIFF
--- a/src/value.jl
+++ b/src/value.jl
@@ -13,6 +13,7 @@ reftype(x::Any) = reftype(typeof(x))
 
 pool(x::CategoricalValue) = x.pool
 level(x::CategoricalValue) = x.level
+isordered(x::CategoricalValue) = isordered(x.pool)
 
 # extract the type of the original value from array eltype `T`
 unwrap_catvaluetype(::Type{T}) where {T} = T

--- a/test/10_isless.jl
+++ b/test/10_isless.jl
@@ -98,6 +98,9 @@ end
 @testset "values from ordered CategoricalPool" begin
     @test ordered!(pool, true) === pool
     @test isordered(pool) === true
+    @test isordered(v1) === true
+    @test isordered(v2) === true
+    @test isordered(v3) === true
 
     @test (v1 < v1) === false
     @test (v1 < v2) === true

--- a/test/10_isless.jl
+++ b/test/10_isless.jl
@@ -9,6 +9,10 @@ v2 = CategoricalValue(2, pool)
 v3 = CategoricalValue(3, pool)
 
 @testset "values from unordered CategoricalPool" begin
+    @test isordered(v1) === false
+    @test isordered(v2) === false
+    @test isordered(v3) === false
+
     @test_throws ArgumentError v1 < v1
     @test_throws ArgumentError v1 < v2
     @test_throws ArgumentError v1 < v3

--- a/test/11_array.jl
+++ b/test/11_array.jl
@@ -14,7 +14,6 @@ using CategoricalArrays: DefaultRefType, leveltype
     @test leveltype(x) === String
     @test eltype(x) === CategoricalValue{String, R}
     @test isordered(x) === ordered
-    @test isordered(x[1]) === ordered
     @test levels(x) == sort(unique(a))
     @test unique(x) == unique(a)
     @test size(x) === (3,)

--- a/test/11_array.jl
+++ b/test/11_array.jl
@@ -14,6 +14,7 @@ using CategoricalArrays: DefaultRefType, leveltype
     @test leveltype(x) === String
     @test eltype(x) === CategoricalValue{String, R}
     @test isordered(x) === ordered
+    @test isordered(x[1]) === ordered
     @test levels(x) == sort(unique(a))
     @test unique(x) == unique(a)
     @test size(x) === (3,)


### PR DESCRIPTION
As discussed on slack, CategoricalValue can benefit from a `isordered` trait like CategoricalArrays.