### PR TITLE
levels!(): enhance performance

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -788,31 +788,52 @@ function levels!(A::CategoricalArray{T, N, R}, newlevels::Vector;
         oldref2newref[i + 1] = get(newlv2ref, lv, 0)
     end
 
-    # first pass to check whether, if some levels are removed, changes can be applied without error
-    # TODO: save original levels and undo changes in case of error to skip this step
-    # equivalent to issubset but faster due to JuliaLang/julia#24624
+    # create the new pool early (throws if the new levels could not be encoded with R)
+    newpool = CategoricalPool{nonmissingtype(T), R}(copy(newlevels), isordered(A))
+
+    # recode the refs
+    arefs = A.refs
+    # check whether potentially an error can occur due to a missing level
     if (!(T >: Missing) || !allowmissing) && any(iszero, @view oldref2newref[2:end])
-        @inbounds for (i, x) in enumerate(A.refs)
-            if x > 0 && (oldref2newref[x + 1] == 0)
-                msg = "cannot remove level $(repr(oldlevels[x])) as it is used at position $i"
-                if !(T >: Missing)
-                    msg *= ". Change the array element type to Union{$T, Missing}" *
-                           " using convert if you want to transform some levels to missing values."
-                elseif !allowmissing
-                    msg *= " and allowmissing=false."
-                end
-                throw(ArgumentError(msg))
+        # slow pass, check for missing levels
+        failedpos = 0
+        @inbounds for (i, oldref) in enumerate(arefs)
+            newref = oldref2newref[oldref + 1]
+            if (oldref > 0) && (newref == 0)
+                failedpos = i
+                break
             end
+            arefs[i] = newref
+        end
+
+        if failedpos > 0 # a missing at failedpos, revert the changes to A.refs
+            # build the inverse ref map
+            newref2oldref = fill(0, length(newlevels) + 1)
+            @inbounds for (oldref, newref) in enumerate(oldref2newref)
+                newref2oldref[newref + 1] = oldref - 1
+            end
+            newref2oldref[1] = 0 # missing stays missing
+            # revert the refs
+            @inbounds for i in 1:(failedpos - 1)
+                arefs[i] = newref2oldref[arefs[i] + 1]
+            end
+            # throw an error
+            msg = "cannot remove level $(repr(oldlevels[arefs[failedpos]])) as it is used at position $failedpos"
+            if !(T >: Missing)
+                msg *= ". Change the array element type to Union{$T, Missing}" *
+                       " using convert if you want to transform some levels to missing values."
+            elseif !allowmissing
+                msg *= " and allowmissing=false."
+            end
+            throw(ArgumentError(msg))
+        end
+    else # fast pass, either introducing new missings is allowed or no new missings can occur
+        @inbounds for i in eachindex(arefs)
+            arefs[i] = oldref2newref[arefs[i] + 1]
         end
     end
+    A.pool = newpool # update the pool
 
-    # replace the pool
-    A.pool = CategoricalPool{nonmissingtype(T), R}(copy(newlevels), isordered(A))
-    # recode refs
-    arefs = A.refs
-    @inbounds for i in eachindex(arefs)
-        arefs[i] = oldref2newref[arefs[i] + 1]
-    end
     return A
 end
 

--- a/test/11_array.jl
+++ b/test/11_array.jl
@@ -188,8 +188,16 @@ using CategoricalArrays: DefaultRefType, leveltype
     @test x[3] === CategoricalValue(x.pool, 1)
 
     @test_throws ArgumentError levels!(x, ["a"])
+    # check that x is restored correctly when dropping levels is not allowed
+    @test x == ["a", "b", "b"]
+    @test levels(x) == ["b", "a"]
+
     @test_throws ArgumentError levels!(x, ["e", "b"])
+
     @test_throws ArgumentError levels!(x, ["e", "a", "b", "a"])
+    # once again check that x is restored correctly when dropping levels is not allowed
+    @test x == ["a", "b", "b"]
+    @test levels(x) == ["b", "a"]
 
     @test levels!(x, ["e", "a", "b"]) === x
     @test levels(x) == ["e", "a", "b"]

--- a/test/12_missingarray.jl
+++ b/test/12_missingarray.jl
@@ -200,8 +200,16 @@ const ≅ = isequal
                 @test levels(x) == ["b", "a"]
 
                 @test_throws ArgumentError levels!(x, ["a"])
+                # check that x is restored correctly when dropping levels is not allowed
+                @test x == ["a", "b", "b"]
+                @test levels(x) == ["b", "a"]
+
                 @test_throws ArgumentError levels!(x, ["e", "b"])
+
                 @test_throws ArgumentError levels!(x, ["e", "a", "b", "a"])
+                # once again check that x is restored correctly when dropping levels is not allowed
+                @test x == ["a", "b", "b"]
+                @test levels(x) == ["b", "a"]
 
                 @test levels!(x, ["e", "a", "b"]) === x
                 @test levels(x) == ["e", "a", "b"]
@@ -216,13 +224,16 @@ const ≅ = isequal
                 @test x[3] === CategoricalValue(x.pool, 3)
                 @test levels(x) == ["e", "a", "b", "c"]
 
+                # check once more that x is restored correctly when dropping levels is not allowed
                 @test_throws ArgumentError levels!(x, ["e", "c"])
+                @test x == ["c", "b", "b"]
+                @test levels(x) == ["e", "a", "b", "c"]
+                # check that with allowed missings the absent levels are converted to missing
                 @test levels!(x, ["e", "c"], allowmissing=true) === x
                 @test levels(x) == ["e", "c"]
                 @test x[1] === CategoricalValue(x.pool, 2)
                 @test x[2] === missing
                 @test x[3] === missing
-                @test levels(x) == ["e", "c"]
 
                 push!(x, "e")
                 @test length(x) == 4


### PR DESCRIPTION
Enhance the performance of `levels!()` by avoiding redundant checks for duplicate new levels, levels intersection, recoding etc.
These checks become expensive as the number of levels grow.