### PR TITLE
Fix copyto! when source and destination levels are equal

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -534,7 +534,7 @@ function copyto!(dest::CatArrOrSub{T, N, R}, dstart::Integer,
     # If destination levels are an ordered superset of source, no need to recompute refs
     if length(dlevs) >= length(slevs) && view(dlevs, 1:length(slevs)) == slevs
         newlevels != dlevs && levels!(dpool, newlevels)
-        copyto!(drefs, srefs)
+        copyto!(drefs, dstart, srefs, sstart, n)
     else # Otherwise, recompute refs according to new levels
         # Then adjust refs from source
         levelsmap = similar(drefs, length(slevs)+1)

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -636,6 +636,20 @@ end
             dest = CategoricalVector{UInt}(undef, 3)
             @test_throws InexactError copyf!(dest, src)
         end
+
+        @testset "partial copyto! between arrays with identical levels" begin
+            v = ["a", "b", "c"]
+            src = CategoricalVector{Union{eltype(v), Missing}}(v)
+            levels!(src, reverse(v))
+            dest = CategoricalVector{Union{eltype(v), Missing}}(fill(missing, 6))
+            levels!(dest, levels(src))
+            copyto!(dest, 3, src)
+            @test dest ≅ [missing, missing, "a", "b", "c", missing]
+            @test levels(dest) == levels(src) == reverse(v)
+            copyto!(dest, 3, src, 2, 1)
+            @test dest ≅ [missing, missing, "b", "b", "c", missing]
+            @test levels(dest) == levels(src) == reverse(v)
+        end
     end
 
     @testset "assigning into array with empty levels uses orderedness of source" begin


### PR DESCRIPTION
The fast path for that case did not take into account the start index nor the number of elements to copy.