### PR TITLE
Allow adding new levels to ordered arrays

### DIFF
--- a/docs/src/using.md
+++ b/docs/src/using.md
@@ -254,7 +254,7 @@ julia> x[1]
 CategoricalValue{String, UInt32} "Young" (1/3)
 ```
 
-In cases where levels with incompatible orderings are combined, the ordering of the first array wins and the resulting array is marked as unordered:
+In cases where levels with incompatible orderings are combined, the ordering of the destination array wins and the destination array is marked as unordered. The same happens when concatenating arrays, and the ordering of the first array wins in case of conflict:
 ```jldoctest using
 julia> a = categorical(["a", "b", "c"], ordered=true);
 
@@ -302,6 +302,8 @@ julia> levels(ab2)
 julia> isordered(ab2)
 false
 ```
+
+The resulting array is marked as ordered only if all the source array(s) are ordered, with the exception that unordered arrays with no levels do not prompt the result to be marked as unordered. In particular, this allows assignment of a `CategoricalValue` to an empty `CategoricalArray` via `setindex!` to copy the levels of the source value and to mark the result as ordered.
 
 Do note that in some cases the two sets of levels may have compatible orderings, but it is not possible to determine in what order should levels appear in the merged set. This is the case for example with `["a, "b", "d"]` and `["c", "d", "e"]`: there is no way to detect that `"c"` should be inserted exactly after `"b"` (lexicographic ordering is not relevant here). In such cases, the resulting array is marked as unordered. This situation can only happen when working with data subsets selected based on non-contiguous subsets of levels.
 

--- a/docs/src/using.md
+++ b/docs/src/using.md
@@ -234,31 +234,24 @@ julia> isordered(xy)
 true
 ```
 
-Likewise, assigning a `CategoricalValue` from `y` to an entry in `x` expands the levels of `x`, *adding a new level to the front to respect the ordering of levels in both vectors*. The new level is added even if the assigned value belongs to another level which is already present in `x`. Note that adding new levels requires marking `x` as unordered:
+Likewise, assigning a `CategoricalValue` from `y` to an entry in `x` expands the levels of `x`, *respecting the ordering of levels of both vectors if possible*. The new level is added even if the assigned value belongs to another level which is already present in `x`. Note that adding new levels requires marking `x` as unordered:
 ```jldoctest using
-julia> x[1] = y[1]
-ERROR: cannot add new level Young since ordered pools cannot be extended implicitly. Use the levels! function to set new levels, or the ordered! function to mark the pool as unordered.
-Stacktrace:
-[...]
-
-julia> ordered!(x, false);
-
 julia> levels(x)
 2-element Array{String,1}:
  "Middle"
  "Old"
 
 julia> x[1] = y[1]
-CategoricalValue{String,UInt32} "Young" (1/2)
-
-julia> x[1]
-CategoricalValue{String,UInt32} "Young"
+CategoricalValue{String, UInt32} "Young" (1/2)
 
 julia> levels(x)
-3-element Array{String,1}:
+3-element Vector{String}:
  "Young"
  "Middle"
  "Old"
+
+julia> x[1]
+CategoricalValue{String, UInt32} "Young" (1/3)
 ```
 
 In cases where levels with incompatible orderings are combined, the ordering of the first array wins and the resulting array is marked as unordered:

--- a/docs/src/using.md
+++ b/docs/src/using.md
@@ -234,7 +234,7 @@ julia> isordered(xy)
 true
 ```
 
-Likewise, assigning a `CategoricalValue` from `y` to an entry in `x` expands the levels of `x`, *respecting the ordering of levels of both vectors if possible*. The new level is added even if the assigned value belongs to another level which is already present in `x`. Note that adding new levels requires marking `x` as unordered:
+Likewise, assigning a `CategoricalValue` from `y` to an entry in `x` expands the levels of `x` with all levels from `y`, *respecting the ordering of levels of both vectors if possible*:
 ```jldoctest using
 julia> levels(x)
 2-element Array{String,1}:

--- a/src/CategoricalArrays.jl
+++ b/src/CategoricalArrays.jl
@@ -2,7 +2,7 @@ module CategoricalArrays
     export CategoricalPool, CategoricalValue
     export AbstractCategoricalArray, AbstractCategoricalVector, AbstractCategoricalMatrix,
            CategoricalArray, CategoricalVector, CategoricalMatrix
-    export LevelsException, OrderedLevelsException
+    export LevelsException
 
     export categorical, compress, decompress, droplevels!, levels, levels!, levelcode,
            isordered, ordered!

--- a/src/array.jl
+++ b/src/array.jl
@@ -462,21 +462,10 @@ function merge_pools!(A::CatArrOrSub,
                       B::Union{CategoricalValue, CatArrOrSub};
                       updaterefs::Bool=true,
                       updatepool::Bool=true)
-    if isordered(A) && length(pool(A)) > 0 && pool(B) ⊈ pool(A)
-        # TODO: extend OrderedLevelsException to take all values in setdiff(levels(B), levels(A))
-        lev = first(setdiff(levels(B), levels(A)))
-        throw(OrderedLevelsException(lev, levels(A)))
-    end
     newlevels, ordered = merge_pools(pool(A), pool(B))
     oldlevels = levels(A)
-    if isordered(A) != ordered
-        A isa SubArray &&
-            throw(ArgumentError("cannot set ordered=$ordered on dest SubArray as it " *
-                                "would affect the parent. "*
-                                "Found when trying to set levels to $newlevels."))
-        ordered!(A, ordered)
-    end
     pA = A isa SubArray ? parent(A) : A
+    ordered!(pA, ordered)
     # If A's levels are an ordered superset of new (merged) pool, no need to recompute refs
     if updaterefs &&
         (length(newlevels) < length(oldlevels) ||

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -138,10 +138,7 @@ end
 
 @inline function Base.get!(pool::CategoricalPool, level::Any)
     get!(pool.invindex, level) do
-        if isordered(pool)
-            throw(OrderedLevelsException(level, pool.levels))
-        end
-
+        ordered!(pool, false)
         push_level!(pool, level)
     end
 end
@@ -151,15 +148,9 @@ end
         return refcode(level)
     end
     if level.pool ⊈ pool
-        if isordered(pool)
-            throw(OrderedLevelsException(level, pool.levels))
-        end
-        newlevs, ordered = mergelevels(isordered(pool), pool.levels, level.pool.levels)
-        # Exception: empty pool marked as ordered if new value is ordered
-        if length(pool) == 0 && isordered(level.pool)
-            ordered!(pool, true)
-        end
+        newlevs, ordered = merge_pools(pool, level.pool)
         levels!(pool, newlevs)
+        ordered!(pool, ordered)
     end
     get!(pool, unwrap(level))
 end
@@ -192,7 +183,8 @@ function merge_pools(a::CategoricalPool{T}, b::CategoricalPool) where {T}
         newlevs = copy(levels(a))
         ordered = isordered(a)
     else
-        nl, ordered = mergelevels(isordered(a), a.levels, b.levels)
+        ordered = isordered(a) && (isordered(b) || b ⊆ a)
+        nl, ordered = mergelevels(ordered, a.levels, b.levels)
         newlevs = convert(Vector{T}, nl)
     end
     newlevs, ordered
@@ -285,10 +277,4 @@ ordered!(pool::CategoricalPool, ordered) = (pool.ordered = ordered; pool)
 function Base.showerror(io::IO, err::LevelsException{T, R}) where {T, R}
     levs = join(repr.(err.levels), ", ", " and ")
     print(io, "cannot store level(s) $levs since reference type $R can only hold $(typemax(R)) levels. Use the decompress function to make room for more levels.")
-end
-
-
-# OrderedLevelsException
-function Base.showerror(io::IO, err::OrderedLevelsException)
-    print(io, "cannot add new level $(err.newlevel) since ordered pools cannot be extended implicitly. Use the levels! function to set new levels, or the ordered! function to mark the pool as unordered.")
 end

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -75,7 +75,16 @@ it doesn't do this itself to avoid doing a dict lookup twice
     i
 end
 
-function mergelevels(ordered, levels...)
+"""
+    mergelevels(ordered::Bool, levels::AbstractVector...) -> (vec::Vector, ordered′::Bool)
+
+Merge vectors of values `levels` and return:
+- `vec`: a superset of all values in `levels`, respecting orders of values
+  in each vector of levels if possible
+- `ordered′`: if `ordered=true`, whether order comparisons between all pairs
+  of levels in `vec` have a defined result based on orders of values in input `levels`
+"""
+function mergelevels(ordered::Bool, levels::AbstractVector...)
     T = cat_promote_eltype(levels...)
     res = Vector{T}(undef, 0)
 
@@ -214,6 +223,7 @@ end
     end
 end
 
+# Efficient equivalent of issubset(levels(a), levels(b)), i.e. ignoring order
 function Base.issubset(a::CategoricalPool, b::CategoricalPool)
     pa = pointer_from_objref(a)
     pb = pointer_from_objref(b)

--- a/src/typedefs.jl
+++ b/src/typedefs.jl
@@ -61,11 +61,6 @@ struct LevelsException{T, R} <: Exception
     levels::Vector{T}
 end
 
-struct OrderedLevelsException{T, S} <: Exception
-    newlevel::S
-    levels::Vector{T}
-end
-
 ## Values
 
 """

--- a/test/07_levels.jl
+++ b/test/07_levels.jl
@@ -103,11 +103,8 @@ using CategoricalArrays: DefaultRefType, levels!, hashlevels
     @test pool[10] === CategoricalValue(pool, 10)
     @test pool[11] === CategoricalValue(pool, 11)
 
-    # get!
+    # get! adding new level works even for ordered pool
     ordered!(pool, true)
-    @test_throws OrderedLevelsException get!(pool, 1000)
-    ordered!(pool, false)
-
     @test get!(pool, 20) === DefaultRefType(12)
 
     @test isa(pool.levels, Vector{Int})
@@ -126,10 +123,6 @@ using CategoricalArrays: DefaultRefType, levels!, hashlevels
 
     # get! with CategoricalValue adding new levels in compatible order
     v = CategoricalValue(CategoricalPool([2, 4, 100, 99]), 4)
-
-    ordered!(pool, true)
-    @test_throws OrderedLevelsException get!(pool, v)
-    ordered!(pool, false)
 
     @test get!(pool, v) === DefaultRefType(14)
 

--- a/test/12_missingarray.jl
+++ b/test/12_missingarray.jl
@@ -373,14 +373,11 @@ const ≅ = isequal
             @test x[2] === CategoricalValue(x.pool, 2)
             @test x[3] === missing
 
-            if ordered
-                @test_throws OrderedLevelsException x[3] = "c"
-                levels!(x, [levels(x); "c"])
-            end
             x[3] = "c"
             @test x[1] === CategoricalValue(x.pool, 2)
             @test x[2] === CategoricalValue(x.pool, 2)
             @test x[3] === CategoricalValue(x.pool, 3)
+            @test isordered(x) === false
             @test levels(x) == ["a", "b", "c"]
 
             x[1] = missing
@@ -582,28 +579,24 @@ const ≅ = isequal
         @test levels(x) == unique(a)
         @test unique(x) == unique(collect(x))
 
-        if ordered
-            @test_throws OrderedLevelsException x[1:2] .= -1
-            levels!(x, [levels(x); -1])
-        end
         x[1:2] .= -1
         @test x[1] === CategoricalValue(x.pool, 5)
         @test x[2] === CategoricalValue(x.pool, 5)
         @test x[3] === CategoricalValue(x.pool, 3)
         @test x[4] === CategoricalValue(x.pool, 4)
+        @test isordered(x) === false
         @test levels(x) == vcat(unique(a), -1)
         @test unique(x) == unique(collect(x))
 
-        if ordered
-            @test_throws OrderedLevelsException push!(x, 2.0)
-            levels!(x, [levels(x); 2.0])
-        end
+
+        ordered!(x, ordered)
         push!(x, 2.0)
         @test length(x) == 5
         @test x == [-1.0, -1.0, 1.0, 1.5, 2.0]
-        @test isordered(x) === ordered
+        @test isordered(x) === false
         @test levels(x) == [0.0,  0.5,  1.0,  1.5, -1.0,  2.0]
 
+        ordered!(x, ordered)
         push!(x, x[1])
         @test length(x) == 6
         @test x == [-1.0, -1.0, 1.0, 1.5, 2.0, -1.0]
@@ -748,10 +741,6 @@ const ≅ = isequal
         @test x[1:2,1] == ["a", "b"]
         @test isa(x[1:2,1], CategoricalVector{Union{String, Missing}, R})
 
-        if ordered
-            @test_throws OrderedLevelsException x[1] = "z"
-            levels!(x, [levels(x); "z"])
-        end
         x[1] = "z"
         @test x[1] === CategoricalValue(x.pool, 4)
         @test x[2] === CategoricalValue(x.pool, 2)
@@ -759,6 +748,7 @@ const ≅ = isequal
         @test x[4] === CategoricalValue(x.pool, 1)
         @test x[5] === CategoricalValue(x.pool, 3)
         @test x[6] === CategoricalValue(x.pool, 3)
+        @test isordered(x) === false
         @test levels(x) == ["a", "b", "c", "z"]
 
         x[1,:] .= "a"
@@ -908,10 +898,6 @@ const ≅ = isequal
         @test_throws BoundsError x[1:1, -1:1]
         @test_throws BoundsError x[4, :]
 
-        if ordered
-            @test_throws OrderedLevelsException x[1] = "z"
-            levels!(x, [levels(x); "z"])
-        end
         x[1] = "z"
         @test x[1] === CategoricalValue(x.pool, 4)
         @test x[2] === CategoricalValue(x.pool, 2)
@@ -919,6 +905,7 @@ const ≅ = isequal
         @test x[4] === CategoricalValue(x.pool, 1)
         @test x[5] === CategoricalValue(x.pool, 3)
         @test x[6] === missing
+        @test isordered(x) === false
         @test levels(x) == ["a", "b", "c", "z"]
 
         x[1,:] .= "a"
@@ -1015,36 +1002,30 @@ const ≅ = isequal
         @test isordered(x2) === isordered(x)
         @test levels(x2) == []
 
-        if ordered
-            @test_throws OrderedLevelsException x[1] = "c"
-            levels!(x, [levels(x); "c"])
-        end
         x[1] = "c"
         @test x[1] === CategoricalValue(x.pool, 1)
         @test ismissing(x[2])
+        @test isordered(x) === false
         @test levels(x) == ["c"]
 
-        if ordered
-            @test_throws OrderedLevelsException x[1] = "a"
-            levels!(x, [levels(x); "a"])
-        end
+        ordered!(x, ordered)
         x[1] = "a"
         @test x[1] === CategoricalValue(x.pool, 2)
         @test ismissing(x[2])
+        @test isordered(x) === false
         @test levels(x) == ["c", "a"]
 
+        ordered!(x, ordered)
         x[2] = missing
         @test x[1] === CategoricalValue(x.pool, 2)
         @test x[2] === missing
+        @test isordered(x) === ordered
         @test levels(x) == ["c", "a"]
 
-        if ordered
-            @test_throws OrderedLevelsException x[1] = "b"
-            levels!(x, [levels(x); "b"])
-        end
         x[1] = "b"
         @test x[1] === CategoricalValue(x.pool, 3)
         @test x[2] === missing
+        @test isordered(x) === false
         @test levels(x) == ["c", "a", "b"]
         end
     end

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -262,17 +262,10 @@ end
 
         for copyf! in (copy!, copyto!)
             x2 = copy(x)
-            if ordered
-                @test_throws OrderedLevelsException copyf!(x2, y)
-                @test x2 == x
-                @test levels(x2) == ["Young", "Middle", "Old"]
-                @test isordered(x2)
-            else
-                @test copyf!(x2, y) === x2
-                @test x2 == y
-                @test levels(x2) == ["Young", "Middle", "Old", "X", "Y", "Z"]
-                @test !isordered(x2)
-            end
+            @test copyf!(x2, y) === x2
+            @test x2 == y
+            @test levels(x2) == ["Young", "Middle", "Old", "X", "Y", "Z"]
+            @test !isordered(x2)
         end
 
         x = CategoricalArray{Union{T, String}}(["Old", "Young", "Middle", "Young"])
@@ -286,17 +279,10 @@ end
             x[3] = x2[3] = missing
             y[3] = a[2] = missing
         end
-        if ordered
-            @test_throws OrderedLevelsException copyto!(x2, 1, y, 2)
-            @test x2 ≅ x
-            @test levels(x2) == ["Young", "Middle", "Old"]
-            @test isordered(x2)
-        else
-            @test copyto!(x2, 1, y, 2) === x2
-            @test x2 ≅ a
-            @test levels(x2) == ["Young", "Middle", "Old", "X", "Y", "Z"]
-            @test !isordered(x2)
-        end
+        @test copyto!(x2, 1, y, 2) === x2
+        @test x2 ≅ a
+        @test levels(x2) == ["Young", "Middle", "Old", "X", "Y", "Z"]
+        @test !isordered(x2)
 
         @testset "0-length copy!/copyto!" begin
             # 0-length copy!/copyto! does nothing (including bounds checks) except setting levels
@@ -304,91 +290,51 @@ end
             v = y[1:0]
 
             x2 = copy(x)
-            if ordered
-                @test_throws OrderedLevelsException copyto!(x2, 1, y, 3, 0)
-                @test levels(x2) == ["Young", "Middle", "Old"]
-            else
-                @test copyto!(x2, 1, y, 3, 0) === x2
-                @test levels(x2) == ["Young", "Middle", "Old", "X", "Y", "Z"]
-            end
-            @test isordered(x2) === ordered
+            @test copyto!(x2, 1, y, 3, 0) === x2
+            @test levels(x2) == ["Young", "Middle", "Old", "X", "Y", "Z"]
+            @test !isordered(x2)
             @test x2 ≅ x
 
             x2 = copy(x)
-            if ordered
-                @test_throws OrderedLevelsException copyto!(x2, 1, y, 5, 0)
-                @test levels(x2) == ["Young", "Middle", "Old"]
-            else
-                @test copyto!(x2, 1, y, 5, 0) === x2
-                @test levels(x2) == ["Young", "Middle", "Old", "X", "Y", "Z"]
-            end
-            @test isordered(x2) === ordered
+            @test copyto!(x2, 1, y, 5, 0) === x2
+            @test levels(x2) == ["Young", "Middle", "Old", "X", "Y", "Z"]
+            @test !isordered(x2)
             @test x2 ≅ x
 
             u2 = copy(u)
-            if ordered
-                @test_throws OrderedLevelsException copyto!(u2, -5, v, 2, 0)
-                @test levels(u2) == ["Young", "Middle", "Old"]
-            else
-                @test copyto!(u2, -5, v, 2, 0) === u2
-                @test levels(u2) == ["Young", "Middle", "Old", "X", "Y", "Z"]
-            end
-            @test isordered(x2) === ordered
+            @test copyto!(u2, -5, v, 2, 0) === u2
+            @test levels(u2) == ["Young", "Middle", "Old", "X", "Y", "Z"]
+            @test !isordered(x2)
             @test isempty(u2)
 
             x2 = copy(x)
-            if ordered
-                @test_throws OrderedLevelsException copyto!(x2, -5, v, 2, 0)
-                @test levels(x2) == ["Young", "Middle", "Old"]
-            else
-                @test copyto!(x2, -5, v, 2, 0) === x2
-                @test levels(x2) == ["Young", "Middle", "Old", "X", "Y", "Z"]
-            end
-            @test isordered(x2) === ordered
+            @test copyto!(x2, -5, v, 2, 0) === x2
+            @test levels(x2) == ["Young", "Middle", "Old", "X", "Y", "Z"]
+            @test !isordered(x2)
             @test x2 ≅ x
 
             u2 = copy(u)
-            if ordered
-                @test_throws OrderedLevelsException copyto!(u2, v)
-                @test levels(u2) == ["Young", "Middle", "Old"]
-            else
-                @test copyto!(u2, v) === u2
-                @test levels(u2) == ["Young", "Middle", "Old", "X", "Y", "Z"]
-            end
-            @test isordered(x2) === ordered
+            @test copyto!(u2, v) === u2
+            @test levels(u2) == ["Young", "Middle", "Old", "X", "Y", "Z"]
+            @test !isordered(x2)
             @test isempty(u2)
 
             x2 = copy(x)
-            if ordered
-                @test_throws OrderedLevelsException copyto!(x2, v)
-                @test levels(x2) == ["Young", "Middle", "Old"]
-            else
-                @test copyto!(x2, v) === x2
-                @test levels(x2) == ["Young", "Middle", "Old", "X", "Y", "Z"]
-            end
-            @test isordered(x2) === ordered
+            @test copyto!(x2, v) === x2
+            @test levels(x2) == ["Young", "Middle", "Old", "X", "Y", "Z"]
+            @test !isordered(x2)
             @test x2 ≅ x
 
             u2 = copy(u)
-            if ordered
-                @test_throws OrderedLevelsException copy!(u2, v)
-                @test levels(u2) == ["Young", "Middle", "Old"]
-            else
-                @test copy!(u2, v) === u2
-                @test levels(u2) == ["Young", "Middle", "Old", "X", "Y", "Z"]
-            end
-            @test isordered(x2) === ordered
+            @test copy!(u2, v) === u2
+            @test levels(u2) == ["Young", "Middle", "Old", "X", "Y", "Z"]
+            @test !isordered(x2)
             @test isempty(u2)
 
             x2 = copy(x)
-            if ordered
-                @test_throws OrderedLevelsException copy!(x2, v)
-                @test levels(x2) == ["Young", "Middle", "Old"]
-            else
-                @test copy!(x2, v) === x2
-                @test levels(x2) == ["Young", "Middle", "Old", "X", "Y", "Z"]
-            end
-            @test isordered(x2) === ordered
+            @test copy!(x2, v) === x2
+            @test levels(x2) == ["Young", "Middle", "Old", "X", "Y", "Z"]
+            @test !isordered(x2)
             @test x2 ≅ x
 
             # test with zero-levels source
@@ -563,14 +509,11 @@ end
             # Destination without any levels should be marked as ordered
             src = levels!(CategoricalVector(v, ordered=true), reverse(v))
             dest = CategoricalVector{Union{String,Missing}}([missing, missing])
-            dest2 = copy(dest)
-            vdest = view(dest2, 1:2)
-            res = @test_throws ArgumentError copyf!(vdest, src)
-            @test res.value.msg == "cannot set ordered=true on dest SubArray as it would " *
-                "affect the parent. Found when trying to set levels to [\"b\", \"a\"]."
-            @test dest2 ≅ dest
-            @test levels(dest2) == levels(vdest) == levels(dest)
-            @test !isordered(dest2) && !isordered(vdest)
+            vdest = view(dest, 1:2)
+            copyf!(vdest, src)
+            @test dest ≅ src
+            @test levels(vdest) == levels(dest)
+            @test isordered(dest)
         end
 
         @testset "copy a src into viewed dest and breaking orderedness" begin
@@ -578,21 +521,17 @@ end
             src = levels!(CategoricalVector(v), reverse(v))
             dest = CategoricalVector{String}(["e", "f", "g"], ordered=true)
             vdest = view(dest, 1:2)
-            res = @test_throws OrderedLevelsException copyf!(vdest, src)
-            @test res.value.newlevel == "b"
-            @test res.value.levels == levels(dest)
-            @test dest[1:2] ==  ["e", "f"]
-            @test levels(dest) == levels(vdest) == ["e", "f", "g"]
-            @test isordered(dest) && isordered(vdest)
+            copyf!(vdest, src)
+            @test dest[1:2] == ["a", "b"]
+            @test levels(dest) == levels(vdest) == ["e", "f", "g", "b", "a"]
+            @test !isordered(dest) && !isordered(vdest)
 
             dest = CategoricalVector{String}(["e", "f"], ordered=true)
             vdest = view(dest, 1:2)
-            res = @test_throws OrderedLevelsException copyf!(vdest, src)
-            @test res.value.newlevel == "b"
-            @test res.value.levels == levels(dest)
-            @test dest == ["e", "f"]
-            @test levels(dest) == levels(vdest) == ["e", "f"]
-            @test isordered(dest) && isordered(vdest)
+            copyf!(vdest, src)
+            @test dest == ["a", "b"]
+            @test levels(dest) == levels(vdest) == ["e", "f", "b", "a"]
+            @test !isordered(dest) && !isordered(vdest)
         end
 
         @testset "viable mixed src and dest types" begin
@@ -781,10 +720,9 @@ end
         ordered!(x, true)
         y = CategoricalArray{Union{T, String}}(["Middle", "Middle", "Old", "Young"])
         levels!(y, ["X", "Young", "Middle", "Old"])
-        res = @test_throws OrderedLevelsException copyf!(x, y)
-        @test res.value.newlevel == "X"
-        @test levels(x) == ["Young", "Middle", "Old"]
-        @test isordered(x)
+        copyf!(x, y)
+        @test levels(x) == ["X", "Young", "Middle", "Old"]
+        @test !isordered(x)
     end
 
     @testset "fill!()" begin
@@ -1610,23 +1548,6 @@ end
     end
 end
 
-@testset "new levels can't be added through assignment when levels are ordered" begin
-    x = categorical([1,2,3])
-    ordered!(x, true)
-    lev = copy(levels(x))
-    res = @test_throws OrderedLevelsException{Int, Float64} x[1] = 4.0
-    @test res.value.newlevel == 4
-    @test sprint(showerror, res.value) ==
-        "cannot add new level 4.0 since ordered pools cannot be extended implicitly. " *
-        "Use the levels! function to set new levels, or the ordered! function to mark the pool as unordered."
-    @test lev == levels(x)
-
-    # Assignment works after adding the level to the pool
-    levels!(x, [3,4,1,2])
-    x[1] = 4
-    @test x == [4,2,3]
-end
-
 @testset "float() and complex()" begin
     x = categorical([1,2,3])
     @test float(x) == x
@@ -1719,37 +1640,22 @@ end
 
         b = ["z","y","x"]
         y = CategoricalVector{String}(b)
-        if ordered
-            @test_throws OrderedLevelsException append!(x, y)
-            @test isordered(x) === ordered
-            @test length(x) == 6
-            @test x == ["a", "b", "c", "a", "b", "c"]
-            @test levels(x) == ["a", "b", "c"]
-        else
-            append!(x, y)
-            @test isordered(x) === ordered
-            @test length(x) == 9
-            @test x == ["a", "b", "c", "a", "b", "c", "z", "y", "x"]
-            @test levels(x) == ["a", "b", "c", "x", "y", "z"]
-        end
+        ordered!(x, ordered)
+        append!(x, y)
+        @test !isordered(x)
+        @test length(x) == 9
+        @test x == ["a", "b", "c", "a", "b", "c", "z", "y", "x"]
+        @test levels(x) == ["a", "b", "c", "x", "y", "z"]
 
         z1 = view(CategoricalVector{String}(["ex1", "ex2"]), 1)
         z2 = view(CategoricalVector{String}(["ex3", "ex4"]), 1:1)
-        if ordered
-            @test_throws OrderedLevelsException append!(x, z1)
-            @test_throws OrderedLevelsException append!(x, z2)
-            @test isordered(x) === ordered
-            @test length(x) == 6
-            @test x == ["a", "b", "c", "a", "b", "c"]
-            @test levels(x) == ["a", "b", "c"]
-        else
-            append!(x, z1)
-            append!(x, z2)
-            @test isordered(x) === ordered
-            @test length(x) == 11
-            @test x == ["a", "b", "c", "a", "b", "c", "z", "y", "x", "ex1", "ex3"]
-            @test levels(x) == ["a", "b", "c", "x", "y", "z", "ex1", "ex2", "ex3", "ex4"]
-        end
+        ordered!(x, ordered)
+        append!(x, z1)
+        append!(x, z2)
+        @test !isordered(x)
+        @test length(x) == 11
+        @test x == ["a", "b", "c", "a", "b", "c", "z", "y", "x", "ex1", "ex3"]
+        @test levels(x) == ["a", "b", "c", "x", "y", "z", "ex1", "ex2", "ex3", "ex4"]
     end
 
     @testset "append! Float64" begin
@@ -1764,36 +1670,21 @@ end
 
         b = [2.5, 3.0, 3.5]
         y = CategoricalVector{Float64}(b, ordered=ordered)
-        if ordered
-            @test_throws OrderedLevelsException append!(x, y)
-            @test length(x) == 6
-            @test x == [-1.0, 0.0, 1.0, -1.0, 0.0, 1.0]
-            @test isordered(x) === ordered
-            @test levels(x) == [-1.0, 0.0, 1.0]
-        else
-            append!(x, y)
-            @test length(x) == 9
-            @test x == [-1.0, 0.0, 1.0, -1.0, 0.0, 1.0, 2.5, 3.0, 3.5]
-            @test isordered(x) === ordered
-            @test levels(x) == [-1.0, 0.0, 1.0, 2.5, 3.0, 3.5]
-        end
+        append!(x, y)
+        @test length(x) == 9
+        @test x == [-1.0, 0.0, 1.0, -1.0, 0.0, 1.0, 2.5, 3.0, 3.5]
+        @test !isordered(x)
+        @test levels(x) == [-1.0, 0.0, 1.0, 2.5, 3.0, 3.5]
 
         z1 = view(CategoricalVector{Float64}([100.0, 101.0]), 1)
         z2 = view(CategoricalVector{Float64}([102.0, 103.0]), 1:1)
-        if ordered
-            @test_throws OrderedLevelsException append!(x, y)
-            @test length(x) == 6
-            @test x == [-1.0, 0.0, 1.0, -1.0, 0.0, 1.0]
-            @test isordered(x) === ordered
-            @test levels(x) == [-1.0, 0.0, 1.0]
-        else
-            append!(x, z1)
-            append!(x, z2)
-            @test length(x) == 11
-            @test x == [-1.0, 0.0, 1.0, -1.0, 0.0, 1.0, 2.5, 3.0, 3.5, 100.0, 102.0]
-            @test isordered(x) === ordered
-            @test levels(x) == [-1.0, 0.0, 1.0, 2.5, 3.0, 3.5, 100.0, 101.0, 102.0, 103.0]
-        end
+        ordered!(x, ordered)
+        append!(x, z1)
+        append!(x, z2)
+        @test length(x) == 11
+        @test x == [-1.0, 0.0, 1.0, -1.0, 0.0, 1.0, 2.5, 3.0, 3.5, 100.0, 102.0]
+        @test !isordered(x)
+        @test levels(x) == [-1.0, 0.0, 1.0, 2.5, 3.0, 3.5, 100.0, 101.0, 102.0, 103.0]
     end
 end
 
@@ -1810,37 +1701,22 @@ end
 
         b = ["x","y",missing]
         y = CategoricalVector{Union{String, Missing}}(b)
-        if ordered
-            @test_throws OrderedLevelsException append!(x, y)
-            @test x ≅ [a; a]
-            @test levels(x) == ["a", "b"]
-            @test isordered(x) === ordered
-            @test length(x) == 6
-        else
-            append!(x, y)
-            @test length(x) == 9
-            @test isordered(x) === ordered
-            @test levels(x) == ["a", "b", "x", "y"]
-            @test x ≅ [a; a; b]
-        end
+        ordered!(x, ordered)
+        append!(x, y)
+        @test length(x) == 9
+        @test !isordered(x)
+        @test levels(x) == ["a", "b", "x", "y"]
+        @test x ≅ [a; a; b]
 
         z1 = view(CategoricalVector{Union{String, Missing}}([missing, "ex2"]), 1)
         z2 = view(CategoricalVector{Union{String, Missing}}(["ex3", "ex4"]), 1:1)
-        if ordered
-            @test_throws OrderedLevelsException append!(x, z1)
-            @test_throws OrderedLevelsException append!(x, z2)
-            @test x ≅ [a; a]
-            @test levels(x) == ["a", "b"]
-            @test isordered(x) === ordered
-            @test length(x) == 6
-        else
-            append!(x, z1)
-            append!(x, z2)
-            @test length(x) == 11
-            @test isordered(x) === ordered
-            @test levels(x) == ["a", "b", "x", "y", "ex2", "ex3", "ex4"]
-            @test x ≅ [a; a; b; missing; "ex3"]
-        end
+        ordered!(x, ordered)
+        append!(x, z1)
+        append!(x, z2)
+        @test length(x) == 11
+        @test !isordered(x)
+        @test levels(x) == ["a", "b", "x", "y", "ex2", "ex3", "ex4"]
+        @test x ≅ [a; a; b; missing; "ex3"]
     end
 
     @testset "Float64" begin
@@ -1855,37 +1731,22 @@ end
 
         b = [2.5, 3.0, missing]
         y = CategoricalVector{Union{Float64, Missing}}(b)
-        if ordered
-            @test_throws OrderedLevelsException append!(x, y)
-            @test length(x) == 6
-            @test x == [a; a]
-            @test isordered(x) === ordered
-            @test levels(x) == [0.0,  0.5,  1.0]
-        else
-            append!(x, y)
-            @test length(x) == 9
-            @test x ≅ [a; a; b]
-            @test isordered(x) === ordered
-            @test levels(x) == [0.0, 0.5, 1.0, 2.5, 3.0]
-        end
+        ordered!(x, ordered)
+        append!(x, y)
+        @test length(x) == 9
+        @test x ≅ [a; a; b]
+        @test !isordered(x)
+        @test levels(x) == [0.0, 0.5, 1.0, 2.5, 3.0]
 
         z1 = view(CategoricalVector{Union{Float64, Missing}}([missing, 101.0]), 1)
         z2 = view(CategoricalVector{Union{Float64, Missing}}([102.0, 103.0]), 1:1)
-        if ordered
-            @test_throws OrderedLevelsException append!(x, z1)
-            @test_throws OrderedLevelsException append!(x, z2)
-            @test length(x) == 6
-            @test x == [a; a]
-            @test isordered(x) === ordered
-            @test levels(x) == [0.0,  0.5,  1.0]
-        else
-            append!(x, z1)
-            append!(x, z2)
-            @test length(x) == 11
-            @test x ≅ [a; a; b; missing; 102.0]
-            @test isordered(x) === ordered
-            @test levels(x) == [0.0, 0.5, 1.0, 2.5, 3.0, 101.0, 102.0, 103.0]
-        end
+        ordered!(x, ordered)
+        append!(x, z1)
+        append!(x, z2)
+        @test length(x) == 11
+        @test x ≅ [a; a; b; missing; 102.0]
+        @test !isordered(x)
+        @test levels(x) == [0.0, 0.5, 1.0, 2.5, 3.0, 101.0, 102.0, 103.0]
     end
 end
 
@@ -1899,31 +1760,18 @@ end
         @test isordered(x) === ordered
         @test levels(x) == ["a", "b", "c"]
 
-        if ordered
-            @test_throws OrderedLevelsException push!(x, "z")
-            @test isordered(x) === ordered
-            @test x == ["a", "b", "c", "a"]
-            @test levels(x) == ["a", "b", "c"]
-        else
-            push!(x, "z")
-            @test isordered(x) === ordered
-            @test x == ["a", "b", "c", "a", "z"]
-            @test levels(x) == ["a", "b", "c", "z"]
-        end
+        push!(x, "z")
+        @test !isordered(x)
+        @test x == ["a", "b", "c", "a", "z"]
+        @test levels(x) == ["a", "b", "c", "z"]
 
         b = ["z","y","x"]
         y = CategoricalVector{String}(b)
-        if ordered
-            @test_throws OrderedLevelsException push!(x, y[1])
-            @test isordered(x) === ordered
-            @test x == ["a", "b", "c", "a"]
-            @test levels(x) == ["a", "b", "c"]
-        else
-            push!(x, y[1])
-            @test isordered(x) === ordered
-            @test x == ["a", "b", "c", "a", "z", "z"]
-            @test levels(x) == ["a", "b", "c", "x", "y", "z"]
-        end
+        ordered!(x, ordered)
+        push!(x, y[1])
+        @test !isordered(x)
+        @test x == ["a", "b", "c", "a", "z", "z"]
+        @test levels(x) == ["a", "b", "c", "x", "y", "z"]
     end
 
     @testset "push! Float64" begin
@@ -1935,31 +1783,18 @@ end
         @test isordered(x) === ordered
         @test levels(x) == [-1.0, 0.0, 1.0]
 
-        if ordered
-            @test_throws OrderedLevelsException push!(x, 3.0)
-            @test x == [-1.0, 0.0, 1.0, 0.0]
-            @test isordered(x) === ordered
-            @test levels(x) == [-1.0, 0.0, 1.0]
-        else
-            push!(x, 3.0)
-            @test x == [-1.0, 0.0, 1.0, 0.0, 3.0]
-            @test isordered(x) === ordered
-            @test levels(x) == [-1.0, 0.0, 1.0, 3.0]
-        end
+        push!(x, 3.0)
+        @test x == [-1.0, 0.0, 1.0, 0.0, 3.0]
+        @test !isordered(x)
+        @test levels(x) == [-1.0, 0.0, 1.0, 3.0]
 
         b = [2.5, 3.0, 3.5]
         y = CategoricalVector{Float64}(b, ordered=ordered)
-        if ordered
-            @test_throws OrderedLevelsException push!(x, y[1])
-            @test x == [-1.0, 0.0, 1.0, 0.0]
-            @test isordered(x) === ordered
-            @test levels(x) == [-1.0, 0.0, 1.0]
-        else
-            push!(x, y[1])
-            @test x == [-1.0, 0.0, 1.0, 0.0, 3.0, 2.5]
-            @test isordered(x) === ordered
-            @test levels(x) == [-1.0, 0.0, 1.0, 2.5, 3.0, 3.5]
-        end
+        ordered!(x, ordered)
+        push!(x, y[1])
+        @test x == [-1.0, 0.0, 1.0, 0.0, 3.0, 2.5]
+        @test !isordered(x)
+        @test levels(x) == [-1.0, 0.0, 1.0, 2.5, 3.0, 3.5]
     end
 end
 


### PR DESCRIPTION
Instead, mark arrays as unordered if one of the pools is unordered, if pools have incompatible orderings or if orders of all pairs of levels cannot be determined.
This ensures that operations supported by any `AbstractArray` never fail for `CategoricalArray`. An additional `protected` setting could be added to manually decide to lock levels of ordered or unordered `CategoricalArray`s.

Fixes https://github.com/JuliaData/DataFrames.jl/issues/2672.