### PR TITLE
Fix droplevels!

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -765,23 +765,13 @@ since it needs to check whether levels are used or not.
 """
 unique(A::CategoricalArray{T}) where {T} = _unique(T, A.refs, A.pool)
 
-if VERSION >= v"0.7.0-DEV.4882"
-    """
-        droplevels!(A::CategoricalArray)
+"""
+    droplevels!(A::CategoricalArray)
 
-    Drop levels which do not appear in categorical array `A` (so that they will no longer be
-    returned by [`levels`](@ref)).
-    """
-    droplevels!(A::CategoricalArray) = levels!(A, intersect!(levels(A), unique(A)))
-else # intersect! method missing on Julia 0.6
-    """
-        droplevels!(A::CategoricalArray)
-
-    Drop levels which do not appear in categorical array `A` (so that they will no longer be
-    returned by [`levels`](@ref)).
-    """
-    droplevels!(A::CategoricalArray) = levels!(A, intersect(levels(A), filter!(!ismissing, unique(A))))
-end
+Drop levels which do not appear in categorical array `A` (so that they will no longer be
+returned by [`levels`](@ref)).
+"""
+droplevels!(A::CategoricalArray) = levels!(A, intersect(levels(A), unique(A)))
 
 """
     isordered(A::CategoricalArray)

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -1377,6 +1377,9 @@ end
     x[2] = "a"
     @test droplevels!(x) === x
     @test levels(x) == ["c", "a"]
+    x .= "a"
+    @test droplevels!(x) === x
+    @test levels(x) == ["a"]
 end
 
 @testset "show" begin


### PR DESCRIPTION
Since the `index` field has been removed, `levels` is the only place where we can know the levels of the array. Computing the intersection in place means that we are no longer able to detect whether levels have been removed at the front.