### PR TITLE
Fix `convert` ambiguity between categorical vectors/matrices

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -292,6 +292,9 @@ convert(::Type{CategoricalVector{T}}, A::AbstractVector) where {T} =
     convert(CategoricalVector{T, DefaultRefType}, A)
 convert(::Type{CategoricalVector}, A::AbstractVector{T}) where {T} =
     convert(CategoricalVector{T}, A)
+convert(::Type{CategoricalVector{T}},
+        A::CategoricalVector{S, R}) where {S, T, R <: Integer} =
+    convert(CategoricalVector{T, R}, A)
 convert(::Type{CategoricalVector{T}}, A::CategoricalVector{T}) where {T} = A
 convert(::Type{CategoricalVector}, A::CategoricalVector) = A
 
@@ -299,6 +302,9 @@ convert(::Type{CategoricalMatrix{T}}, A::AbstractMatrix) where {T} =
     convert(CategoricalMatrix{T, DefaultRefType}, A)
 convert(::Type{CategoricalMatrix}, A::AbstractMatrix{T}) where {T} =
     convert(CategoricalMatrix{T}, A)
+convert(::Type{CategoricalMatrix{T}},
+        A::CategoricalMatrix{S, R}) where {S, T, R <: Integer} =
+    convert(CategoricalMatrix{T, R}, A)
 convert(::Type{CategoricalMatrix{T}}, A::CategoricalMatrix{T}) where {T} = A
 convert(::Type{CategoricalMatrix}, A::CategoricalMatrix) = A
 

--- a/test/11_array.jl
+++ b/test/11_array.jl
@@ -57,6 +57,28 @@ using CategoricalArrays: DefaultRefType, leveltype
     @test CategoricalVector{String, DefaultRefType}(a, ordered=ordered) == x
     @test CategoricalVector{String, UInt8}(a, ordered=ordered) == x
 
+    @test convert(CategoricalArray{Union{String, Missing}}, x) == x
+    @test convert(CategoricalArray{Union{String, Missing}, 1}, x) == x
+    @test convert(CategoricalArray{Union{String, Missing}, 1, R}, x) == x
+    @test convert(CategoricalArray{Union{String, Missing}, 1, DefaultRefType}, x) == x
+    @test convert(CategoricalArray{Union{String, Missing}, 1, UInt8}, x) == x
+
+    @test convert(CategoricalVector{Union{String, Missing}}, x) == x
+    @test convert(CategoricalVector{Union{String, Missing}, R}, x) == x
+    @test convert(CategoricalVector{Union{String, Missing}, DefaultRefType}, x) == x
+    @test convert(CategoricalVector{Union{String, Missing}, UInt8}, x) == x
+
+    @test CategoricalArray{Union{String, Missing}}(x, ordered=ordered) == x
+    @test CategoricalArray{Union{String, Missing}, 1}(x, ordered=ordered) == x
+    @test CategoricalArray{Union{String, Missing}, 1, R}(x, ordered=ordered) == x
+    @test CategoricalArray{Union{String, Missing}, 1, DefaultRefType}(x, ordered=ordered) == x
+    @test CategoricalArray{Union{String, Missing}, 1, UInt8}(x, ordered=ordered) == x
+
+    @test CategoricalVector{Union{String, Missing}}(x, ordered=ordered) == x
+    @test CategoricalVector{Union{String, Missing}, R}(x, ordered=ordered) == x
+    @test CategoricalVector{Union{String, Missing}, DefaultRefType}(x, ordered=ordered) == x
+    @test CategoricalVector{Union{String, Missing}, UInt8}(x, ordered=ordered) == x
+
     @testset "categorical($(typeof(y)), compress=$comp) R1=$R1 R2=$R2" for (y, R1, R2, comp) in
         ((a, DefaultRefType, UInt8, true),
          (a, DefaultRefType, DefaultRefType, false),
@@ -229,9 +251,13 @@ using CategoricalArrays: DefaultRefType, leveltype
 
         @test convert(CategoricalVector, x) === x
         @test convert(CategoricalVector{Float64}, x) === x
+        @test convert(CategoricalVector{Float32}, x) == x
         @test convert(CategoricalVector{Float64, R}, x) === x
+        @test convert(CategoricalVector{Float32, R}, x) == x
         @test convert(CategoricalVector{Float64, DefaultRefType}, x) == x
+        @test convert(CategoricalVector{Float32, DefaultRefType}, x) == x
         @test convert(CategoricalVector{Float64, UInt8}, x) == x
+        @test convert(CategoricalVector{Float32, UInt8}, x) == x
 
         @test convert(CategoricalArray, a) == x
         @test convert(CategoricalArray{Float64}, a) == x
@@ -271,6 +297,42 @@ using CategoricalArrays: DefaultRefType, leveltype
         @test CategoricalVector{Float32, R}(a, ordered=ordered) == x
         @test CategoricalVector{Float64, DefaultRefType}(a, ordered=ordered) == x
         @test CategoricalVector{Float32, DefaultRefType}(a, ordered=ordered) == x
+
+        @test convert(CategoricalArray{Union{Float64, Missing}}, x) == x
+        @test convert(CategoricalArray{Union{Float32, Missing}}, x) == x
+        @test convert(CategoricalArray{Union{Float64, Missing}, 1}, x) == x
+        @test convert(CategoricalArray{Union{Float32, Missing}, 1}, x) == x
+        @test convert(CategoricalArray{Union{Float64, Missing}, 1, R}, x) == x
+        @test convert(CategoricalArray{Union{Float32, Missing}, 1, R}, x) == x
+        @test convert(CategoricalArray{Union{Float64, Missing}, 1, DefaultRefType}, x) == x
+        @test convert(CategoricalArray{Union{Float32, Missing}, 1, DefaultRefType}, x) == x
+        @test convert(CategoricalArray{Union{Float64, Missing}, 1, UInt8}, x) == x
+        @test convert(CategoricalArray{Union{Float32, Missing}, 1, UInt8}, x) == x
+
+        @test convert(CategoricalVector{Union{Float64, Missing}}, x) == x
+        @test convert(CategoricalVector{Union{Float32, Missing}}, x) == x
+        @test convert(CategoricalVector{Union{Float64, Missing}, R}, x) == x
+        @test convert(CategoricalVector{Union{Float32, Missing}, R}, x) == x
+        @test convert(CategoricalVector{Union{Float64, Missing}, DefaultRefType}, x) == x
+        @test convert(CategoricalVector{Union{Float32, Missing}, DefaultRefType}, x) == x
+        @test convert(CategoricalVector{Union{Float64, Missing}, UInt8}, x) == x
+        @test convert(CategoricalVector{Union{Float32, Missing}, UInt8}, x) == x
+
+        @test CategoricalArray{Union{Float64, Missing}}(x, ordered=ordered) == x
+        @test CategoricalArray{Union{Float32, Missing}}(x, ordered=ordered) == x
+        @test CategoricalArray{Union{Float64, Missing}, 1}(x, ordered=ordered) == x
+        @test CategoricalArray{Union{Float32, Missing}, 1}(x, ordered=ordered) == x
+        @test CategoricalArray{Union{Float64, Missing}, 1, R}(x, ordered=ordered) == x
+        @test CategoricalArray{Union{Float32, Missing}, 1, R}(x, ordered=ordered) == x
+        @test CategoricalArray{Union{Float64, Missing}, 1, DefaultRefType}(x, ordered=ordered) == x
+        @test CategoricalArray{Union{Float32, Missing}, 1, DefaultRefType}(x, ordered=ordered) == x
+
+        @test CategoricalVector{Union{Float64, Missing}}(x, ordered=ordered) == x
+        @test CategoricalVector{Union{Float32, Missing}}(x, ordered=ordered) == x
+        @test CategoricalVector{Union{Float64, Missing}, R}(x, ordered=ordered) == x
+        @test CategoricalVector{Union{Float32, Missing}, R}(x, ordered=ordered) == x
+        @test CategoricalVector{Union{Float64, Missing}, DefaultRefType}(x, ordered=ordered) == x
+        @test CategoricalVector{Union{Float32, Missing}, DefaultRefType}(x, ordered=ordered) == x
 
         @testset "categorical($(typeof(y)), compress=$comp) R1=$R1 R2=$R2" for (y, R1, R2, comp) in
             ((a, DefaultRefType, UInt8, true),
@@ -422,6 +484,28 @@ using CategoricalArrays: DefaultRefType, leveltype
         @test CategoricalMatrix{String, R}(a, ordered=ordered) == x
         @test CategoricalMatrix{String, DefaultRefType}(a, ordered=ordered) == x
         @test CategoricalMatrix{String, UInt8}(a, ordered=ordered) == x
+
+        @test convert(CategoricalArray{Union{String, Missing}}, x) == x
+        @test convert(CategoricalArray{Union{String, Missing}, 2, R}, x) == x
+        @test convert(CategoricalArray{Union{String, Missing}, 2, DefaultRefType}, x) == x
+        @test convert(CategoricalArray{Union{String, Missing}, 2, UInt8}, x) == x
+
+        @test convert(CategoricalMatrix{Union{String, Missing}}, x) == x
+        @test convert(CategoricalMatrix{Union{String, Missing}, R}, x) == x
+        @test convert(CategoricalMatrix{Union{String, Missing}, DefaultRefType}, x) == x
+        @test convert(CategoricalMatrix{Union{String, Missing}, UInt8}, x) == x
+
+        @test CategoricalArray{Union{String, Missing}}(x, ordered=ordered) == x
+        @test CategoricalArray{Union{String, Missing}, 2}(x, ordered=ordered) == x
+        @test CategoricalArray{Union{String, Missing}, 2}(x, ordered=ordered) == x
+        @test CategoricalArray{Union{String, Missing}, 2, R}(x, ordered=ordered) == x
+        @test CategoricalArray{Union{String, Missing}, 2, DefaultRefType}(x, ordered=ordered) == x
+        @test CategoricalArray{Union{String, Missing}, 2, UInt8}(x, ordered=ordered) == x
+
+        @test CategoricalMatrix{Union{String, Missing}}(x, ordered=ordered) == x
+        @test CategoricalMatrix{Union{String, Missing}, R}(x, ordered=ordered) == x
+        @test CategoricalMatrix{Union{String, Missing}, DefaultRefType}(x, ordered=ordered) == x
+        @test CategoricalMatrix{Union{String, Missing}, UInt8}(x, ordered=ordered) == x
 
         @testset "categorical($(typeof(y)), compress=$comp) R1=$R1 R2=$R2" for (y, R1, R2, comp) in
             ((a, DefaultRefType, UInt8, true),

--- a/test/12_missingarray.jl
+++ b/test/12_missingarray.jl
@@ -60,6 +60,27 @@ const ≅ = isequal
                 @test CategoricalVector{Union{String, Missing}, DefaultRefType}(a, ordered=ordered) == x
                 @test CategoricalVector{Union{String, Missing}, UInt8}(a, ordered=ordered) == x
 
+                @test convert(CategoricalArray{String}, x) == x
+                @test convert(CategoricalArray{String, 1}, x) == x
+                @test convert(CategoricalArray{String, 1, R}, x) == x
+                @test convert(CategoricalArray{String, 1, DefaultRefType}, x) == x
+                @test convert(CategoricalArray{String, 1, UInt8}, x) == x
+
+                @test convert(CategoricalVector{String}, x) == x
+                @test convert(CategoricalVector{String, R}, x) == x
+                @test convert(CategoricalVector{String, DefaultRefType}, x) == x
+                @test convert(CategoricalVector{String, UInt8}, x) == x
+
+                @test CategoricalArray{String, 1}(x, ordered=ordered) == x
+                @test CategoricalArray{String, 1, R}(x, ordered=ordered) == x
+                @test CategoricalArray{String, 1, DefaultRefType}(x, ordered=ordered) == x
+                @test CategoricalArray{String, 1, UInt8}(x, ordered=ordered) == x
+
+                @test CategoricalVector{String}(x, ordered=ordered) == x
+                @test CategoricalVector{String, R}(x, ordered=ordered) == x
+                @test CategoricalVector{String, DefaultRefType}(x, ordered=ordered) == x
+                @test CategoricalVector{String, UInt8}(x, ordered=ordered) == x
+
                 @testset "categorical($(typeof(y)), compress=$comp) R1=$R1 R2=$R2" for (y, R1, R2, comp) in
                     ((a, DefaultRefType, UInt8, true),
                      (a, DefaultRefType, DefaultRefType, false),
@@ -441,6 +462,42 @@ const ≅ = isequal
         @test CategoricalVector{Union{Float64, Missing}, DefaultRefType}(a, ordered=ordered) == x
         @test CategoricalVector{Union{Float32, Missing}, DefaultRefType}(a, ordered=ordered) == x
 
+        @test convert(CategoricalArray{Float64}, x) == x
+        @test convert(CategoricalArray{Float32}, x) == x
+        @test convert(CategoricalArray{Float64, 1}, x) == x
+        @test convert(CategoricalArray{Float32, 1}, x) == x
+        @test convert(CategoricalArray{Float64, 1, R}, x) == x
+        @test convert(CategoricalArray{Float32, 1, R}, x) == x
+        @test convert(CategoricalArray{Float64, 1, DefaultRefType}, x) == x
+        @test convert(CategoricalArray{Float32, 1, DefaultRefType}, x) == x
+        @test convert(CategoricalArray{Float64, 1, UInt8}, x) == x
+        @test convert(CategoricalArray{Float32, 1, UInt8}, x) == x
+
+        @test convert(CategoricalVector{Float64}, x) == x
+        @test convert(CategoricalVector{Float32}, x) == x
+        @test convert(CategoricalVector{Float64, R}, x) == x
+        @test convert(CategoricalVector{Float32, R}, x) == x
+        @test convert(CategoricalVector{Float64, DefaultRefType}, x) == x
+        @test convert(CategoricalVector{Float32, DefaultRefType}, x) == x
+        @test convert(CategoricalVector{Float64, UInt8}, x) == x
+        @test convert(CategoricalVector{Float32, UInt8}, x) == x
+
+        @test CategoricalArray{Float64}(a, ordered=ordered) == x
+        @test CategoricalArray{Float32}(a, ordered=ordered) == x
+        @test CategoricalArray{Float64, 1}(a, ordered=ordered) == x
+        @test CategoricalArray{Float32, 1}(a, ordered=ordered) == x
+        @test CategoricalArray{Float64, 1, R}(a, ordered=ordered) == x
+        @test CategoricalArray{Float32, 1, R}(a, ordered=ordered) == x
+        @test CategoricalArray{Float64, 1, DefaultRefType}(a, ordered=ordered) == x
+        @test CategoricalArray{Float32, 1, DefaultRefType}(a, ordered=ordered) == x
+
+        @test CategoricalVector{Float64}(a, ordered=ordered) == x
+        @test CategoricalVector{Float32}(a, ordered=ordered) == x
+        @test CategoricalVector{Float64, R}(a, ordered=ordered) == x
+        @test CategoricalVector{Float32, R}(a, ordered=ordered) == x
+        @test CategoricalVector{Float64, DefaultRefType}(a, ordered=ordered) == x
+        @test CategoricalVector{Float32, DefaultRefType}(a, ordered=ordered) == x
+
         @testset "categorical($(typeof(y)), compress=$comp) R1=$R1 R2=$R2" for (y, R1, R2, comp) in
             ((a, DefaultRefType, UInt8, true),
              (a, DefaultRefType, DefaultRefType, false),
@@ -608,6 +665,28 @@ const ≅ = isequal
         @test CategoricalMatrix{Union{String, Missing}, R}(a, ordered=ordered) == x
         @test CategoricalMatrix{Union{String, Missing}, DefaultRefType}(a, ordered=ordered) == x
         @test CategoricalMatrix{Union{String, Missing}, UInt8}(a, ordered=ordered) == x
+
+        @test convert(CategoricalArray{String}, x) == x
+        @test convert(CategoricalArray{String, 2, R}, x) == x
+        @test convert(CategoricalArray{String, 2, DefaultRefType}, x) == x
+        @test convert(CategoricalArray{String, 2, UInt8}, x) == x
+
+        @test convert(CategoricalMatrix{String}, x) == x
+        @test convert(CategoricalMatrix{String, R}, x) == x
+        @test convert(CategoricalMatrix{String, DefaultRefType}, x) == x
+        @test convert(CategoricalMatrix{String, UInt8}, x) == x
+
+        @test CategoricalArray{String}(a, ordered=ordered) == x
+        @test CategoricalArray{String, 2}(a, ordered=ordered) == x
+        @test CategoricalArray{String, 2}(a, ordered=ordered) == x
+        @test CategoricalArray{String, 2, R}(a, ordered=ordered) == x
+        @test CategoricalArray{String, 2, DefaultRefType}(a, ordered=ordered) == x
+        @test CategoricalArray{String, 2, UInt8}(a, ordered=ordered) == x
+
+        @test CategoricalMatrix{String}(a, ordered=ordered) == x
+        @test CategoricalMatrix{String, R}(a, ordered=ordered) == x
+        @test CategoricalMatrix{String, DefaultRefType}(a, ordered=ordered) == x
+        @test CategoricalMatrix{String, UInt8}(a, ordered=ordered) == x
 
         @testset "categorical($(typeof(y)), compress=$comp) R1=$R1 R2=$R2" for (y, R1, R2, comp) in
             ((a, DefaultRefType, UInt8, true),


### PR DESCRIPTION
`convert(CategoricalVector{T}, ::CategoricalVector)` and `convert(CategoricalMatrix{T}, ::CategoricalMatrix)` were ambiguous when the source and destination eltypes differed. Tests should have caught this, but for some reason the ambiguity isn't detected for the particular case that was tested. Add a series of tests to ensure we cover all cases.

Fixes #299.