### PR TITLE
Return unwrapped values from DataAPI.refpool

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -1066,7 +1066,7 @@ Base.IndexStyle(::Type{<: CategoricalRefPool}) = Base.IndexLinear()
 
 @inline function Base.getindex(x::CategoricalRefPool, i::Int)
     @boundscheck checkbounds(x, i)
-    i > 0 ? @inbounds(x.pool[i]) : missing
+    i > 0 ? get(@inbounds(x.pool[i])) : missing
 end
 
 Base.size(x::CategoricalRefPool{T}) where {T} = (length(x.pool) + (T >: Missing),)
@@ -1076,7 +1076,7 @@ Base.LinearIndices(x::CategoricalRefPool) = axes(x, 1)
 
 DataAPI.refarray(A::CatArrOrSub) = refs(A)
 DataAPI.refpool(A::CatArrOrSub{T}) where {T} =
-    CategoricalRefPool{eltype(A), typeof(pool(A))}(pool(A))
+    CategoricalRefPool{leveltype(eltype(A)), typeof(pool(A))}(pool(A))
 
 @inline function DataAPI.refvalue(A::CatArrOrSub{T}, i::Integer) where T
     @boundscheck checkindex(Bool, (T >: Missing ? 0 : 1):length(pool(A)), i) ||

--- a/src/value.jl
+++ b/src/value.jl
@@ -2,6 +2,7 @@ CategoricalValue(level::Integer, pool::CategoricalPool{T, R}) where {T, R} =
     CategoricalValue(convert(R, level), pool)
 
 leveltype(::Type{<:CategoricalValue{T}}) where {T} = T
+leveltype(::Type{Union{Missing, C}}) where {C <: CategoricalValue} = Union{Missing, leveltype(C)}
 leveltype(::Type{T}) where {T} = T
 leveltype(x::Any) = leveltype(typeof(x))
 # to fix ambiguity

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -2042,7 +2042,7 @@ end
         end
 
         rp = DataAPI.refpool(y)
-        @test rp isa AbstractVector{eltype(y)}
+        @test rp isa AbstractVector{CategoricalArrays.leveltype(eltype(y))}
         @test Base.IndexStyle(rp) isa Base.IndexLinear
         @test LinearIndices(rp) == axes(rp, 1)
         if eltype(y) >: Missing


### PR DESCRIPTION
I'm wondering if this would be ok; it allows CategoricalArray to "just work" with Arrow.jl w/o further changes needed there. The problem is it's weird in Arrow.jl because it doesn't know how to treat `CategoricalValue`; it's not a plain type, so must be a struct? so we should serialize each field separately? When in reality it's just a wrapped type and should be treated like a plain type.

My thought here is that the refpool is really just about getting the values; and if they're ordered, then the order of the pool is all that's needed for downstream processing; i.e. if I called `refpool` on a PooledArray and a hypothetical `DataAPI.isorered(pool)`, then I would expect to be able to compare two random strings from the pool for their "ordered", but I'd need to rely on the index of the values in the pool. I propose that same reasoning can be applied to `CategoricalRefPool`; i.e. just return the plain values, and to maintain ordering, you'll need to refer to the order the values are stored in the pool itself.

cc: @bkamins 