### PR TITLE
Add uniquelevels(), fix unique() behaviour

### DIFF
--- a/src/CategoricalArrays.jl
+++ b/src/CategoricalArrays.jl
@@ -5,7 +5,7 @@ module CategoricalArrays
     export LevelsException
 
     export categorical, compress, decompress, droplevels!, levels, levels!, levelcode,
-           isordered, ordered!
+           isordered, ordered!, uniquelevels
     export cut, recode, recode!
 
     import DataAPI: unwrap

--- a/src/array.jl
+++ b/src/array.jl
@@ -1,7 +1,7 @@
 ## Code for CategoricalArray
 
 import Base: Array, convert, collect, copy, getindex, setindex!, similar, size,
-             vcat, in, summary, float, complex, copyto!
+             unique, vcat, in, summary, float, complex, copyto!
 
 # Used for keyword argument default value
 _isordered(x::AbstractCategoricalArray) = isordered(x)
@@ -834,6 +834,18 @@ function uniquelevels(A::AbstractCategoricalArray{T}) where T
     alevs = levels(A)
     T[ref == 0 ? missing : @inbounds alevs[ref]
       for ref in _uniquerefs(A)]
+end
+
+unique(A::AbstractCategoricalArray{T}) where T =
+    CategoricalVector{T}(_uniquerefs(A), copy(pool(A)))
+
+function unique!(A::CategoricalVector{T}) where T
+    _urefs = _uniquerefs(A)
+    if length(_urefs) != length(A)
+        resize!(A.refs, length(_urefs))
+        copyto!(A.refs, _urefs)
+    end
+    return A
 end
 
 """

--- a/src/array.jl
+++ b/src/array.jl
@@ -769,7 +769,7 @@ function levels!(A::CategoricalArray{T, N, R}, newlevels::Vector;
     end
     if !allunique(newlevels)
         throw(ArgumentError(string("duplicated levels found: ",
-                                   join(unique(filter(x->sum(newlevels.==x)>1, newlevels)), ", "))))
+                                   join(unique(filter(x->sum(==(x), newlevels)>1, newlevels)), ", "))))
     end
 
     oldlevels = levels(A.pool)

--- a/src/array.jl
+++ b/src/array.jl
@@ -1,7 +1,7 @@
 ## Code for CategoricalArray
 
 import Base: Array, convert, collect, copy, getindex, setindex!, similar, size,
-             unique, vcat, in, summary, float, complex, copyto!
+             vcat, in, summary, float, complex, copyto!
 
 # Used for keyword argument default value
 _isordered(x::AbstractCategoricalArray) = isordered(x)
@@ -804,31 +804,37 @@ function levels!(A::CategoricalArray{T, N, R}, newlevels::Vector;
     A
 end
 
-function _unique(::Type{S},
-                 refs::AbstractArray{T},
-                 pool::CategoricalPool) where {S, T<:Integer}
-    nlevels = length(levels(pool)) + 1
-    order = fill(0, nlevels) # 0 indicates not seen
-    # If we don't track missings, short-circuit even if none has been seen
-    count = S >: Missing ? 0 : 1
-    @inbounds for i in refs
-        if order[i + 1] == 0
-            count += 1
-            order[i + 1] = count
-            count == nlevels && break
+# return unique refs (each value is unique) in the order of appearance in `refs`
+# similar to fallback Base.unique() implementation,
+# but short-circuits once references to all levels are encountered
+function _uniquerefs(A::AbstractCategoricalArray{T}) where T
+    arefs = refs(A)
+    res = similar(arefs, 0)
+    nlevels = length(levels(A))
+    seen = fill(false, nlevels+1) # +1 for 0 (missing ref)
+    maxunique = nlevels + (T >: Missing ? 1 : 0)
+    @inbounds for ref in arefs
+        if !seen[ref + 1]
+            push!(res, ref)
+            seen[ref + 1] = true
+            (length(res) == maxunique) && break
         end
     end
-    S[i == 1 ? missing : levels(pool)[i - 1] for i in sortperm(order) if order[i] != 0]
+    return res
 end
 
 """
-    unique(A::CategoricalArray)
+    uniquelevels(A::AbstractCategoricalArray)
 
 Return levels which appear in `A` in their order of appearance.
 This function is significantly slower than [`levels`](@ref DataAPI.levels)
 since it needs to check whether levels are used or not.
 """
-unique(A::CategoricalArray{T}) where {T} = _unique(T, A.refs, A.pool)
+function uniquelevels(A::AbstractCategoricalArray{T}) where T
+    alevs = levels(A)
+    T[ref == 0 ? missing : @inbounds alevs[ref]
+      for ref in _uniquerefs(A)]
+end
 
 """
     droplevels!(A::CategoricalArray)
@@ -836,7 +842,7 @@ unique(A::CategoricalArray{T}) where {T} = _unique(T, A.refs, A.pool)
 Drop levels which do not appear in categorical array `A` (so that they will no longer be
 returned by [`levels`](@ref DataAPI.levels)).
 """
-droplevels!(A::CategoricalArray) = levels!(A, intersect(levels(A), unique(A)))
+droplevels!(A::CategoricalArray) = levels!(A, intersect(levels(A), uniquelevels(A)))
 
 """
     isordered(A::CategoricalArray)

--- a/src/subarray.jl
+++ b/src/subarray.jl
@@ -6,13 +6,6 @@ isordered(sa::SubArray{T,N,P}) where {T,N,P<:CategoricalArray} = isordered(paren
 levels!(sa::SubArray{T,N,P}, newlevels::Vector) where {T,N,P<:CategoricalArray} =
     levels!(parent(sa), newlevels)
 
-function unique(sa::SubArray{T,N,P}) where {T,N,P<:CategoricalArray}
-    A = parent(sa)
-    refs = view(A.refs, sa.indices...)
-    S = eltype(P) >: Missing ? Union{eltype(levels(A.pool)), Missing} : eltype(levels(A.pool))
-    _unique(S, refs, A.pool)
-end
-
 refs(A::SubArray{<:Any, <:Any, <:CategoricalArray}) =
     view(parent(A).refs, parentindices(A)...)
 

--- a/test/11_array.jl
+++ b/test/11_array.jl
@@ -15,7 +15,7 @@ using CategoricalArrays: DefaultRefType, leveltype
     @test eltype(x) === CategoricalValue{String, R}
     @test isordered(x) === ordered
     @test levels(x) == sort(unique(a))
-    @test unique(x) == unique(a)
+    @test uniquelevels(x) == unique(a)
     @test size(x) === (3,)
     @test length(x) === 3
 
@@ -236,7 +236,7 @@ using CategoricalArrays: DefaultRefType, leveltype
 
         @test x == collect(a)
         @test isordered(x) === ordered
-        @test levels(x) == unique(x) == unique(a)
+        @test levels(x) == uniquelevels(x) == unique(a)
         @test size(x) === (4,)
         @test length(x) === 4
         @test leveltype(x) === Float64
@@ -401,7 +401,7 @@ using CategoricalArrays: DefaultRefType, leveltype
         @test x[3] === CategoricalValue(x.pool, 3)
         @test x[4] === CategoricalValue(x.pool, 4)
         @test levels(x) == unique(a)
-        @test unique(x) == unique(collect(x))
+        @test uniquelevels(x) == unique(collect(x))
 
         x[1:2] .= -1
         @test x[1] === CategoricalValue(x.pool, 5)
@@ -409,7 +409,7 @@ using CategoricalArrays: DefaultRefType, leveltype
         @test x[3] === CategoricalValue(x.pool, 3)
         @test x[4] === CategoricalValue(x.pool, 4)
         @test levels(x) == vcat(unique(a), -1)
-        @test unique(x) == unique(collect(x))
+        @test uniquelevels(x) == unique(collect(x))
 
         push!(x, 2.0)
         @test length(x) == 5
@@ -437,7 +437,7 @@ using CategoricalArrays: DefaultRefType, leveltype
 
         @test x == a
         @test isordered(x) === ordered
-        @test levels(x) == unique(x) == unique(a)
+        @test levels(x) == uniquelevels(x) == unique(a)
         @test size(x) === (2, 3)
         @test length(x) === 6
 
@@ -693,28 +693,28 @@ end
     x = CategoricalArray(["Old", "Young", "Middle", "Young"])
     @test levels!(x, ["Young", "Middle", "Old"]) === x
     @test levels(x) == ["Young", "Middle", "Old"]
-    @test unique(x) == ["Old", "Young", "Middle"]
+    @test uniquelevels(x) == ["Old", "Young", "Middle"]
     @test levels!(x, ["Young", "Middle", "Old", "Unused"]) === x
     @test levels(x) == ["Young", "Middle", "Old", "Unused"]
-    @test unique(x) == ["Old", "Young", "Middle"]
+    @test uniquelevels(x) == ["Old", "Young", "Middle"]
     @test levels!(x, ["Unused1", "Young", "Middle", "Old", "Unused2"]) === x
     @test levels(x) == ["Unused1", "Young", "Middle", "Old", "Unused2"]
-    @test unique(x) == ["Old", "Young", "Middle"]
+    @test uniquelevels(x) == ["Old", "Young", "Middle"]
 
     x = CategoricalArray(String[])
     @test isa(levels(x), Vector{String}) && isempty(levels(x))
-    @test isa(unique(x), Vector{String}) && isempty(unique(x))
+    @test isa(uniquelevels(x), Vector{String}) && isempty(uniquelevels(x))
     @test levels!(x, ["Young", "Middle", "Old"]) === x
     @test levels(x) == ["Young", "Middle", "Old"]
-    @test isa(unique(x), Vector{String}) && isempty(unique(x))
+    @test isa(uniquelevels(x), Vector{String}) && isempty(uniquelevels(x))
 
     # To test short-circuiting
     x = CategoricalArray(repeat(1:10, inner=10))
     @test levels(x) == collect(1:10)
-    @test unique(x) == collect(1:10)
+    @test uniquelevels(x) == collect(1:10)
     @test levels!(x, [19:-1:1; 20]) === x
     @test levels(x) == [19:-1:1; 20]
-    @test unique(x) == collect(1:10)
+    @test uniquelevels(x) == collect(1:10)
 end
 
 end

--- a/test/12_missingarray.jl
+++ b/test/12_missingarray.jl
@@ -18,7 +18,7 @@ const ≅ = isequal
                 @test eltype(x) === Union{CategoricalValue{String, R}, Missing}
                 @test isordered(x) === ordered
                 @test levels(x) == sort(unique(a))
-                @test unique(x) == unique(a)
+                @test uniquelevels(x) == unique(a)
                 @test size(x) === (3,)
                 @test length(x) === 3
 
@@ -257,7 +257,7 @@ const ≅ = isequal
 
             @test x ≅ a
             @test levels(x) == filter(x->!ismissing(x), unique(a))
-            @test unique(x) ≅ unique(a)
+            @test uniquelevels(x) ≅ unique(a)
             @test size(x) === (3,)
             @test length(x) === 3
 
@@ -401,7 +401,7 @@ const ≅ = isequal
 
         @test x == collect(a)
         @test isordered(x) === ordered
-        @test levels(x) == unique(x) == unique(a)
+        @test levels(x) == uniquelevels(x) == unique(a)
         @test size(x) === (4,)
         @test length(x) === 4
         @test leveltype(x) === Float64
@@ -577,7 +577,7 @@ const ≅ = isequal
         @test x[3] === CategoricalValue(x.pool, 3)
         @test x[4] === CategoricalValue(x.pool, 4)
         @test levels(x) == unique(a)
-        @test unique(x) == unique(collect(x))
+        @test uniquelevels(x) == unique(collect(x))
 
         x[1:2] .= -1
         @test x[1] === CategoricalValue(x.pool, 5)
@@ -586,7 +586,7 @@ const ≅ = isequal
         @test x[4] === CategoricalValue(x.pool, 4)
         @test isordered(x) === false
         @test levels(x) == vcat(unique(a), -1)
-        @test unique(x) == unique(collect(x))
+        @test uniquelevels(x) == unique(collect(x))
 
 
         ordered!(x, ordered)
@@ -617,7 +617,7 @@ const ≅ = isequal
 
         @test x == a
         @test isordered(x) === ordered
-        @test levels(x) == unique(x) == unique(a)
+        @test levels(x) == uniquelevels(x) == unique(a)
         @test size(x) === (2, 3)
         @test length(x) === 6
 
@@ -777,7 +777,7 @@ const ≅ = isequal
         @test x ≅ a
         @test isordered(x) === ordered
         @test levels(x) == filter(x->!ismissing(x), unique(a))
-        @test unique(x) ≅ unique(a)
+        @test uniquelevels(x) ≅ unique(a)
         @test size(x) === (2, 3)
         @test length(x) === 6
 
@@ -1095,35 +1095,35 @@ end
     @test isordered(r)
 end
 
-@testset "unique() and levels()" begin
+@testset "uniquelevels() and levels()" begin
     x = CategoricalArray(["Old", "Young", "Middle", missing, "Young"])
     @test levels(x) == ["Middle", "Old", "Young"]
-    @test unique(x) ≅ ["Old", "Young", "Middle", missing]
+    @test uniquelevels(x) ≅ ["Old", "Young", "Middle", missing]
     @test levels!(x, ["Young", "Middle", "Old"]) === x
     @test levels(x) == ["Young", "Middle", "Old"]
-    @test unique(x) ≅ ["Old", "Young", "Middle", missing]
+    @test uniquelevels(x) ≅ ["Old", "Young", "Middle", missing]
     @test levels!(x, ["Young", "Middle", "Old", "Unused"]) === x
     @test levels(x) == ["Young", "Middle", "Old", "Unused"]
-    @test unique(x) ≅ ["Old", "Young", "Middle", missing]
+    @test uniquelevels(x) ≅ ["Old", "Young", "Middle", missing]
     @test levels!(x, ["Unused1", "Young", "Middle", "Old", "Unused2"]) === x
     @test levels(x) == ["Unused1", "Young", "Middle", "Old", "Unused2"]
-    @test unique(x) ≅ ["Old", "Young", "Middle", missing]
+    @test uniquelevels(x) ≅ ["Old", "Young", "Middle", missing]
 
     x = CategoricalArray((Union{String, Missing})[missing])
     @test isa(levels(x), Vector{String}) && isempty(levels(x))
-    @test unique(x) ≅ [missing]
+    @test uniquelevels(x) ≅ [missing]
     @test levels!(x, ["Young", "Middle", "Old"]) === x
     @test levels(x) == ["Young", "Middle", "Old"]
-    @test unique(x) ≅ [missing]
+    @test uniquelevels(x) ≅ [missing]
 
     # To test short-circuiting
     x = CategoricalArray{Union{Int, Missing}}(repeat(1:10, inner=10))
     @test levels(x) == collect(1:10)
-    @test unique(x) == collect(1:10)
+    @test uniquelevels(x) == collect(1:10)
     @test levels!(x, [19:-1:1; 20]) === x
     x[3] = missing
     @test levels(x) == [19:-1:1; 20]
-    @test unique(x) ≅ [1; missing; 2:10]
+    @test uniquelevels(x) ≅ [1; missing; 2:10]
 
     # in
     x = CategoricalArray{Int}(repeat(1:1500, inner=10))


### PR DESCRIPTION
A draft of a solution for #357, this PR renames `unique(::CategoricalArray)` to `uniquelevels(::CategoricalArray)` as it better reflects what this method does.
As a byproduct, the internal implementation of `uniquelevels()` is cleaned up and optimized a bit (avoid intermediate array sorting, generalize to `AbstractCategoricalArray`).

The PR also re-adds `Base.unique(::CategoricalArray)` with the expected behaviour (returns `CategoricalVector` of unique values).
The new `unique()` is not yet covered by unit tests. I'll do that if the overall approach would be considered ok.

Fixes #357