### PR TITLE
Add canonical URL to manual

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,7 +8,7 @@ end
 makedocs(
     modules = [CategoricalArrays],
     sitename = "CategoricalArrays",
-    format = Documenter.HTML(canonical = "https://juliadata.github.io/CategoricalArrays.jl/stable/")
+    format = Documenter.HTML(canonical = "https://juliadata.github.io/CategoricalArrays.jl/stable/"))
     pages = Any[
         "Overview" => "index.md",
         "Using CategoricalArrays" => "using.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,6 +8,7 @@ end
 makedocs(
     modules = [CategoricalArrays],
     sitename = "CategoricalArrays",
+    format = Documenter.HTML(canonical = "https://juliadata.github.io/CategoricalArrays.jl/stable/")
     pages = Any[
         "Overview" => "index.md",
         "Using CategoricalArrays" => "using.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,7 +8,7 @@ end
 makedocs(
     modules = [CategoricalArrays],
     sitename = "CategoricalArrays",
-    format = Documenter.HTML(canonical = "https://juliadata.github.io/CategoricalArrays.jl/stable/"))
+    format = Documenter.HTML(canonical = "https://juliadata.github.io/CategoricalArrays.jl/stable/"),
     pages = Any[
         "Overview" => "index.md",
         "Using CategoricalArrays" => "using.md",


### PR DESCRIPTION
This prevents older releases and development releases from being indexed by search engines.