### PR TITLE
Improve copyto! performance

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -522,8 +522,7 @@ function copyto!(dest::CatArrOrSub{T, N, R}, dstart::Integer,
     newlevels = levels(newpool)
 
     # If destination levels are an ordered superset of source, no need to recompute refs
-    if length(dlevs) >= length(slevs) && view(dlevs, 1:length(slevs)) == slevs
-        newlevels != dlevs && levels!(dpool, newlevels)
+    if view(newlevels, 1:length(slevs)) == slevs
         copyto!(drefs, dstart, srefs, sstart, n)
     else # Otherwise, recompute refs according to new levels
         # Then adjust refs from source
@@ -536,6 +535,11 @@ function copyto!(dest::CatArrOrSub{T, N, R}, dstart::Integer,
             x = srefs[sstart+i]
             drefs[dstart+i] = levelsmap[x+1]
         end
+    end
+    # Need to allocate a new pool only if reordering destination levels
+    if view(newlevels, 1:length(dlevs)) == dlevs
+        levels!(dpool, newlevels)
+    else
         destp.pool = CategoricalPool{nonmissingtype(T), R}(newlevels, isordered(newpool))
     end
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -519,7 +519,7 @@ function copyto!(dest::CatArrOrSub{T, N, R}, dstart::Integer,
     # For partial copy, need to recompute existing refs
     # TODO: for performance, avoid ajusting refs which are going to be overwritten
     updaterefs = isa(dest, SubArray) || !(n == length(dest) == length(src))
-    newlevels, ordered = merge_pools!(dest, src, updaterefs=updaterefs)
+    newlevels, ordered = merge_pools!(dest, src, updaterefs=updaterefs, updatepool=false)
 
     # If destination levels are an ordered superset of source, no need to recompute refs
     if view(newlevels, 1:length(slevs)) == slevs
@@ -538,7 +538,7 @@ function copyto!(dest::CatArrOrSub{T, N, R}, dstart::Integer,
     end
     # Need to allocate a new pool only if reordering destination levels
     if view(newlevels, 1:length(dlevs)) == dlevs
-        levels!(dpool, newlevels)
+        levels!(dpool, newlevels, checkunique=false)
     else
         destp.pool = CategoricalPool{nonmissingtype(T), R}(newlevels, ordered)
     end
@@ -571,7 +571,7 @@ function copyto!(dest::CatArrOrSub{T1, N, R}, dstart::Integer,
             srclevsnm = srclevsnm === srclevs ? sort(srclevsnm) : sort!(srclevsnm)
         end
         newdestlevs = union(destlevs, srclevsnm)
-        levels!(pool(dest), newdestlevs)
+        levels!(pool(dest), newdestlevs, checkunique=false)
     end
     levelsmap = something.(indexin(srclevs, [missing; newdestlevs])) .- 1
     destrefs = refs(dest)

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -184,9 +184,10 @@ Base.issubset(a::CategoricalPool, b::CategoricalPool) = issubset(a.levels, keys(
 
 # Contrary to the CategoricalArray one, this method only allows adding new levels at the end
 # so that existing CategoricalValue objects still point to the same value
-function levels!(pool::CategoricalPool{S, R}, newlevels::Vector) where {S, R}
+function levels!(pool::CategoricalPool{S, R}, newlevels::Vector;
+                 checkunique::Bool=true) where {S, R}
     levs = convert(Vector{S}, newlevels)
-    if !allunique(levs)
+    if checkunique && !allunique(levs)
         throw(ArgumentError(string("duplicated levels found in levs: ",
                                    join(unique(filter(x->sum(levs.==x)>1, levs)), ", "))))
     elseif length(levs) < length(pool) || view(levs, 1:length(pool)) != pool.levels

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -163,7 +163,7 @@ end
 
 # Do not override Base.merge as for internal use we need to use the type and orderedness
 # of the first pool rather than promoting both pools
-function merge_pools(a::CategoricalPool{T, R}, b::CategoricalPool) where {T, R}
+function merge_pools(a::CategoricalPool{T}, b::CategoricalPool) where {T}
     if length(a) == 0 && length(b) == 0
         newlevs = T[]
         ordered = isordered(a)
@@ -177,7 +177,7 @@ function merge_pools(a::CategoricalPool{T, R}, b::CategoricalPool) where {T, R}
         nl, ordered = mergelevels(isordered(a), a.levels, b.levels)
         newlevs = convert(Vector{T}, nl)
     end
-    CategoricalPool{T, R}(newlevs, ordered)
+    newlevs, ordered
 end
 
 Base.issubset(a::CategoricalPool, b::CategoricalPool) = issubset(a.levels, keys(b.invindex))


### PR DESCRIPTION
The check was against the levels in destination before merging them with source levels, so it missed the cases where destination levels where an ordered  subset of source levels. This notably includes the case where destination levels are empty. Add even more tests to make sure we cover everything.

Avoid creating pool in merge_pools! when not needed. Creating a pool is expensive when there are many levels, and in `copyto!`we sometimes don't use it.

Avoid checking for duplicate levels when not needed. When levels have been computing internally we don't need to check for duplicates, which is expensive when the number of levels is large.

Fixes #308.


```julia
julia> using CategoricalArrays

julia> x = categorical(1:10^6);

# master
julia> y = similar(x, 10); xx=x[1:10]; @time copyto!(y, xx);
  1.053766 seconds (2.77 M allocations: 299.787 MiB, 18.95% gc time)

julia> y = similar(x, 10); xx=x[1:10]; @time copyto!(y, xx);
  0.472269 seconds (2.00 M allocations: 261.165 MiB)

julia> y = similar(x, 10); xx=x[1:10]; @time copyto!(y, xx);
  0.642487 seconds (2.00 M allocations: 261.165 MiB, 31.97% gc time)

# This PR
julia> y = similar(x, 10); xx=x[1:10]; @time copyto!(y, xx);
  0.681033 seconds (1.85 M allocations: 145.464 MiB, 22.58% gc time)

julia> y = similar(x, 10); xx=x[1:10]; @time copyto!(y, xx);
  0.153095 seconds (1.00 M allocations: 103.242 MiB)

julia> y = similar(x, 10); xx=x[1:10]; @time copyto!(y, xx);
  0.199941 seconds (1.00 M allocations: 103.242 MiB, 46.05% gc time)
```