### PR TITLE
droplevels!(): more efficient implementation

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -849,13 +849,15 @@ function droplevels!(A::CategoricalArray)
             (nseen == nlevels) && return A # all levels observed, nothing to drop
         end
     end
-    # recode refs to keep only the seen ones (optimized version of update_refs!())
-    levelsmap = cumsum(seen)
-    @inbounds for i in eachindex(arefs)
-        arefs[i] = levelsmap[arefs[i] + 1] - 1
-    end
+
     # replace the pool
     A.pool = typeof(pool(A))(@inbounds(levels(A)[view(seen, 2:nlevels)]), isordered(A))
+    # recode refs to keep only the seen ones (optimized version of update_refs!())
+    seen[1] = false # to start levelsmap from 0
+    levelsmap = cumsum(seen)
+    @inbounds for i in eachindex(arefs)
+        arefs[i] = levelsmap[Int(arefs[i]) + 1]
+    end
     return A
 end
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -838,7 +838,7 @@ returned by [`levels`](@ref DataAPI.levels)).
 """
 function droplevels!(A::CategoricalArray)
     arefs = refs(A)
-    nlevels = length(levels(A))+1 # +1 for missing
+    nlevels = length(levels(A)) + 1 # +1 for missing
     seen = fill(false, nlevels)
     seen[1] = true # assume that missing is always observed to simplify checks
     nseen = 1


### PR DESCRIPTION
Replace the current one-line implementation of `droplevels!()` as behind the scenes it requires sorting and arrays intersection.
The new implementation scans the array only once, and doesn't rebuild the array when all levels are observed.