### PR TITLE
Make `fill(v::CategoricalValue, ...)` return a `CategoricalArray`

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -383,6 +383,17 @@ end
     @inbounds A.refs[I...] = get!(A.pool, v)
 end
 
+function Base.fill(v::CategoricalValue{T, R}, dims::NTuple{N, Integer}) where {T, R, N}
+    A = CategoricalArray{T, N, R}(undef, dims)
+    merge_pools!(A, v, updaterefs=false)
+    fill!(A.refs, get!(A.pool, v))
+    A
+end
+
+# to avoid ambiguity
+Base.fill(v::CategoricalValue, dims::Tuple{}) =
+    invoke(fill, Tuple{CategoricalValue{T}, NTuple{N, Integer}} where {T, N}, v, dims)
+
 function Base.fill!(A::CategoricalArray, v::Any)
     # TODO: use a global table to cache subset relations for all pairs of pools
     if v isa CategoricalValue && pool(v) !== pool(A) && pool(v) ⊈ pool(A)

--- a/src/array.jl
+++ b/src/array.jl
@@ -383,12 +383,8 @@ end
     @inbounds A.refs[I...] = get!(A.pool, v)
 end
 
-function Base.fill(v::CategoricalValue{T, R}, dims::NTuple{N, Integer}) where {T, R, N}
-    A = CategoricalArray{T, N, R}(undef, dims)
-    merge_pools!(A, v, updaterefs=false)
-    fill!(A.refs, get!(A.pool, v))
-    A
-end
+Base.fill(v::CategoricalValue{T}, dims::NTuple{N, Integer}) where {T, N} =
+    CategoricalArray{T, N}(fill(level(v), dims), copy(pool(v)))
 
 # to avoid ambiguity
 Base.fill(v::CategoricalValue, dims::Tuple{}) =

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -1643,7 +1643,7 @@ end
 end
 
 @testset "fill()" begin
-    for ordered in (false, true), dims in ([1], [2, 3], [(2, 3)], [])
+    for ordered in (false, true), dims in ([1], [(1,)], [2, 3], [(2, 3)], [], [()])
         x = CategoricalArray{String, 1, UInt8}(["a", "b", "c"],
                                             ordered=ordered)
 

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -1642,4 +1642,18 @@ end
     @test levelcode.(x) isa Vector{Union{Missing,Int16}}
 end
 
+@testset "fill()" begin
+    for ordered in (false, true), dims in ([1], [2, 3], [(2, 3)], [])
+        x = CategoricalArray{String, 1, UInt8}(["a", "b", "c"],
+                                            ordered=ordered)
+
+        y = fill(x[1], dims...)
+        yref = fill("a", dims...)
+        @test y == yref
+        @test y isa CategoricalArray{String, ndims(yref), UInt8}
+        @test levels(y) == levels(x)
+        @test isordered(y) === isordered(x)
+    end
+end
+
 end


### PR DESCRIPTION
This is more useful and more efficient, and it's in line with the docstring for `fill`.

Fixes #249.