### PR TITLE
Add optimized method for collect(::SkipMissing{<: CatArrOrSub}}

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -967,6 +967,12 @@ end
 Array(A::CategoricalArray{T}) where {T} = Array{T}(A)
 collect(A::CategoricalArray) = copy(A)
 
+# Defined for performance
+function collect(x::Base.SkipMissing{<: CatArrOrSub{T}}) where {T}
+    r = refs(x.x)
+    return CategoricalVector{T}(r[r .> 0], copy(pool(x.x)))
+end
+
 function float(A::CategoricalArray{T}) where T
     if !isconcretetype(T)
         error("`float` not defined on abstractly-typed arrays; please convert to a more specific type")

--- a/src/array.jl
+++ b/src/array.jl
@@ -968,10 +968,8 @@ Array(A::CategoricalArray{T}) where {T} = Array{T}(A)
 collect(A::CategoricalArray) = copy(A)
 
 # Defined for performance
-function collect(x::Base.SkipMissing{<: CatArrOrSub{T}}) where {T}
-    r = refs(x.x)
-    return CategoricalVector{T}(r[r .> 0], copy(pool(x.x)))
-end
+collect(x::Base.SkipMissing{<: CatArrOrSub{T}}) where {T} =
+    CategoricalVector{nonmissingtype(T)}(filter(v -> v > 0, refs(x.x)), copy(pool(x.x)))
 
 function float(A::CategoricalArray{T}) where T
     if !isconcretetype(T)

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -1350,6 +1350,17 @@ end
     end
 end
 
+@testset "collect for SkipMissing" begin
+    for x in (categorical([1, missing, 3, missing, 2]),
+              view(categorical([2, 1, missing, 3, missing, 2]), 2:6),
+              categorical([1 missing; 3 missing]),
+              view(categorical([2 1; missing 3; missing 2]), 2:3, :))
+        res = collect(skipmissing(x))
+        @test res == collect(skipmissing(unwrap.(x)))
+        @test res isa CategoricalVector
+    end
+end
+
 @testset "Array(::CategoricalArray{T}) produces Array{T}" begin
     x = [1,1,2,2]
     y = categorical(x)

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -1354,11 +1354,34 @@ end
     for x in (categorical([1, missing, 3, missing, 2]),
               view(categorical([2, 1, missing, 3, missing, 2]), 2:6),
               categorical([1 missing; 3 missing]),
-              view(categorical([2 1; missing 3; missing 2]), 2:3, :))
+              view(categorical([2 1; missing 3; missing 2]), 2:3, :),
+              categorical(fill(1)))
+        levels!(x, [2, 1, 3, 4])
         res = collect(skipmissing(x))
         @test res == collect(skipmissing(unwrap.(x)))
-        @test res isa CategoricalVector
+        @test res isa CategoricalVector{Int, UInt32}
+        @test levels(x) == [2, 1, 3, 4]
     end
+
+    x = categorical(Array{Union{Int,Missing}, 0}(undef))
+    x[1] = 1
+    levels!(x, [2, 1, 3, 4])
+    res = collect(skipmissing(x))
+    @test res isa CategoricalVector{Int, UInt32}
+    @test res == [1]
+    @test levels(x) == [2, 1, 3, 4]
+
+    x = categorical(Array{Union{Int,Missing}, 0}(missing))
+    levels!(x, [2, 1, 3, 4])
+    res = collect(skipmissing(x))
+    @test res isa CategoricalVector{Int, UInt32}
+    @test isempty(res)
+    @test levels(x) == [2, 1, 3, 4]
+
+    res = collect(skipmissing(categorical(fill(missing))))
+    @test res isa CategoricalVector{Union{}, UInt32}
+    @test isempty(res)
+    @test levels(x) == [2, 1, 3, 4]
 end
 
 @testset "Array(::CategoricalArray{T}) produces Array{T}" begin


### PR DESCRIPTION
The fallback method is currently extremely slow as it checks that the destination pool is a superset of the source pool for each entry. This optimization would be faster anyway even if we fixed that.

Fixes https://github.com/JuliaData/DataFrames.jl/issues/2693.