### PR TITLE
Add text/plain show method for CategoricalValue

### DIFF
--- a/src/value.jl
+++ b/src/value.jl
@@ -94,6 +94,8 @@ function Base.show(io::IO, x::CategoricalValue)
     end
 end
 
+Base.show(io::IO, ::MIME"text/plain", x::CategoricalValue) = Base.show(io, x)
+
 Base.print(io::IO, x::CategoricalValue) = print(io, get(x))
 Base.string(x::CategoricalValue) = string(get(x))
 Base.write(io::IO, x::CategoricalValue) = write(io, get(x))


### PR DESCRIPTION
Since this method defines the "human-readable" representation, it should have the text/plain MIME type: https://docs.julialang.org/en/v1/base/io-network/#Base.show-Tuple{IO,Any,Any}

This fixes https://github.com/fonsp/Pluto.jl/issues/807 and does not change behaviour in other environments.