### PR TITLE
Restrict wrapped types to reduce invalidations

### DIFF
--- a/src/pool.jl
+++ b/src/pool.jl
@@ -62,7 +62,7 @@ avoid doing a dict lookup twice
 end
 
 function mergelevels(ordered, levels...)
-    T = Base.promote_eltype(levels...)
+    T = cat_promote_eltype(levels...)
     res = Vector{T}(undef, 0)
 
     nonempty_lv = findfirst(!isempty, levels)

--- a/test/04_constructors.jl
+++ b/test/04_constructors.jl
@@ -5,9 +5,9 @@ using CategoricalArrays: DefaultRefType
 
 @testset "Type parameter constraints" begin
     # cannot use categorical value as level type
-    @test_throws ArgumentError CategoricalPool{CategoricalValue{Int,UInt8}, UInt8, CategoricalValue{CategoricalValue{Int,UInt8},UInt8}}(
+    @test_throws TypeError CategoricalPool{CategoricalValue{Int,UInt8}, UInt8, CategoricalValue{CategoricalValue{Int,UInt8},UInt8}}(
             Dict{CategoricalValue{Int,UInt8}, UInt8}(), false)
-    @test_throws ArgumentError CategoricalPool{CategoricalValue{Int,UInt8}, UInt8, CategoricalValue{CategoricalValue{Int,UInt8},UInt8}}(
+    @test_throws TypeError CategoricalPool{CategoricalValue{Int,UInt8}, UInt8, CategoricalValue{CategoricalValue{Int,UInt8},UInt8}}(
                 CategoricalValue{Int,UInt8}[], false)
     # cannot use non-categorical value as categorical value type
     @test_throws ArgumentError CategoricalPool{Int, UInt8, Int}(Int[], false)

--- a/test/05_convert.jl
+++ b/test/05_convert.jl
@@ -65,43 +65,78 @@ end
         CategoricalValue{Float64, UInt32}
     @test promote_type(CategoricalValue{Int, UInt8}, CategoricalValue{Float64}) ===
         CategoricalValue{Float64}
+    @test promote_type(CategoricalValue{Int, UInt8}, CategoricalValue{String}) ===
+        CategoricalValue{Union{Int, String}}
     # Tests that return Any before Julia 1.3 are due to JuliaLang/julia#29348
     if VERSION >= v"1.3.0-DEV"
         @test promote_type(CategoricalValue{Int},
                            Union{CategoricalValue{Float64}, Missing}) ===
-            Union{Missing, Float64}
+            Union{CategoricalValue{Float64}, Missing}
+        @test promote_type(CategoricalValue{Int},
+                           Union{CategoricalValue{String}, Missing}) ===
+            Union{CategoricalValue{Union{Int, String}}, Missing}
         @test promote_type(CategoricalValue{Int, UInt8},
                            Union{CategoricalValue{Float64, UInt32}, Missing}) ===
             Union{CategoricalValue{Float64, UInt32}, Missing}
+        @test promote_type(CategoricalValue{Int, UInt8},
+                           Union{CategoricalValue{String, UInt32}, Missing}) ===
+            Union{CategoricalValue{Union{Int, String}, UInt32}, Missing}
         @test promote_type(Union{CategoricalValue{Int}, Missing},
                            CategoricalValue{Float64}) ===
-            Union{Missing, Float64}
+            Union{CategoricalValue{Float64}, Missing}
+        @test promote_type(Union{CategoricalValue{Int}, Missing},
+                           CategoricalValue{String}) ===
+            Union{CategoricalValue{Union{Int, String}}, Missing}
         @test promote_type(Union{CategoricalValue{Int, UInt8}, Missing},
                            CategoricalValue{Float64, UInt32}) ===
             Union{CategoricalValue{Float64, UInt32}, Missing}
+        @test promote_type(Union{CategoricalValue{Int, UInt8}, Missing},
+                           CategoricalValue{String, UInt32}) ===
+            Union{CategoricalValue{Union{Int, String}, UInt32}, Missing}
         @test promote_type(Union{CategoricalValue{Int}, Missing},
                            Union{CategoricalValue{Float64}, Missing}) ===
-            Union{Missing, Float64}
+            Union{CategoricalValue{Float64}, Missing}
+        @test promote_type(Union{CategoricalValue{Int}, Missing},
+                           Union{CategoricalValue{String}, Missing}) ===
+            Union{CategoricalValue{Union{Int, String}}, Missing}
     else
         @test promote_type(CategoricalValue{Int},
                            Union{CategoricalValue{Float64}, Missing}) ===
-            Any
+            Union{CategoricalValue{Float64}, Missing}
+        @test promote_type(CategoricalValue{Int},
+                           Union{CategoricalValue{String}, Missing}) ===
+            Union{CategoricalValue{Union{Int, String}}, Missing}
         @test promote_type(CategoricalValue{Int, UInt8},
                            Union{CategoricalValue{Float64, UInt32}, Missing}) ===
             Union{CategoricalValue{Float64, UInt32}, Missing}
+        @test promote_type(CategoricalValue{Int, UInt8},
+                           Union{CategoricalValue{String, UInt32}, Missing}) ===
+            Union{CategoricalValue{Union{Int, String}, UInt32}, Missing}
         @test promote_type(Union{CategoricalValue{Int}, Missing},
                            CategoricalValue{Float64}) ===
-            Any
-        @test promote_type(Union{CategoricalValue{Int, UInt8}, Missing},
-                        CategoricalValue{Float64, UInt32}) ===
-            Union{CategoricalValue{Float64, UInt32}, Missing}
+            Union{CategoricalValue{Float64}, Missing}
         @test promote_type(Union{CategoricalValue{Int}, Missing},
-                        Union{CategoricalValue{Float64}, Missing}) ===
+                           CategoricalValue{String}) ===
+            Union{CategoricalValue{Union{Int, String}}, Missing}
+        @test promote_type(Union{CategoricalValue{Int, UInt8}, Missing},
+                           CategoricalValue{Float64, UInt32}) ===
+            Union{CategoricalValue{Float64, UInt32}, Missing}
+        @test promote_type(Union{CategoricalValue{Int, UInt8}, Missing},
+                           CategoricalValue{String, UInt32}) ===
+            Union{CategoricalValue{Union{Int, String}, UInt32}, Missing}
+        @test promote_type(Union{CategoricalValue{Int}, Missing},
+                           Union{CategoricalValue{Float64}, Missing}) ===
+            Any
+        @test promote_type(Union{CategoricalValue{Int}, Missing},
+                           Union{CategoricalValue{String}, Missing}) ===
             Any
     end
     @test promote_type(Union{CategoricalValue{Int, UInt8}, Missing},
                        Union{CategoricalValue{Float64, UInt32}, Missing}) ===
         Union{CategoricalValue{Float64, UInt32}, Missing}
+    @test promote_type(Union{CategoricalValue{Int, UInt8}, Missing},
+                       Union{CategoricalValue{String, UInt32}, Missing}) ===
+        Union{CategoricalValue{Union{Int, String}, UInt32}, Missing}
 
     @test promote_type(CategoricalValue, Missing) === Union{CategoricalValue, Missing}
     @test promote_type(CategoricalValue{Int}, Missing) === Union{CategoricalValue{Int}, Missing}
@@ -113,15 +148,6 @@ end
 @testset "convert() preserves `ordered`" begin
     pool = CategoricalPool([1, 2, 3], true)
     @test convert(CategoricalPool{Float64, UInt8}, pool).ordered === true
-end
-
-@testset "convert() with Union{T, Nothing}" begin
-    pool = CategoricalPool([nothing, 2, 3])
-    v1 = CategoricalValue(1, pool)
-    v2 = CategoricalValue(2, pool)
-    @test convert(Union{Int, Nothing}, v1) === nothing
-    @test convert(Union{Int, Nothing}, v2) === 2
-    @test convert(Union{Float64, Nothing}, v2) === 2.0
 end
 
 @testset "levelcode" begin

--- a/test/06_show.jl
+++ b/test/06_show.jl
@@ -18,13 +18,13 @@ using CategoricalArrays
     @test sprint(show, pool) == "$CategoricalPool{String,UInt32}([\"c\", \"b\", \"a\"])"
     @test sprint(show, opool) == "$CategoricalPool{String,UInt32}([\"c\", \"b\", \"a\"]) with ordered levels"
 
-    @test sprint(show, nv1) == "$CategoricalValue{String,UInt32} \"c\""
-    @test sprint(show, nv2) == "$CategoricalValue{String,UInt32} \"b\""
-    @test sprint(show, nv3) == "$CategoricalValue{String,UInt32} \"a\""
+    @test sprint(show, nv1) == repr(nv1) == "$CategoricalValue{String,UInt32} \"c\""
+    @test sprint(show, nv2) == repr(nv2) == "$CategoricalValue{String,UInt32} \"b\""
+    @test sprint(show, nv3) == repr(nv3) == "$CategoricalValue{String,UInt32} \"a\""
 
-    @test sprint(show, ov1) == "$CategoricalValue{String,UInt32} \"c\" (1/3)"
-    @test sprint(show, ov2) == "$CategoricalValue{String,UInt32} \"b\" (2/3)"
-    @test sprint(show, ov3) == "$CategoricalValue{String,UInt32} \"a\" (3/3)"
+    @test sprint(show, ov1) == repr(ov1) =="$CategoricalValue{String,UInt32} \"c\" (1/3)"
+    @test sprint(show, ov2) == repr(ov2) == "$CategoricalValue{String,UInt32} \"b\" (2/3)"
+    @test sprint(show, ov3) == repr(ov3) =="$CategoricalValue{String,UInt32} \"a\" (3/3)"
 
     @test sprint(show, nv1, context=:typeinfo=>typeof(nv1)) == "\"c\""
     @test sprint(show, nv2, context=:typeinfo=>typeof(nv2)) == "\"b\""
@@ -46,10 +46,6 @@ using CategoricalArrays
     @test String(nv2) == String(ov2) == "b"
     @test String(nv3) == String(ov3) == "a"
 
-    @test repr(nv1) == repr(ov1) == "\"c\""
-    @test repr(nv2) == repr(ov2) == "\"b\""
-    @test repr(nv3) == repr(ov3) == "\"a\""
-
     b = IOBuffer()
     @test write(b, nv1) == 1
     @test String(take!(b)) == "c"
@@ -65,78 +61,6 @@ using CategoricalArrays
     @test String(take!(b)) == "a"
 end
 
-@testset "show() for CategoricalPool{Date} and its values" begin
-    levs = [Date(1999, 12), Date(1991, 8), Date(1993, 10)]
-    pool = CategoricalPool(levs)
-    opool = CategoricalPool(levs, true)
-
-    nv1 = CategoricalValue(1, pool)
-    nv2 = CategoricalValue(2, pool)
-    nv3 = CategoricalValue(3, pool)
-
-    ov1 = CategoricalValue(1, opool)
-    ov2 = CategoricalValue(2, opool)
-    ov3 = CategoricalValue(3, opool)
-
-    if VERSION >= v"1.5.0-DEV"
-        @test sprint(show, pool) == "$CategoricalPool{$Date,UInt32}($levs)"
-        @test sprint(show, opool) == "$CategoricalPool{$Date,UInt32}($levs) with ordered levels"
-
-        @test sprint(show, nv1) == "$CategoricalValue{$Date,UInt32} $Date(\"1999-12-01\")"
-        @test sprint(show, nv2) == "$CategoricalValue{$Date,UInt32} $Date(\"1991-08-01\")"
-        @test sprint(show, nv3) == "$CategoricalValue{$Date,UInt32} $Date(\"1993-10-01\")"
-
-        @test sprint(show, ov1) == "$CategoricalValue{$Date,UInt32} $Date(\"1999-12-01\") (1/3)"
-        @test sprint(show, ov2) == "$CategoricalValue{$Date,UInt32} $Date(\"1991-08-01\") (2/3)"
-        @test sprint(show, ov3) == "$CategoricalValue{$Date,UInt32} $Date(\"1993-10-01\") (3/3)"
-
-        @test sprint(show, nv1, context=:typeinfo=>typeof(nv1)) == "$Date(\"1999-12-01\")"
-        @test sprint(show, nv2, context=:typeinfo=>typeof(nv2)) == "$Date(\"1991-08-01\")"
-        @test sprint(show, nv3, context=:typeinfo=>typeof(nv3)) == "$Date(\"1993-10-01\")"
-
-        @test sprint(show, ov1, context=:typeinfo=>typeof(ov1)) == "$Date(\"1999-12-01\")"
-        @test sprint(show, ov2, context=:typeinfo=>typeof(ov2)) == "$Date(\"1991-08-01\")"
-        @test sprint(show, ov3, context=:typeinfo=>typeof(ov3)) == "$Date(\"1993-10-01\")"
-    else
-        @test sprint(show, pool) == "$CategoricalPool{$Date,UInt32}([1999-12-01, 1991-08-01, 1993-10-01])"
-        @test sprint(show, opool) == "$CategoricalPool{$Date,UInt32}([1999-12-01, 1991-08-01, 1993-10-01]) with ordered levels"
-
-        @test sprint(show, nv1) == "$CategoricalValue{$Date,UInt32} 1999-12-01"
-        @test sprint(show, nv2) == "$CategoricalValue{$Date,UInt32} 1991-08-01"
-        @test sprint(show, nv3) == "$CategoricalValue{$Date,UInt32} 1993-10-01"
-
-        @test sprint(show, ov1) == "$CategoricalValue{$Date,UInt32} 1999-12-01 (1/3)"
-        @test sprint(show, ov2) == "$CategoricalValue{$Date,UInt32} 1991-08-01 (2/3)"
-        @test sprint(show, ov3) == "$CategoricalValue{$Date,UInt32} 1993-10-01 (3/3)"
-
-        @test sprint(show, nv1, context=:typeinfo=>typeof(nv1)) == "1999-12-01"
-        @test sprint(show, nv2, context=:typeinfo=>typeof(nv2)) == "1991-08-01"
-        @test sprint(show, nv3, context=:typeinfo=>typeof(nv3)) == "1993-10-01"
-
-        @test sprint(show, ov1, context=:typeinfo=>typeof(ov1)) == "1999-12-01"
-        @test sprint(show, ov2, context=:typeinfo=>typeof(ov2)) == "1991-08-01"
-        @test sprint(show, ov3, context=:typeinfo=>typeof(ov3)) == "1993-10-01"
-    end
-
-    @test sprint(print, nv1) == sprint(print, ov1) == "1999-12-01"
-    @test sprint(print, nv2) == sprint(print, ov2) == "1991-08-01"
-    @test sprint(print, nv3) == sprint(print, ov3) == "1993-10-01"
-
-    @test string(nv1) == string(ov1) == "1999-12-01"
-    @test string(nv2) == string(ov2) == "1991-08-01"
-    @test string(nv3) == string(ov3) == "1993-10-01"
-
-    if VERSION >= v"1.5.0-DEV"
-        @test repr(nv1) == repr(ov1) == "$Date(\"1999-12-01\")"
-        @test repr(nv2) == repr(ov2) == "$Date(\"1991-08-01\")"
-        @test repr(nv3) == repr(ov3) == "$Date(\"1993-10-01\")"
-    else
-        @test repr(nv1) == repr(ov1) == "1999-12-01"
-        @test repr(nv2) == repr(ov2) == "1991-08-01"
-        @test repr(nv3) == repr(ov3) == "1993-10-01"
-    end
-end
-
 using JSON
 @testset "JSON.lower" for pool in (CategoricalPool(["a"]),
                                    CategoricalPool([1]),
@@ -150,9 +74,6 @@ using JSON3
 using StructTypes
 @testset "JSON3.write" begin
     v = CategoricalValue(1, CategoricalPool(["a"]))
-    @test JSON3.write(v) === "\"a\""
-
-    v = CategoricalValue(1, CategoricalPool([:a]))
     @test JSON3.write(v) === "\"a\""
 
     v = CategoricalValue(1, CategoricalPool([1]))

--- a/test/07_levels.jl
+++ b/test/07_levels.jl
@@ -150,12 +150,6 @@ using CategoricalArrays: DefaultRefType, levels!
     v = CategoricalValue(1, CategoricalPool(["a", "b"]))
     @test_throws MethodError get!(pool, v)
 
-    # get! with CategoricalValue{Any} (#220)
-    p1 = CategoricalPool(Any['a', 'b', 'c'])
-    p2 = CategoricalPool(Any['a', 'b', 'x'])
-    @test get!(p1, p2[1]) === UInt32(1)
-    @test get!(p1, p2[3]) === UInt32(4)
-
     # get! with ordered CategoricalValue marks unordered empty pool as ordered
     p1 = CategoricalPool(['b', 'c', 'a'])
     ordered!(p1, true)

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -1162,6 +1162,29 @@ end
     end
 end
 
+@testset "constructors from arrays with unsupported eltypes" begin
+    for (CT, a) in zip((CategoricalVector, CategoricalMatrix),
+                        ([1, 2, 3], [1 2 3])),
+        f in (categorical, CategoricalArray, CT,
+                x -> convert(CategoricalArray, x),
+                x -> convert(CT, x)),
+        T in (Any, Union{Int, Symbol}, Union{Real, Symbol, Missing})
+        x = f(collect(T, a))
+        @test x isa CT{Int}
+        @test x == categorical(a)
+    end
+    for (CT, a) in zip((CategoricalVector, CategoricalMatrix),
+                        ([1, missing, 3], [1 missing 3])),
+        f in (categorical, CategoricalArray, CT,
+                x -> convert(CategoricalArray, x),
+                x -> convert(CT, x)),
+        T in (Any, Union{Int, Symbol, Missing}, Union{Real, Symbol, Missing})
+        x = f(collect(T, a))
+        @test x isa CT{Union{Int, Missing}}
+        @test x ≅ categorical(a)
+    end
+end
+
 @testset "converting from array with missings to array without missings CategoricalArray fails with missings" begin
     x = CategoricalArray{Union{String, Missing}}(undef, 1)
     @test_throws MissingException CategoricalArray{String}(x)

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -1183,6 +1183,25 @@ end
         @test x isa CT{Union{Int, Missing}}
         @test x ≅ categorical(a)
     end
+
+    for f in (categorical, CategoricalArray, CategoricalVector,
+              x -> convert(CategoricalArray, x),
+              x -> convert(CategoricalVector, x))
+        @test_throws ArgumentError f([:a])
+        @test_throws ArgumentError f(Any[:a])
+        @test_throws ArgumentError f([nothing])
+        @test_throws ArgumentError f(Any[nothing])
+        @test_throws ArgumentError f([1, nothing])
+    end
+    for f in (categorical, CategoricalArray, CategoricalMatrix,
+              x -> convert(CategoricalArray, x),
+              x -> convert(CategoricalMatrix, x))
+        @test_throws ArgumentError f([:a :a])
+        @test_throws ArgumentError f(Any[:a :a])
+        @test_throws ArgumentError f([nothing nothing])
+        @test_throws ArgumentError f(Any[nothing nothing])
+        @test_throws ArgumentError f([1 nothing])
+    end
 end
 
 @testset "converting from array with missings to array without missings CategoricalArray fails with missings" begin

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -1251,11 +1251,11 @@ end
     if VERSION > v"1.2.0-DEV"
         @inferred vcat(x, y)
     end
-    @test vcat(x, y) isa CategoricalVector{Any}
+    @test vcat(x, y) isa CategoricalVector{Union{String, Int}}
     if VERSION > v"1.2.0-DEV"
         @inferred vcat(x, z1)
     end
-    @test vcat(x, z1) isa CategoricalVector{Any}
+    @test vcat(x, z1) isa CategoricalVector{Union{String, Float64}}
     if VERSION > v"1.2.0-DEV"
         @inferred vcat(y, z1)
     end
@@ -2008,7 +2008,7 @@ end
 end
 
 # TODO: move struct definition inside @testset block once we require Julia 1.6
-struct UnorderedBar
+struct UnorderedBar <: Number
     a::String
 end
 
@@ -2068,25 +2068,6 @@ StructTypes.StructType(::Type{<:MyCustomType}) = StructTypes.Struct()
     @test x ≅ readx
     @test levels(readx) == levels(x)
     @test readx isa CategoricalVector{Union{Missing,String}}
-
-    readx = JSON3.read(str, CategoricalVector{Union{Nothing,String}})
-    @test all((ismissing(a) && (get(b) isa Nothing)) || a == b for (a,b) in zip(x,readx))
-    @test nothing in levels(readx)
-    @test length(union(setdiff(levels(readx),[nothing]), levels(x))) == length(levels(x))
-    @test readx isa CategoricalVector{Union{Nothing,String}}
-
-    readx = JSON3.read(str, CategoricalArray{Union{Nothing,String}})
-    @test all((ismissing(a) && (get(b) isa Nothing)) || a == b for (a,b) in zip(x,readx))
-    @test nothing in levels(readx)
-    @test length(union(setdiff(levels(readx),[nothing]), levels(x))) == length(levels(x))
-    @test readx isa CategoricalVector{Union{Nothing,String}}
-
-    x = CategoricalArray(["x",nothing,"y","z","y",nothing,"z","x"])
-    str = JSON3.write(x)
-
-    readx = JSON3.read(str, CategoricalArray{Union{Missing,String}})
-    @test all(((get(a) isa Nothing) && ismissing(b)) || a == b for (a,b) in zip(x,readx))
-    @test readx isa CategoricalVector
 
     x = MyCustomType(
         collect(1:3),

--- a/test/16_recode.jl
+++ b/test/16_recode.jl
@@ -318,15 +318,15 @@ end
         @test typeof(y) === Vector{Union{Float64, T}}
     end
 
-    # Recoding from Int to Any
+    # Recoding from Int to Union{Int, String}
     y = @inferred recode(x, 1=>"a", 2:4=>0, [5; 9:10]=>-1)
     @test y == ["a", 0, 0, 0, -1, 6, 7, 8, -1, -1]
     if isa(x, CategoricalArray)
-        @test isa(y, CategoricalVector{Any, DefaultRefType})
+        @test isa(y, CategoricalVector{Union{Int, String, T}, DefaultRefType})
         @test levels(y) == [6, 7, 8, "a", 0, -1]
         @test !isordered(y)
     else
-        @test typeof(y) === Vector{Any}
+        @test typeof(y) === Vector{Union{Int, String, T}}
     end
 
     # Recoding from Int to String, with String default
@@ -351,15 +351,15 @@ end
         @test typeof(y) === Vector{Union{String, T}}
     end
 
-    # Recoding from Int to Int/String (i.e. Any), with default String and other values Int
+    # Recoding from Int to Union{Int, String}, with default String and other values Int
     y = @inferred recode(x, "x", 1=>100, 2:4=>0, [5; 9:10]=>-1)
     @test y == [100, 0, 0, 0, -1, "x", "x", "x", -1, -1]
     if isa(x, CategoricalArray)
-        @test isa(y, CategoricalVector{Any, DefaultRefType})
+        @test isa(y, CategoricalVector{Union{Int, String, T}, DefaultRefType})
         @test levels(y) == [100, 0, -1, "x"]
         @test !isordered(y)
     else
-        @test typeof(y) === Vector{Any}
+        @test typeof(y) === Vector{Union{Int, String, T}}
     end
 
     # Recoding from Int to Int/String, without any Int value in pairs
@@ -434,17 +434,17 @@ end
     end
 end
 
-@testset "Recoding from $(typeof(x)) to Int/String (i.e. Any), with levels in custom order" for
+@testset "Recoding from $(typeof(x)) to Union{Int, String}, with levels in custom order" for
     x in (10:-1:1, CategoricalArray(10:-1:1))
 
     y = @inferred recode(x, 0, 1=>"a", 2:4=>"c", [5; 9:10]=>"b")
     @test y == ["b", "b", 0, 0, 0, "b", "c", "c", "c", "a"]
     if isa(x, CategoricalArray)
-        @test isa(y, CategoricalVector{Any, DefaultRefType})
+        @test isa(y, CategoricalVector{Union{Int, String}, DefaultRefType})
         @test levels(y) == ["a", "c", "b", 0]
         @test !isordered(y)
     else
-        @test typeof(y) === Vector{Any}
+        @test typeof(y) === Vector{Union{Int, String}}
     end
 
     # Recoding from Int to String via default, with levels in custom order
@@ -566,8 +566,8 @@ end
 
         testf(replace, String, x, missing => "")
         testf(replace, Union{String, Missing}, x, "b" => "c")
-        testf(replace, Any, x, "a" => 1, "b" => 2)
-        testf(replace, Any, x, "a" => 1, "b" => 2, missing => 3)
+        testf(replace, Union{Int, String, Missing}, x, "a" => 1, "b" => 2)
+        testf(replace, Union{Int, String}, x, "a" => 1, "b" => 2, missing => 3)
         y = testf(replace!, Union{String, Missing}, x, "b" => "c")
         @test y === x
 
@@ -619,15 +619,15 @@ end
 end
 
 # TODO: move struct definition inside @testset block after 1.6 becomes LTS
-struct UnorderedFoo0
+struct UnorderedFoo0 <: Number
     a::String
 end
-    
+
 @testset "recode AbstractVector with unordered eltype" begin
     x0 = [UnorderedFoo0("s$i") for i in 1:10]
     x = CategoricalArray{UnorderedFoo0}(undef, size(x0))
     recode!(x, x0, UnorderedFoo0("s3") => UnorderedFoo0("xxx"))
-    
+
     @test x[3] == UnorderedFoo0("xxx")
     @test x[(1:end) .!= 3] == x0[(1:end) .!= 3]
     @test levels(x)[1:(end-1)] == x0[(1:end) .!= 3]


### PR DESCRIPTION
Methods like `convert(::Type{Any}, ::CategoricalValue)` triggers lots of invalidations. Restricting the wrapped types to `AbstractString`, `AbstractChar` and `Number` alleviates this problem without affecting usability too much.

One limit with this approach is that e.g. `convert(Union{String, T}, CategoricalValue{String})` won't work anymore for any `T`, even though `convert(String, CategoricalValue{String})` will. Though thanks to special casing, it will work for `T <: Missing` and `T <: Nothing`.

This also means that `CategoricalArray{Any}` is no longer supported. Adapt promotion rules to ensure that mixing e.g. strings and integers gives `Union{String, Integer}`. Drop support for `nothing`.

Also remove the custom `repr` method which was a legacy of the `CategoricalString` era.