### PR TITLE
Add parse method

### DIFF
--- a/src/value.jl
+++ b/src/value.jl
@@ -118,6 +118,7 @@ Base.print(io::IO, x::CategoricalValue) = print(io, unwrap(x))
 Base.string(x::CategoricalValue) = string(unwrap(x))
 Base.write(io::IO, x::CategoricalValue) = write(io, unwrap(x))
 Base.String(x::CategoricalValue{<:AbstractString}) = String(unwrap(x))
+Base.parse(T::DataType, catval::CategoricalValue) = parse(T, unwrap(catval))
 
 @inline function Base.:(==)(x::CategoricalValue, y::CategoricalValue)
     if pool(x) === pool(y) || pool(x) == pool(y)


### PR DESCRIPTION
Motivation:

```
julia> using CategoricalArrays

julia> x = categorical(["2", "1"], ordered=true)
2-element CategoricalArray{String,1,UInt32}:
 "2"
 "1"

julia> parse(Int64, x[1])
ERROR: MethodError: no method matching parse(::Type{Int64}, ::CategoricalValue{String, UInt32})
Closest candidates are:
  parse(::Type{T}, ::AbstractChar; base) where T<:Integer at C:\Users\Dennis Bal\.julia\juliaup\julia-1.7.1+0~x64\share\julia\base\parse.jl:40
  parse(::Type{T}, ::AbstractString; base) where T<:Integer at C:\Users\Dennis Bal\.julia\juliaup\julia-1.7.1+0~x64\share\julia\base\parse.jl:240
  parse(::Type{T}, ::AbstractString; kwargs...) where T<:Real at C:\Users\Dennis Bal\.julia\juliaup\julia-1.7.1+0~x64\share\julia\base\parse.jl:379
Stacktrace:
 [1] top-level scope
   @ REPL[176]:1

julia> parse.(Int64, x)
ERROR: MethodError: no method matching parse(::Type{Int64}, ::CategoricalValue{String, UInt32})
Closest candidates are:
  parse(::Type{T}, ::AbstractChar; base) where T<:Integer at C:\Users\Dennis Bal\.julia\juliaup\julia-1.7.1+0~x64\share\julia\base\parse.jl:40
  parse(::Type{T}, ::AbstractString; base) where T<:Integer at C:\Users\Dennis Bal\.julia\juliaup\julia-1.7.1+0~x64\share\julia\base\parse.jl:240
  parse(::Type{T}, ::AbstractString; kwargs...) where T<:Real at C:\Users\Dennis Bal\.julia\juliaup\julia-1.7.1+0~x64\share\julia\base\parse.jl:379
Stacktrace:
 [1] _broadcast_getindex_evalf
   @ .\broadcast.jl:670 [inlined]
 [2] _broadcast_getindex
   @ .\broadcast.jl:653 [inlined]
 [3] getindex
   @ .\broadcast.jl:597 [inlined]
 [4] copy
   @ .\broadcast.jl:899 [inlined]
 [5] materialize(bc::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(parse), Tuple{Base.RefValue{Type{Int64}}, CategoricalVector{String, UInt32, String, CategoricalValue{String, UInt32}, Union{}}}})
   @ Base.Broadcast .\broadcast.jl:860
 [6] top-level scope
   @ REPL[177]:1

julia> import Base.parse

julia> parse(T::DataType, catval::CategoricalValue) = parse(T, unwrap(catval))
parse (generic function with 17 methods)

julia> parse(Int64, x[1])
2

julia> parse.(Int64, x)
2-element Vector{Int64}:
 2
 1
```

I am not sure if I added the code in the correct place, or if it makes more sense somewhere else. I also don't know if `Base.parse` would need to be explicitly imported. I just tried to do what has been done is the surrounding lines.