### PR TITLE
Add indexes methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .travis.yml
 docs/build/
 docs/site/
+
+Manifest.toml

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 .travis.yml
 docs/build/
 docs/site/
-
-Manifest.toml

--- a/src/value.jl
+++ b/src/value.jl
@@ -33,6 +33,10 @@ of possible values returned by [`levels(x)`](@ref DataAPI.levels).
 """
 levelcode(x::CategoricalValue) = Signed(widen(level(x)))
 
+Base.checkindex(T::Type{Bool}, inds::AbstractUnitRange, x::CategoricalValue{String, UInt32}) =
+      Base.checkindex(T, inds, levelcode(x))
+Base.to_index(x::CategoricalValue{String, UInt32}) = Base.to_index(levelcode(x))
+
 """
     levelcode(x::Missing)
 

--- a/test/01_value.jl
+++ b/test/01_value.jl
@@ -62,4 +62,10 @@ end
     end
 end
 
+@testset "Indexing CategoricalValues" begin
+    x = first(CategoricalArray(["a"]))
+    @test checkindex(Bool, 1:1, x) == true
+    @test Base.to_index(x) == 1
 end
+
+end # module


### PR DESCRIPTION
I was trying to use CategoricalArrays with Turing.jl. Surprisingly, it worked after I added some CategoricalArrays specialized type signatures for `Base.checkindex` and `Base.to_index`. According to the docstrings of both, these extensions are allowed, see `?Base.checkindex` and `?Base.to_index`.

With this PR, I suggest to add these specialized type signatures.

By the way, this PR is slightly related to https://github.com/JuliaData/CategoricalArrays.jl/issues/296, which is about a specialization for InvertedIndices.