### PR TITLE
Minor fix in doc

### DIFF
--- a/docs/src/using.md
+++ b/docs/src/using.md
@@ -104,7 +104,7 @@ julia> lowercase(String(x[3]))
 julia> replace(String(x[3]), 'M'=>'R')
 "Riddle"
 ```
-Note that the call to `String` does reduce performance compared with working with a `Vector{String}` as it simply returns the string object which is stored by the pool.
+Note that the call to `String` does not reduce performance compared with working with a `Vector{String}` as it simply returns the string object which is stored by the pool.
 
 ## Handling Missing Values
 


### PR DESCRIPTION
I guess this tries to say that using CategoricalArrays won't reduce the performance.

> Note that the call to `String` does reduce performance compared with working with a `Vector{String}` as it simply returns the string object which is stored by the pool.
