### PR TITLE
Add `refcode`, deprecate `level`

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -499,7 +499,7 @@ end
 end
 
 Base.fill(v::CategoricalValue{T}, dims::NTuple{N, Integer}) where {T, N} =
-    CategoricalArray{T, N}(fill(level(v), dims), copy(pool(v)))
+    CategoricalArray{T, N}(fill(refcode(v), dims), copy(pool(v)))
 
 # to avoid ambiguity
 Base.fill(v::CategoricalValue, dims::Tuple{}) =

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -15,3 +15,4 @@ end
 import Base: get
 
 @deprecate get(x::CategoricalValue) DataAPI.unwrap(x)
+@deprecate level(x::CategoricalValue) refcode(x) false

--- a/src/value.jl
+++ b/src/value.jl
@@ -12,7 +12,7 @@ reftype(::Type{<:CategoricalValue{<:Any, R}}) where {R} = R
 reftype(x::Any) = reftype(typeof(x))
 
 pool(x::CategoricalValue) = x.pool
-level(x::CategoricalValue) = x.level
+refcode(x::CategoricalValue) = x.level
 isordered(x::CategoricalValue) = isordered(x.pool)
 
 # extract the type of the original value from array eltype `T`
@@ -29,7 +29,7 @@ unwrap_catvaluetype(::Type{T}) where {T <: CategoricalValue} = leveltype(T)
 
 Get the value wrapped by categorical value `x`. If `x` is `Missing` return `missing`.
 """
-DataAPI.unwrap(x::CategoricalValue) = levels(x)[level(x)]
+DataAPI.unwrap(x::CategoricalValue) = levels(x)[refcode(x)]
 
 """
     levelcode(x::CategoricalValue)
@@ -37,7 +37,7 @@ DataAPI.unwrap(x::CategoricalValue) = levels(x)[level(x)]
 Get the code of categorical value `x`, i.e. its index in the set
 of possible values returned by [`levels(x)`](@ref DataAPI.levels).
 """
-levelcode(x::CategoricalValue) = Signed(widen(level(x)))
+levelcode(x::CategoricalValue) = Signed(widen(refcode(x)))
 
 """
     levelcode(x::Missing)
@@ -107,7 +107,7 @@ Base.String(x::CategoricalValue{<:AbstractString}) = String(unwrap(x))
 
 @inline function Base.:(==)(x::CategoricalValue, y::CategoricalValue)
     if pool(x) === pool(y)
-        return level(x) == level(y)
+        return refcode(x) == refcode(y)
     else
         return unwrap(x) == unwrap(y)
     end
@@ -118,7 +118,7 @@ Base.:(==)(x::SupportedTypes, y::CategoricalValue) = x == unwrap(y)
 
 @inline function Base.isequal(x::CategoricalValue, y::CategoricalValue)
     if pool(x) === pool(y)
-        return level(x) == level(y)
+        return refcode(x) == refcode(y)
     else
         return isequal(unwrap(x), unwrap(y))
     end

--- a/test/01_value.jl
+++ b/test/01_value.jl
@@ -1,7 +1,7 @@
 module TestValue
 using Test
 using CategoricalArrays
-using CategoricalArrays: DefaultRefType, level,  reftype, leveltype
+using CategoricalArrays: DefaultRefType, refcode,  reftype, leveltype
 
 @testset "leveltype on non CategoricalValue types" begin
     @test leveltype("abc") === String
@@ -28,7 +28,7 @@ end
         @test reftype(typeof(x)) === DefaultRefType
         @test x isa CategoricalValue{String, DefaultRefType}
 
-        @test level(x) === DefaultRefType(i)
+        @test refcode(x) === DefaultRefType(i)
         @test CategoricalArrays.pool(x) === pool
 
         @test typeof(x)(x) === x
@@ -54,7 +54,7 @@ end
         @test reftype(typeof(x)) === UInt8
         @test x isa CategoricalValue{String, UInt8}
 
-        @test level(x) === UInt8(i)
+        @test refcode(x) === UInt8(i)
         @test CategoricalArrays.pool(x) === pool
 
         @test typeof(x)(x) === x

--- a/test/17_deprecated.jl
+++ b/test/17_deprecated.jl
@@ -13,4 +13,9 @@ const ≅ = isequal
     @test x ≅ ["[1, 2)", missing, missing]
 end
 
+@testset "level" begin
+    x = categorical(["a", "b", missing])
+    @test CategoricalArrays.level(x[1]) === CategoricalArrays.refcode(x[1])
+end
+
 end


### PR DESCRIPTION
This allows supporting both CategoricalArrays 0.10 and 0.9.