### PR TITLE
Fix tests on Julia 1.9 nightlies

### DIFF
--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -1952,11 +1952,11 @@ end
 
 @testset "repeat" begin
     for o in (false, true), c in (false, true), i in 0:2,
-        a in [["b", "a", "b"], ["b" "a"; "b" "c"],
-              [missing, "a", "b"], ["b" "a"; missing "c"]],
-        x in [categorical(a, ordered=o, compress=c),
+        a in (["b", "a", "b"], ["b" "a"; "b" "c"],
+              [missing, "a", "b"], ["b" "a"; missing "c"]),
+        x in (categorical(a, ordered=o, compress=c),
               view(categorical(a, ordered=o, compress=c), axes(a)...),
-              view(categorical([a a], ordered=o, compress=c), axes(a)...)]
+              view(categorical([a a], ordered=o, compress=c), axes(a)...))
         xr = @inferred repeat(x, i)
         @test which(repeat, (typeof(x), Int)).module == CategoricalArrays
         @test typeof(parent(x)) == typeof(xr)


### PR DESCRIPTION
A recent change on Julia master (JuliaLang/julia#44096) makes an array of arrays use more precise promotion, which ends up converting `CategoricalArray`s into `Vector`s.