### PR TITLE
Implement DataAPI's refarray/refvalue/refpool interface

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -1057,20 +1057,23 @@ struct CategoricalRefPool{T, P} <: AbstractVector{T}
 end
 
 Base.IndexStyle(::Type{<: CategoricalRefPool}) = Base.IndexLinear()
+
 @inline function Base.getindex(x::CategoricalRefPool, i::Int)
     @boundscheck checkbounds(x, i)
     i > 0 ? @inbounds(x.pool[i]) : missing
 end
+
 Base.size(x::CategoricalRefPool{T}) where {T} = (length(x.pool) + (T >: Missing),)
 Base.axes(x::CategoricalRefPool{T}) where {T} =
     ((T >: Missing ? 0 : 1):length(x.pool),)
 Base.LinearIndices(x::CategoricalRefPool) = axes(x, 1)
 
 DataAPI.refarray(A::CatArrOrSub) = refs(A)
+DataAPI.refpool(A::CatArrOrSub{T}) where {T} =
+    CategoricalRefPool{eltype(A), typeof(pool(A))}(pool(A))
+
 @inline function DataAPI.refvalue(A::CatArrOrSub{T}, i::Integer) where T
     @boundscheck checkindex(Bool, (T >: Missing ? 0 : 1):length(pool(A)), i) ||
         throw(BoundsError())
     i > 0 ? @inbounds(pool(A)[i]) : missing
 end
-DataAPI.refpool(A::CatArrOrSub{T}) where {T} =
-    CategoricalRefPool{eltype(A), typeof(pool(A))}(pool(A))

--- a/src/array.jl
+++ b/src/array.jl
@@ -1050,3 +1050,26 @@ StructTypes.construct(::Type{<:CategoricalArray{Union{Nothing, T}}},
                       A::Vector) where {T} =
     categoricalnothing(T, A)
 categoricalnothing(T, A::AbstractVector) = CategoricalArray{Union{Nothing, T}}(A)
+
+# DataAPI refarray/refvalue/refpool support
+struct CategoricalRefPool{T, P} <: AbstractVector{T}
+    pool::P
+end
+
+Base.IndexStyle(::Type{<: CategoricalRefPool}) = Base.IndexLinear()
+@inline function Base.getindex(x::CategoricalRefPool, i::Int)
+    @boundscheck checkbounds(x, i)
+    i > 0 ? @inbounds(x.pool[i]) : missing
+end
+Base.size(x::CategoricalRefPool{T}) where {T} = (length(x.pool) + (T >: Missing),)
+Base.axes(x::CategoricalRefPool{T}) where {T} =
+    ((T >: Missing ? 0 : 1):length(x.pool),)
+
+DataAPI.refarray(A::CatArrOrSub) = refs(A)
+@inline function DataAPI.refvalue(A::CatArrOrSub{T}, i::Integer) where T
+    @boundscheck checkindex(Bool, (T >: Missing ? 0 : 1):length(pool(A)), i) ||
+        throw(BoundsError())
+    i > 0 ? @inbounds(pool(A)[i]) : missing
+end
+DataAPI.refpool(A::CatArrOrSub{T}) where {T} =
+    CategoricalRefPool{eltype(A), typeof(pool(A))}(pool(A))

--- a/src/array.jl
+++ b/src/array.jl
@@ -1064,6 +1064,7 @@ end
 Base.size(x::CategoricalRefPool{T}) where {T} = (length(x.pool) + (T >: Missing),)
 Base.axes(x::CategoricalRefPool{T}) where {T} =
     ((T >: Missing ? 0 : 1):length(x.pool),)
+Base.LinearIndices(x::CategoricalRefPool) = axes(x, 1)
 
 DataAPI.refarray(A::CatArrOrSub) = refs(A)
 @inline function DataAPI.refvalue(A::CatArrOrSub{T}, i::Integer) where T

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -2048,11 +2048,14 @@ end
             @test collect(rp) ≅ [missing; levels(y)]
             @test size(rp) == (length(levels(y)) + 1,)
             @test axes(rp) == (0:length(levels(y)),)
-            @test_throws ArgumentError reshape(rp, length(rp))
+            if VERSION >= v"1.5"
+                @test_throws ArgumentError reshape(rp, length(rp))
+            end
         else
             @test collect(rp) == levels(y)
             @test size(rp) == (length(levels(y)),)
             @test axes(rp) == (1:length(levels(y)),)
+            @test reshape(rp, length(rp)) == rp
             @test_throws BoundsError rp[0]
         end
         @test_throws BoundsError rp[-1]

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -2043,6 +2043,7 @@ end
 
         rp = DataAPI.refpool(y)
         @test rp isa AbstractVector{eltype(y)}
+        @test Base.IndexStyle(rp) isa Base.IndexLinear
         @test LinearIndices(rp) == axes(rp, 1)
         if eltype(y) >: Missing
             @test collect(rp) ≅ [missing; levels(y)]

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -2032,32 +2032,24 @@ end
               view(categorical(["a", "a", "c", "b"]), 1:3),
               categorical(["b" missing; "a" "c"; "b" missing]),
               view(categorical(["b" missing; "a" "c"; "b" missing]), 2:3, 1))
-        ra = DataAPI.refarray(y)
-        rp = DataAPI.refpool(y)
-        @test ra === CategoricalArrays.refs(y)
-        @test all(DataAPI.refvalue(y, r) ≅ yi for (r, yi) in zip(ra, y))
-        @test all(rp[r] ≅ yi for (r, yi) in zip(ra, y))
+        @test DataAPI.refarray(y) === CategoricalArrays.refs(y)
+        @test DataAPI.refvalue.(Ref(y), DataAPI.refarray(y)) ≅ y
+        @test DataAPI.getindex.(Ref(DataAPI.refpool(y)), DataAPI.refarray(y)) ≅ y
         @test_throws BoundsError DataAPI.refvalue(y, -1)
         @test_throws BoundsError DataAPI.refvalue(y, length(levels(y))+1)
         if !(eltype(y) >: Missing)
             @test_throws BoundsError DataAPI.refvalue(y, 0)
         end
 
-        @test eltype(rp) === eltype(y)
-        @test lastindex(rp) == length(levels(y))
+        rp = DataAPI.refpool(y)
+        @test rp isa AbstractVector{eltype(y)}
         if eltype(y) >: Missing
-            @test [rp[i] for i in eachindex(rp)] ≅ [missing; levels(y)]
-            @test length(rp) == length(levels(y)) + 1
+            @test collect(rp) ≅ [missing; levels(y)]
             @test size(rp) == (length(levels(y)) + 1,)
-            @test firstindex(rp) == 0
-            @test eachindex(rp) == 0:length(levels(y))
             @test axes(rp) == (0:length(levels(y)),)
         else
-            @test [rp[i] for i in eachindex(rp)] == levels(y)
-            @test length(rp) == length(levels(y))
+            @test collect(rp) == levels(y)
             @test size(rp) == (length(levels(y)),)
-            @test firstindex(rp) == 1
-            @test eachindex(rp) == 1:length(levels(y))
             @test axes(rp) == (1:length(levels(y)),)
             @test_throws BoundsError rp[0]
         end

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -2043,10 +2043,12 @@ end
 
         rp = DataAPI.refpool(y)
         @test rp isa AbstractVector{eltype(y)}
+        @test LinearIndices(rp) == axes(rp, 1)
         if eltype(y) >: Missing
             @test collect(rp) ≅ [missing; levels(y)]
             @test size(rp) == (length(levels(y)) + 1,)
             @test axes(rp) == (0:length(levels(y)),)
+            @test_throws ArgumentError reshape(rp, length(rp))
         else
             @test collect(rp) == levels(y)
             @test size(rp) == (length(levels(y)),)
@@ -2055,6 +2057,7 @@ end
         end
         @test_throws BoundsError rp[-1]
         @test_throws BoundsError rp[end + 1]
+        @test_throws MethodError similar(rp)
     end
 end
 


### PR DESCRIPTION
It turns out it is much simpler to return a new special `CategoricalRefPool` type from `refpool` than to return directly the `CategoricalPool`. Indeed, `CategoricalPool` is not currently aware of whether its parent `CategoricalArray`  allows for missing values or not. Adding this as a type parameter requires adding a similar parameter to `CategoricalValue`, making it more complex for users than it needs to be.

Supersedes https://github.com/JuliaData/CategoricalArrays.jl/pull/297. Cc: @quinnj @bkamins 