### PR TITLE
Rename allow_missing to allowmissing, fix bug in `cut`

### DIFF
--- a/docs/src/using.md
+++ b/docs/src/using.md
@@ -171,7 +171,7 @@ missing
 
 ```
 
-It is also possible to transform all values belonging to some levels into missing values, which gives the same result as above in the present case since we have only one individual in the `"Old"` group. Let's first restore the original value for the first element, and then set it to missing again using the `allow_missing` argument to `levels!`:
+It is also possible to transform all values belonging to some levels into missing values, which gives the same result as above in the present case since we have only one individual in the `"Old"` group. Let's first restore the original value for the first element, and then set it to missing again using the `allowmissing` argument to `levels!`:
 
 ```jldoctest using
 julia> y[1] = "Old"
@@ -184,7 +184,7 @@ julia> y
  "Middle"
  "Young" 
 
-julia> levels!(y, ["Young", "Middle"]; allow_missing=true)
+julia> levels!(y, ["Young", "Middle"]; allowmissing=true)
 4-element CategoricalArray{Union{Missing, String},1,UInt32}:
  missing
  "Young" 

--- a/src/subarray.jl
+++ b/src/subarray.jl
@@ -2,7 +2,7 @@
 
 DataAPI.levels(sa::SubArray{T,N,P}) where {T,N,P<:CategoricalArray} = levels(parent(sa))
 isordered(sa::SubArray{T,N,P}) where {T,N,P<:CategoricalArray} = isordered(parent(sa))
-# This method cannot support allow_missing=true since that would modify the parent
+# This method cannot support allowmissing=true since that would modify the parent
 levels!(sa::SubArray{T,N,P}, newlevels::Vector) where {T,N,P<:CategoricalArray} =
     levels!(parent(sa), newlevels)
 

--- a/test/12_missingarray.jl
+++ b/test/12_missingarray.jl
@@ -196,7 +196,7 @@ const ≅ = isequal
                 @test levels(x) == ["e", "a", "b", "c"]
 
                 @test_throws ArgumentError levels!(x, ["e", "c"])
-                @test levels!(x, ["e", "c"], allow_missing=true) === x
+                @test levels!(x, ["e", "c"], allowmissing=true) === x
                 @test levels(x) == ["e", "c"]
                 @test x[1] === x.pool.valindex[2]
                 @test x[2] === missing

--- a/test/15_extras.jl
+++ b/test/15_extras.jl
@@ -13,7 +13,7 @@ const ≅ = isequal
 
     err = @test_throws ArgumentError cut(Vector{Union{T, Int}}([2, 3, 5]), [3, 6])
     if T === Missing
-        @test err.value.msg == "value 2 (at index 1) does not fall inside the breaks: adapt them manually, or pass extend=true or allow_missing=true"
+        @test err.value.msg == "value 2 (at index 1) does not fall inside the breaks: adapt them manually, or pass extend=true or allowmissing=true"
     else
         @test err.value.msg == "value 2 (at index 1) does not fall inside the breaks: adapt them manually, or pass extend=true"
     end
@@ -21,19 +21,19 @@ const ≅ = isequal
 
     err = @test_throws ArgumentError cut(Vector{Union{T, Int}}([2, 3, 5]), [2, 5])
     if T === Missing
-        @test err.value.msg == "value 5 (at index 3) does not fall inside the breaks: adapt them manually, or pass extend=true or allow_missing=true"
+        @test err.value.msg == "value 5 (at index 3) does not fall inside the breaks: adapt them manually, or pass extend=true or allowmissing=true"
     else
         @test err.value.msg == "value 5 (at index 3) does not fall inside the breaks: adapt them manually, or pass extend=true"
     end
 
     if T === Missing
-        x = @inferred cut(Vector{Union{T, Int}}([2, 3, 5]), [2, 5], allow_missing=true)
+        x = @inferred cut(Vector{Union{T, Int}}([2, 3, 5]), [2, 5], allowmissing=true)
         @test x ≅ ["[2, 5)", "[2, 5)", missing]
         @test isa(x, CategoricalVector{Union{String, T}})
         @test isordered(x)
         @test levels(x) == ["[2, 5)"]
     else
-        err = @test_throws ArgumentError cut(Vector{Int}([2, 3, 5]), [2, 5], allow_missing=true)
+        err = @test_throws ArgumentError cut(Vector{Int}([2, 3, 5]), [2, 5], allowmissing=true)
         @test err.value.msg == "value 5 (at index 3) does not fall inside the breaks: adapt them manually, or pass extend=true"
     end
 
@@ -96,6 +96,14 @@ const ≅ = isequal
     @test isa(x, CategoricalMatrix{Union{String, T}})
     @test isordered(x)
     @test levels(x) == ["[-2.134, 3.0)", "[3.0, 12.5)"]
+end
+
+@testset "cut with missing values in input" begin
+    # use a large vector since values can be zero by chance
+    x = [1; fill(missing, 100)]
+    y = cut(x, [1, 5])
+    y[1] = missing
+    @test all(ismissing, y)
 end
 
 # TODO: test on arrays supporting missing values once a quantile() method is provided for them

--- a/test/17_deprecated.jl
+++ b/test/17_deprecated.jl
@@ -2,6 +2,8 @@ module TestExtras
 using Test
 using CategoricalArrays
 
+const ≅ = isequal
+
 @testset "categorical" begin
     for ord in (false, true)
         x = categorical(["a"], true; ordered=ord)
@@ -14,6 +16,15 @@ using CategoricalArrays
         @test x == ["a"]
         @test isordered(x) === ord
     end
+end
+
+@testset "allow_missing argument" begin
+    x = categorical(["a", "b", missing])
+    levels!(x, ["a"], allow_missing=true)
+    @test x ≅ ["a", missing, missing]
+
+    x = cut([1, missing, 100], [1, 2], allow_missing=true)
+    @test x ≅ ["[1, 2)", missing, missing]
 end
 
 end


### PR DESCRIPTION
That's more consistent with `allowmissing` in Missings.
Also fix a bug in `cut`: missing values in input where left unitialized (most of the time they were correctly set to `missing` because the memory was zeroed, but they could also end up undefined, or any valid level).