### PR TITLE
Define ArrowType for CategoricalValue

### DIFF
--- a/src/value.jl
+++ b/src/value.jl
@@ -185,3 +185,7 @@ StructTypes.StructType(x::CategoricalValue) = StructTypes.StructType(get(x))
 StructTypes.StructType(::Type{<:CategoricalValue{T}}) where {T} = StructTypes.StructType(T)
 StructTypes.numbertype(::Type{<:CategoricalValue{T}}) where {T <: Number} = T
 StructTypes.construct(::Type{T}, x::CategoricalValue{T}) where {T} = T(get(x))
+
+using Arrow
+Arrow.ArrowTypes.ArrowType(::Type{<:CategoricalValue{T}}) where {T} = Arrow.ArrowTypes.ArrowType(T)
+Arrow.ArrowTypes.isstringtype(::Type{<:CategoricalValue{T}}) where {T <: AbstractString} = true


### PR DESCRIPTION
Alternative to https://github.com/JuliaData/CategoricalArrays.jl/pull/306 for supporting CategoricalArray in Arrow.jl.

Marked as draft for now to get review, but also because I've been considering registering the ArrowTypes module in the Arrow.jl package as its own package; it's similar to StructTypes.jl in some ways, but is specific to the arrow format; basically, it allows custom types to declare their `ArrowType` trait and then be treated as such in the arrow reading/writing process. 

This PR, along with https://github.com/JuliaData/Arrow.jl/pull/41, gets CategoricalArray support writing working as long as there are no `missing` values. The problem with `missing` values is they're coded in the refs as `0`, but in the arrow writing process, I have a step that translates the julian-1-based indexing ref code to 0-based, by subtracting 1 from each ref; this is an issue for `missing` because it tries to change its ref code to `-1`, but the ref type is `UInt32` (usually). Not quite sure how to adjust for that yet.