### PR TITLE
Improve efficiency of mergelevels

### DIFF
--- a/src/pool.jl
+++ b/src/pool.jl
@@ -75,25 +75,28 @@ function mergelevels(ordered, levels...)
         return res, ordered
     end
 
-    for l in levels
-        levelsmap = indexin(l, res)
+    union!(res, levels...)
 
-        i = length(res)+1
-        for j = length(l):-1:1
-            @static if VERSION >= v"0.7.0-DEV.3627"
-                if levelsmap[j] === nothing
-                    insert!(res, i, l[j])
-                else
-                    i = levelsmap[j]
-                end
+    # Ensure that relative orders of levels are preserved if possible,
+    # giving priority to the first sets of levels in case of conflicts
+    for levs in reverse(levels)
+        levelsmap = indexin(res, levs)
+
+        # Do not touch levels from other sets at the end
+        n = length(res)
+        @inbounds for i in length(levelsmap):-1:1
+            levelsmap[i] === nothing || break
+            levelsmap[i] = n
+        end
+        j = 1
+        @inbounds for i in 1:length(levelsmap)
+            if levelsmap[i] === nothing
+                levelsmap[i] = j
             else
-                if levelsmap[j] == 0
-                    insert!(res, i, l[j])
-                else
-                    i = levelsmap[j]
-                end
+                j = levelsmap[i] + 1
             end
         end
+        permute!(res, sortperm(levelsmap, alg=Base.Sort.MergeSort))
     end
 
     # Check that result is ordered

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -43,12 +43,13 @@ const ≇ = !isequal
         (["A", "B", "C", "D", "E"], true)
 
     # Test that mergelevels handles mutually incompatible orderings
+    # by giving priority to first sets of levels
     @test CategoricalArrays.mergelevels(true, [6, 3, 4, 7], [2, 3, 6, 5, 4], [2, 4, 8]) ==
-        ([6, 2, 3, 5, 4, 7, 8], false)
+        ([2, 6, 3, 5, 4, 7, 8], false)
     @test CategoricalArrays.mergelevels(true, ["A", "C", "D"], ["D", "C"], []) ==
         (["A", "C", "D"], false)
     @test CategoricalArrays.mergelevels(true, ["A", "D", "C"], ["A", "B", "C"], ["A", "D", "E"], ["C", "D"]) ==
-        (["A", "D", "B", "C", "E"], false)
+        (["A", "B", "D", "C", "E"], false)
 
     # Test that mergelevels handles incomplete orderings
     @test CategoricalArrays.mergelevels(true, ["B", "C", "D"], ["A", "C"]) ==


### PR DESCRIPTION
`mergelevels` was implemented very inefficiently, which is acceptable when the number of levels is small but incredibly slow when it's large.

@bkamins This is still slow for large pools but at least it finishes:
```julia
julia> using CategoricalArrays

julia> function f(x, y)
           z = similar(x, length(x)+length(y))
           copyto!(z, x)
           copyto!(z, length(x)+1, y, 1, length(y))
           return z
       end
f (generic function with 1 method)

julia> @time x = categorical(1:10^7);
  8.157592 seconds (10.03 M allocations: 1.562 GiB, 10.83% gc time)

julia> @time y = categorical(1:2*10^7);
 18.108206 seconds (20.00 M allocations: 3.123 GiB, 11.00% gc time)

julia> @time f(x, y);
 34.870381 seconds (31.33 M allocations: 5.735 GiB, 10.83% gc time)
```