### PR TITLE
Changed recode to accept more general collection types

### DIFF
--- a/src/recode.jl
+++ b/src/recode.jl
@@ -42,10 +42,9 @@ recode!(dest::CategoricalArray, src::CategoricalArray, pairs::Pair...) =
 
 Helper function to test if `x` is a member of `collection`.
 
-If `collection` is a collection type without `missing` elements, the 
-`in` function is used. If `collection` contains a `missing element`, every
-element is tested using the `isequal` function. This ensures that `missing`
-doesn't trigger an error.
+The default method is to test if any element in the `collection` `isequal` to
+`x`. For sets using `in` should be faster than the default method.
+A user defined type could override this method to define an appropriate test function.
 """
 @inline recode_in(x, ::Missing) = false
 @inline recode_in(x, ::AbstractString) = false
@@ -63,8 +62,7 @@ function recode!(dest::AbstractArray{T}, src::AbstractArray, default::Any, pairs
 
         for j in 1:length(pairs)
             p = pairs[j]
-            # if p.first is a collection-type, `isequal` returns false.
-            # if p.first is not a collection-type, `in` returns false (except for AbstractString, which gives an error)
+            # we use isequal and recode_in because we cannot really distinguish scalars from collections
             if (x ≅ p.first || recode_in(x, p.first))
                 dest[i] = p.second
                 @goto nextitem
@@ -117,8 +115,7 @@ function recode!(dest::CategoricalArray{T}, src::AbstractArray, default::Any, pa
 
         for j in 1:length(pairs)
             p = pairs[j]
-            # if p.first is a collection-type, `isequal` returns false.
-            # if p.first is not a collection-type, `recode_in` returns false
+            # we use isequal and recode_in because we cannot really distinguish scalars from collections
             if (x ≅ p.first || recode_in(x, p.first))
                 drefs[i] = dupvals ? pairmap[j] : j
                 @goto nextitem

--- a/src/recode.jl
+++ b/src/recode.jl
@@ -42,10 +42,10 @@ recode!(dest::CategoricalArray, src::CategoricalArray, pairs::Pair...) =
 
 Helper function to test if `x` is a member of `collection`.
 
-If collection is a regular collection-type without missing elements the 
-`in`-function is used. If collection contains a missing element, every
-element is tested using the isequal function. This ensures that missing
-is treated as a valid value.
+If `collection` is a collection type without `missing` elements, the 
+`in` function is used. If `collection` contains a `missing element`, every
+element is tested using the `isequal` function. This ensures that `missing`
+doesn't trigger an error.
 """
 @inline recode_in(x, ::Missing) = false
 @inline recode_in(x, ::AbstractString} = false

--- a/src/recode.jl
+++ b/src/recode.jl
@@ -40,7 +40,7 @@ recode!(dest::CategoricalArray, src::CategoricalArray, pairs::Pair...) =
 """
     recode_in(x, collection)
 
-Helper function to test if x is a member of the collection.
+Helper function to test if `x` is a member of `collection`.
 
 If collection is a regular collection-type without missing elements the 
 `in`-function is used. If collection contains a missing element, every

--- a/src/recode.jl
+++ b/src/recode.jl
@@ -48,7 +48,7 @@ element is tested using the isequal function. This ensures that missing
 is treated as a valid value.
 """
 @inline recode_in(x, ::Missing) = false
-@inline recode_in(x, ::T) where {T<:AbstractString} = false
+@inline recode_in(x, ::AbstractString} = false
 @inline function recode_in(x, collection)
     if ismissing(x) || eltype(collection) >: Missing
         return any(x ≅ y for y in collection)

--- a/src/recode.jl
+++ b/src/recode.jl
@@ -48,7 +48,8 @@ element is tested using the `isequal` function. This ensures that `missing`
 doesn't trigger an error.
 """
 @inline recode_in(x, ::Missing) = false
-@inline recode_in(x, ::AbstractString} = false
+@inline recode_in(x, ::AbstractString) = false
+@inline recode_in(x, collection::Set) = x in collection
 @inline function recode_in(x, collection)
     if ismissing(x) || eltype(collection) >: Missing
         return any(x ≅ y for y in collection)
@@ -190,7 +191,7 @@ function recode!(dest::CategoricalArray{T, N, R}, src::CategoricalArray,
 
         for l in srclevels
             if !(any(x -> x ≅ l, firsts) ||
-                 any(f -> (!isa(f, AbstractString) && !ismissing(f) && any(l ≅ y for y in f)), firsts))
+                 any(f -> recode_in(l, f), firsts))
                 try
                     push!(keptlevels, l)
                 catch err
@@ -237,7 +238,7 @@ function recode!(dest::CategoricalArray{T, N, R}, src::CategoricalArray,
     @inbounds for (i, l) in enumerate(srclevels)
         for j in 1:length(pairs)
             p = pairs[j]
-            if (l ≅ p.first || (!isa(p.first, AbstractString) && !ismissing(p.first) && any(l ≅ y for y in p.first)))
+            if (l ≅ p.first || recode_in(l, p.first))
                 levelsmap[i+1] = pairmap[j]
                 @goto nextitem
             end

--- a/src/recode.jl
+++ b/src/recode.jl
@@ -50,13 +50,7 @@ doesn't trigger an error.
 @inline recode_in(x, ::Missing) = false
 @inline recode_in(x, ::AbstractString) = false
 @inline recode_in(x, collection::Set) = x in collection
-@inline function recode_in(x, collection)
-    if ismissing(x) || eltype(collection) >: Missing
-        return any(x ≅ y for y in collection)
-    else
-        return x in collection
-    end
-end
+@inline recode_in(x, collection) = any(x ≅ y for y in collection)
 
 
 function recode!(dest::AbstractArray{T}, src::AbstractArray, default::Any, pairs::Pair...) where {T}
@@ -124,7 +118,7 @@ function recode!(dest::CategoricalArray{T}, src::AbstractArray, default::Any, pa
         for j in 1:length(pairs)
             p = pairs[j]
             # if p.first is a collection-type, `isequal` returns false.
-            # if p.first is not a collection-type, `in` returns false (except for AbstractString, which gives an error)
+            # if p.first is not a collection-type, `recode_in` returns false
             if (x ≅ p.first || recode_in(x, p.first))
                 drefs[i] = dupvals ? pairmap[j] : j
                 @goto nextitem

--- a/src/recode.jl
+++ b/src/recode.jl
@@ -36,21 +36,18 @@ recode!(dest::CategoricalArray, src::AbstractArray, pairs::Pair...) =
 recode!(dest::CategoricalArray, src::CategoricalArray, pairs::Pair...) =
     recode!(dest, src, nothing, pairs...)
 
-
 """
     recode_in(x, collection)
 
 Helper function to test if `x` is a member of `collection`.
 
 The default method is to test if any element in the `collection` `isequal` to
-`x`. For sets using `in` should be faster than the default method.
+`x`. For `Set`s `in` is used as it is faster than the default method and equivalent to it.
 A user defined type could override this method to define an appropriate test function.
 """
 @inline recode_in(x, ::Missing) = false
-@inline recode_in(x, ::AbstractString) = false
 @inline recode_in(x, collection::Set) = x in collection
 @inline recode_in(x, collection) = any(x ≅ y for y in collection)
-
 
 function recode!(dest::AbstractArray{T}, src::AbstractArray, default::Any, pairs::Pair...) where {T}
     if length(dest) != length(src)
@@ -63,7 +60,7 @@ function recode!(dest::AbstractArray{T}, src::AbstractArray, default::Any, pairs
         for j in 1:length(pairs)
             p = pairs[j]
             # we use isequal and recode_in because we cannot really distinguish scalars from collections
-            if (x ≅ p.first || recode_in(x, p.first))
+            if x ≅ p.first || recode_in(x, p.first)
                 dest[i] = p.second
                 @goto nextitem
             end
@@ -116,7 +113,7 @@ function recode!(dest::CategoricalArray{T}, src::AbstractArray, default::Any, pa
         for j in 1:length(pairs)
             p = pairs[j]
             # we use isequal and recode_in because we cannot really distinguish scalars from collections
-            if (x ≅ p.first || recode_in(x, p.first))
+            if x ≅ p.first || recode_in(x, p.first)
                 drefs[i] = dupvals ? pairmap[j] : j
                 @goto nextitem
             end
@@ -229,7 +226,7 @@ function recode!(dest::CategoricalArray{T, N, R}, src::CategoricalArray,
     @inbounds for (i, l) in enumerate(srclevels)
         for j in 1:length(pairs)
             p = pairs[j]
-            if (l ≅ p.first || recode_in(l, p.first))
+            if l ≅ p.first || recode_in(l, p.first)
                 levelsmap[i+1] = pairmap[j]
                 @goto nextitem
             end

--- a/test/16_recode.jl
+++ b/test/16_recode.jl
@@ -9,6 +9,46 @@ end
 
 const ≅ = isequal
 
+@testset "recode_in" begin
+    @testset "collection is a string" begin
+        @test !CategoricalArrays.recode_in("a", "ab")
+        @test !CategoricalArrays.recode_in(missing, "b")
+    end
+    @testset "collection without missing" begin
+        @test CategoricalArrays.recode_in(1, [1, 2])
+        @test !CategoricalArrays.recode_in(1, [2, 3])
+    end
+    @testset "collection with missing" begin
+        @test CategoricalArrays.recode_in(1, [1, 2, missing])
+        @test !CategoricalArrays.recode_in(1, [2, missing])
+        @test CategoricalArrays.recode_in(missing, [1, 2, missing])
+    end
+    @testset "collection is a single value" begin
+        @test CategoricalArrays.recode_in(1, 1)
+        @test !CategoricalArrays.recode_in(1, missing)
+        @test !CategoricalArrays.recode_in(missing, missing)
+    end
+    @testset "tuple without missing" begin
+        @test CategoricalArrays.recode_in(1, (1, 2))
+        @test !CategoricalArrays.recode_in(1, (2, 3))
+    end
+    @testset "tuple with missing" begin
+        @test CategoricalArrays.recode_in(1, (1, 2, missing))
+        @test !CategoricalArrays.recode_in(1, (2, missing))
+        @test CategoricalArrays.recode_in(missing, (1, 2, missing))
+    end
+    @testset "nested arrays" begin
+        @test CategoricalArrays.recode_in([1,2], [[1, 2], [3, 4]])
+        @test !CategoricalArrays.recode_in([1, 3], [[1, 2], [3, 4]])
+    end
+    @testset "NaN in array" begin
+        @test CategoricalArrays.recode_in(NaN, [1, 2, NaN])
+        @test !CategoricalArrays.recode_in(NaN, [1, 2, 3])
+        @test CategoricalArrays.recode_in(2, [1, 2, NaN])
+        @test !CategoricalArrays.recode_in(3, [1, 2, NaN])
+    end
+end
+
 ## Test recode!, used by recode
 
 # Test both recoding into x itself and into an uninitialized vector
@@ -26,27 +66,6 @@ const ≅ = isequal
     if isa(y, CategoricalArray)
         @test levels(y) == [6, 7, 8, 100, 0, -1]
         @test !isordered(y)
-    end
-end
-
-@testset "recode_in" begin
-    @testset "collection is a string" begin
-        @test CategoricalArrays.recode_in("a", "b") == false
-        @test CategoricalArrays.recode_in(missing, "b") == false
-    end
-    @testset "collection without missing" begin
-        @test CategoricalArrays.recode_in(1, [1, 2]) == true
-        @test CategoricalArrays.recode_in(1, [2, 3]) == false
-    end
-    @testset "collection with missing" begin
-        @test CategoricalArrays.recode_in(1, [1, 2, missing]) == true
-        @test CategoricalArrays.recode_in(1, [2, missing]) == false
-        @test CategoricalArrays.recode_in(missing, [1, 2, missing]) == true
-    end
-    @testset "collection is a single value" begin
-        @test CategoricalArrays.recode_in(1, 1) == true
-        @test CategoricalArrays.recode_in(1, missing) == false
-        @test CategoricalArrays.recode_in(missing, missing) == false
     end
 end
 

--- a/test/16_recode.jl
+++ b/test/16_recode.jl
@@ -12,6 +12,8 @@ const ≅ = isequal
 @testset "recode_in" begin
     @testset "collection is a string" begin
         @test !CategoricalArrays.recode_in("a", "ab")
+        @test CategoricalArrays.recode_in('a', "ab")
+        @test !CategoricalArrays.recode_in('c', "ab")
         @test !CategoricalArrays.recode_in(missing, "b")
     end
     @testset "collection without missing" begin


### PR DESCRIPTION
The first element in a Pair for recoding can now be anything that
behaves like a collection and supports `in`.