### PR TITLE
Fix sort with unused levels

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -946,7 +946,7 @@ function Base.sort!(v::CategoricalVector;
     seen = counts .> 0
     anymissing = eltype(v) >: Missing && seen[1]
     levs = eltype(v) >: Missing ? [missing; v.pool.valindex] : v.pool.valindex
-    sortedlevs = sort(Vector(view(levs, seen)), order=ord)
+    sortedlevs = sort!(Vector(view(levs, seen)), order=ord)
     levelsmap = something.(indexin(sortedlevs, levs))
     j = 0
     refs = v.refs

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -926,7 +926,11 @@ end
             cv = categorical(v)
             levels!(cv, ["b", "a", "c", "d"])
             @test sort(cv, rev=rev) ≅
-                ["b", "a", "c", "d", missing][sort([5, 1, 2, 3, 4][cv.refs .+ 1], rev=rev)]
+                ["b", "a", "c", "d", missing][sort([5; 1:4][cv.refs .+ 1], rev=rev)]
+
+            levels!(cv, ["x", "z", "b", "a", "y", "c", "d", "0"])
+            @test sort(cv, rev=rev) ≅
+                ["x", "z", "b", "a", "y", "c", "d", "0", missing][sort([9; 1:8][cv.refs .+ 1], rev=rev)]
 
             cv = categorical(v)
             @test sort(cv, rev=rev, lt=(x, y) -> isless(y, x)) ≅


### PR DESCRIPTION
The code did not handle correctly the case when unused levels were present at the front.
This seems to have become easier to trigger since the index vs. levels distinction was dropped.

Fixes #269.