### PR TITLE
Allow strings and numbers as labels in cut

### DIFF
--- a/src/extras.jl
+++ b/src/extras.jl
@@ -72,7 +72,7 @@ julia> cut(-1:0.5:1, [0, 1], extend=true)
  "[-1.0, 0.0)"
  "[0.0, 1.0]"
  "[0.0, 1.0]"
- "[0.0, 1.0]"
+ "[0.0, 1.0]" 
 
 julia> cut(-1:0.5:1, 2)
 5-element CategoricalArray{String,1,UInt32}:
@@ -80,7 +80,7 @@ julia> cut(-1:0.5:1, 2)
  "Q1: [-1.0, 0.0)"
  "Q2: [0.0, 1.0]"
  "Q2: [0.0, 1.0]"
- "Q2: [0.0, 1.0]"
+ "Q2: [0.0, 1.0]" 
 
 julia> cut(-1:0.5:1, 2, labels=["A", "B"])
 5-element CategoricalArray{String,1,UInt32}:
@@ -88,15 +88,15 @@ julia> cut(-1:0.5:1, 2, labels=["A", "B"])
  "A"
  "B"
  "B"
- "B"
+ "B" 
 
- julia> cut(-1:0.5:1, 2, labels=[-0.5, +0.5])
- 5-element CategoricalArray{Float64,1,UInt32}:
-  -0.5
-  -0.5
-  0.5
-  0.5
-  0.5
+julia> cut(-1:0.5:1, 2, labels=[-0.5, +0.5])
+5-element CategoricalArray{Float64,1,UInt32}:
+ -0.5
+ -0.5
+ 0.5
+ 0.5
+ 0.5
 
 julia> fmt(from, to, i; leftclosed, rightclosed) = "grp $i ($from//$to)"
 fmt (generic function with 1 method)
@@ -161,11 +161,11 @@ function _cut(x::AbstractArray{T, N}, breaks::AbstractVector,
             end
         end
         if !ismissing(min_x) && breaks[1] > min_x
-            # this typecast is needed on Julia<1.7 for stable inference
-            breaks = eltype(breaks)[min_x; breaks]
+            # this type annotation is needed on Julia<1.7 for stable inference
+            breaks = [min_x::nonmissingtype(eltype(x)); breaks]
         end
         if !ismissing(max_x) && breaks[end] < max_x
-            breaks = eltype(breaks)[breaks; max_x]
+            breaks = [breaks; max_x::nonmissingtype(eltype(x))]
         end
         length(breaks) > 1 ||
             throw(ArgumentError("could not extend breaks as all values are equal: " *

--- a/src/extras.jl
+++ b/src/extras.jl
@@ -34,7 +34,7 @@ default_formatter(from, to, i; leftclosed, rightclosed) =
 
 @doc raw"""
     cut(x::AbstractArray, breaks::AbstractVector;
-        labels::Union{AbstractVector{<:AbstractString},Function},
+        labels::Union{AbstractVector,Function},
         extend::Union{Bool,Missing}=false, allowempty::Bool=false)
 
 Cut a numeric array into intervals at values `breaks`
@@ -52,7 +52,7 @@ also accept them.
   in `x` fall outside of the breaks; when `true`, breaks are automatically added to include
   all values in `x`, and the upper bound is included in the last interval; when `missing`,
   values outside of the breaks generate `missing` entries.
-* `labels::Union{AbstractVector,Function}`: a vector of strings giving the names to use for
+* `labels::Union{AbstractVector,Function}`: a vector of strings or numbers giving the names to use for
   the intervals; or a function `f(from, to, i; leftclosed, rightclosed)` that generates
   the labels from the left and right interval boundaries and the group index. Defaults to
   `"[from, to)"` (or `"[from, to]"` for the rightmost interval if `extend == true`).
@@ -89,6 +89,15 @@ julia> cut(-1:0.5:1, 2, labels=["A", "B"])
  "B"
  "B"
 
+ julia> cut(-1:0.5:1, 2, labels=[-0.5, +0.5])
+ levs = [-0.5, 0.5]
+ 5-element CategoricalArray{Float64,1,UInt32}:
+  -0.5
+  -0.5
+  0.5
+  0.5
+  0.5
+
 julia> fmt(from, to, i; leftclosed, rightclosed) = "grp $i ($from//$to)"
 fmt (generic function with 1 method)
 
@@ -103,7 +112,7 @@ julia> cut(-1:0.5:1, 3, labels=fmt)
 """
 @inline function cut(x::AbstractArray, breaks::AbstractVector;
                      extend::Union{Bool, Missing}=false,
-                     labels::Union{AbstractVector{<:AbstractString},Function}=default_formatter,
+                     labels::Union{AbstractVector{<:SupportedTypes},Function}=default_formatter,
                      allowmissing::Union{Bool, Nothing}=nothing,
                      allow_missing::Union{Bool, Nothing}=nothing,
                      allowempty::Bool=false)
@@ -123,8 +132,8 @@ end
 # Separate function for inferability (thanks to inlining of cut)
 function _cut(x::AbstractArray{T, N}, breaks::AbstractVector,
               extend::Union{Bool, Missing},
-              labels::Union{AbstractVector{<:AbstractString},Function},
-              allowempty::Bool=false) where {T, N}
+              labels::Union{AbstractVector{L},Function},
+              allowempty::Bool=false) where {T, N, L<:SupportedTypes}
     if !allowempty && !allunique(breaks)
         throw(ArgumentError("all breaks must be unique unless `allowempty=true`"))
     end
@@ -180,8 +189,11 @@ function _cut(x::AbstractArray{T, N}, breaks::AbstractVector,
     if labels isa Function
         from = breaks[1:n-1]
         to = breaks[2:n]
-        levs = Vector{String}(undef, n-1)
-        for i in 1:n-2
+        levs = [labels(from[1], to[1], 1,
+            leftclosed=breaks[1] != breaks[2], rightclosed=false)]
+        resize!(levs, n-1)
+        _L = eltype(levs)
+        for i in 2:n-2
             levs[i] = labels(from[i], to[i], i,
                              leftclosed=breaks[i] != breaks[i+1], rightclosed=false)
         end
@@ -191,8 +203,8 @@ function _cut(x::AbstractArray{T, N}, breaks::AbstractVector,
     else
         length(labels) == n-1 ||
             throw(ArgumentError("labels must be of length $(n-1), but got length $(length(labels))"))
-        # Levels must have element type String for type stability of the result
-        levs::Vector{String} = copy(labels)
+        levs = copy(labels)
+        _L = L
     end
     if !allunique(levs)
         if labels === default_formatter
@@ -204,7 +216,7 @@ function _cut(x::AbstractArray{T, N}, breaks::AbstractVector,
     end
 
     pool = CategoricalPool(levs, true)
-    S = T >: Missing || extend isa Missing ? Union{String, Missing} : String
+    S = T >: Missing || extend isa Missing ? Union{_L, Missing} : _L
     CategoricalArray{S, N}(refs, pool)
 end
 
@@ -227,7 +239,7 @@ If `x` contains `missing` values, they are automatically skipped when computing
 quantiles.
 
 # Keyword arguments
-* `labels::Union{AbstractVector,Function}`: a vector of strings giving the names to use for
+* `labels::Union{AbstractVector,Function}`: a vector of strings or numbers giving the names to use for
   the intervals; or a function `f(from, to, i; leftclosed, rightclosed)` that generates
   the labels from the left and right interval boundaries and the group index. Defaults to
   `"Qi: [from, to)"` (or `"Qi: [from, to]"` for the rightmost interval).
@@ -237,7 +249,7 @@ quantiles.
   (but duplicate labels are not allowed).
 """
 function cut(x::AbstractArray, ngroups::Integer;
-             labels::Union{AbstractVector{<:AbstractString},Function}=quantile_formatter,
+             labels::Union{AbstractVector{<:SupportedTypes},Function}=quantile_formatter,
              allowempty::Bool=false)
     xnm = eltype(x) >: Missing ? skipmissing(x) : x
     breaks = Statistics.quantile(xnm, (1:ngroups-1)/ngroups)

--- a/src/extras.jl
+++ b/src/extras.jl
@@ -52,7 +52,8 @@ also accept them.
   in `x` fall outside of the breaks; when `true`, breaks are automatically added to include
   all values in `x`, and the upper bound is included in the last interval; when `missing`,
   values outside of the breaks generate `missing` entries.
-* `labels::Union{AbstractVector, Function}`: a vector of strings or numbers giving the names to use for
+* `labels::Union{AbstractVector, Function}`: a vector of strings, characters
+  or numbers giving the names to use for
   the intervals; or a function `f(from, to, i; leftclosed, rightclosed)` that generates
   the labels from the left and right interval boundaries and the group index. Defaults to
   `"[from, to)"` (or `"[from, to]"` for the rightmost interval if `extend == true`).
@@ -190,7 +191,7 @@ function _cut(x::AbstractArray{T, N}, breaks::AbstractVector,
         from = breaks[1:n-1]
         to = breaks[2:n]
         firstlevel = labels(from[1], to[1], 1,
-            leftclosed=(breaks[1] != breaks[2]), rightclosed=false)
+                            leftclosed=breaks[1] != breaks[2], rightclosed=false)
         levs = Vector{typeof(firstlevel)}(undef, n-1)
         levs[1] = firstlevel
         for i in 2:n-2

--- a/src/extras.jl
+++ b/src/extras.jl
@@ -52,7 +52,7 @@ also accept them.
   in `x` fall outside of the breaks; when `true`, breaks are automatically added to include
   all values in `x`, and the upper bound is included in the last interval; when `missing`,
   values outside of the breaks generate `missing` entries.
-* `labels::Union{AbstractVector,Function}`: a vector of strings or numbers giving the names to use for
+* `labels::Union{AbstractVector, Function}`: a vector of strings or numbers giving the names to use for
   the intervals; or a function `f(from, to, i; leftclosed, rightclosed)` that generates
   the labels from the left and right interval boundaries and the group index. Defaults to
   `"[from, to)"` (or `"[from, to]"` for the rightmost interval if `extend == true`).
@@ -71,7 +71,7 @@ julia> cut(-1:0.5:1, [0, 1], extend=true)
  "[-1.0, 0.0)"
  "[0.0, 1.0]"
  "[0.0, 1.0]"
- "[0.0, 1.0]" 
+ "[0.0, 1.0]"
 
 julia> cut(-1:0.5:1, 2)
 5-element CategoricalArray{String,1,UInt32}:
@@ -79,7 +79,7 @@ julia> cut(-1:0.5:1, 2)
  "Q1: [-1.0, 0.0)"
  "Q2: [0.0, 1.0]"
  "Q2: [0.0, 1.0]"
- "Q2: [0.0, 1.0]" 
+ "Q2: [0.0, 1.0]"
 
 julia> cut(-1:0.5:1, 2, labels=["A", "B"])
 5-element CategoricalArray{String,1,UInt32}:
@@ -106,7 +106,7 @@ julia> cut(-1:0.5:1, 3, labels=fmt)
  "grp 1 (-1.0//-0.3333333333333335)"
  "grp 2 (-0.3333333333333335//0.33333333333333326)"
  "grp 3 (0.33333333333333326//1.0)"
- "grp 3 (0.33333333333333326//1.0)"      
+ "grp 3 (0.33333333333333326//1.0)"
 ```
 """
 @inline function cut(x::AbstractArray, breaks::AbstractVector;
@@ -131,8 +131,8 @@ end
 # Separate function for inferability (thanks to inlining of cut)
 function _cut(x::AbstractArray{T, N}, breaks::AbstractVector,
               extend::Union{Bool, Missing},
-              labels::Union{AbstractVector{L},Function},
-              allowempty::Bool=false) where {T, N, L<:SupportedTypes}
+              labels::Union{AbstractVector{<:SupportedTypes},Function},
+              allowempty::Bool=false) where {T, N}
     if !allowempty && !allunique(breaks)
         throw(ArgumentError("all breaks must be unique unless `allowempty=true`"))
     end
@@ -160,10 +160,11 @@ function _cut(x::AbstractArray{T, N}, breaks::AbstractVector,
             end
         end
         if !ismissing(min_x) && breaks[1] > min_x
-            breaks = [min_x; breaks]
+            # this typecast is needed on Julia<1.7 for stable inference
+            breaks = eltype(breaks)[min_x; breaks]
         end
         if !ismissing(max_x) && breaks[end] < max_x
-            breaks = [breaks; max_x]
+            breaks = eltype(breaks)[breaks; max_x]
         end
         length(breaks) > 1 ||
             throw(ArgumentError("could not extend breaks as all values are equal: " *
@@ -188,10 +189,10 @@ function _cut(x::AbstractArray{T, N}, breaks::AbstractVector,
     if labels isa Function
         from = breaks[1:n-1]
         to = breaks[2:n]
-        levs = [labels(from[1], to[1], 1,
-            leftclosed=breaks[1] != breaks[2], rightclosed=false)]
-        resize!(levs, n-1)
-        _L = eltype(levs)
+        firstlevel = labels(from[1], to[1], 1,
+            leftclosed=(breaks[1] != breaks[2]), rightclosed=false)
+        levs = Vector{typeof(firstlevel)}(undef, n-1)
+        levs[begin] = firstlevel
         for i in 2:n-2
             levs[i] = labels(from[i], to[i], i,
                              leftclosed=breaks[i] != breaks[i+1], rightclosed=false)
@@ -203,7 +204,6 @@ function _cut(x::AbstractArray{T, N}, breaks::AbstractVector,
         length(labels) == n-1 ||
             throw(ArgumentError("labels must be of length $(n-1), but got length $(length(labels))"))
         levs = copy(labels)
-        _L = L
     end
     if !allunique(levs)
         if labels === default_formatter
@@ -215,7 +215,7 @@ function _cut(x::AbstractArray{T, N}, breaks::AbstractVector,
     end
 
     pool = CategoricalPool(levs, true)
-    S = T >: Missing || extend isa Missing ? Union{_L, Missing} : _L
+    S = T >: Missing || extend isa Missing ? Union{eltype(levs), Missing} : eltype(levs)
     CategoricalArray{S, N}(refs, pool)
 end
 
@@ -238,7 +238,7 @@ If `x` contains `missing` values, they are automatically skipped when computing
 quantiles.
 
 # Keyword arguments
-* `labels::Union{AbstractVector,Function}`: a vector of strings, characters
+* `labels::Union{AbstractVector, Function}`: a vector of strings, characters
   or numbers giving the names to use for
   the intervals; or a function `f(from, to, i; leftclosed, rightclosed)` that generates
   the labels from the left and right interval boundaries and the group index. Defaults to

--- a/src/extras.jl
+++ b/src/extras.jl
@@ -90,7 +90,6 @@ julia> cut(-1:0.5:1, 2, labels=["A", "B"])
  "B"
 
  julia> cut(-1:0.5:1, 2, labels=[-0.5, +0.5])
- levs = [-0.5, 0.5]
  5-element CategoricalArray{Float64,1,UInt32}:
   -0.5
   -0.5
@@ -239,7 +238,8 @@ If `x` contains `missing` values, they are automatically skipped when computing
 quantiles.
 
 # Keyword arguments
-* `labels::Union{AbstractVector,Function}`: a vector of strings or numbers giving the names to use for
+* `labels::Union{AbstractVector,Function}`: a vector of strings, characters
+  or numbers giving the names to use for
   the intervals; or a function `f(from, to, i; leftclosed, rightclosed)` that generates
   the labels from the left and right interval boundaries and the group index. Defaults to
   `"Qi: [from, to)"` (or `"Qi: [from, to]"` for the rightmost interval).

--- a/src/extras.jl
+++ b/src/extras.jl
@@ -192,7 +192,7 @@ function _cut(x::AbstractArray{T, N}, breaks::AbstractVector,
         firstlevel = labels(from[1], to[1], 1,
             leftclosed=(breaks[1] != breaks[2]), rightclosed=false)
         levs = Vector{typeof(firstlevel)}(undef, n-1)
-        levs[begin] = firstlevel
+        levs[1] = firstlevel
         for i in 2:n-2
             levs[i] = labels(from[i], to[i], i,
                              leftclosed=breaks[i] != breaks[i+1], rightclosed=false)

--- a/test/15_extras.jl
+++ b/test/15_extras.jl
@@ -102,18 +102,18 @@ const ≅ = isequal
     @test isordered(x)
     @test levels(x) == [0,"2",4,"6",8]
 
-    labels = (from, to, i; leftclosed, rightclosed) -> (to+from)/2
-     x = @inferred cut(Vector{Union{T, Int}}([1,2,3,4,5,6,7,8]), 0:2:10, labels=labels)
-    @test x == [1.0, 3.0, 3.0, 5.0, 5.0, 7.0, 7.0, 9.0]
-    @test isa(x, CategoricalVector{Union{Float64, T}})
-    @test isordered(x)
-    @test levels(x) == [1.0, 3.0, 5.0, 7.0, 9.0]
+    @test_throws ArgumentError cut([-0.0, 0.0], 2)
+    @test_throws ArgumentError cut([-0.0, 0.0], 2, labels=[-0.0, 0.0])
 end
 
 @testset "cut with missing values in input" begin
     # use a large vector since values can be zero by chance
     x = [1; fill(missing, 100)]
     y = cut(x, [1, 5])
+    y[1] = missing
+    @test all(ismissing, y)
+
+    y = cut(x, [1, 5], labels=[1])
     y[1] = missing
     @test all(ismissing, y)
 end
@@ -140,13 +140,35 @@ end
     x = 0.15:0.20:0.95
     p = [0, 0.4, 0.8, 1.0]
 
-    @test cut(x, p, labels=my_formatter) ==
-        ["1: 0.0 -- 0.4", "1: 0.0 -- 0.4", "2: 0.4 -- 0.8", "2: 0.4 -- 0.8", "3: 0.8 -- 1.0"]
+    a = @inferred cut(x, p, labels=my_formatter)
+    @test a == ["1: 0.0 -- 0.4", "1: 0.0 -- 0.4", "2: 0.4 -- 0.8", "2: 0.4 -- 0.8", "3: 0.8 -- 1.0"]
 
     # GH 274
     my_formatter_2(from, to, i; leftclosed, rightclosed) = "$i: $(from+1) -- $(to+1)"
-    @test cut(x, p, labels=my_formatter_2) ==
-        ["1: 1.0 -- 1.4", "1: 1.0 -- 1.4", "2: 1.4 -- 1.8", "2: 1.4 -- 1.8", "3: 1.8 -- 2.0"]
+    a = @inferred cut(x, p, labels=my_formatter_2)
+    @test a == ["1: 1.0 -- 1.4", "1: 1.0 -- 1.4", "2: 1.4 -- 1.8", "2: 1.4 -- 1.8", "3: 1.8 -- 2.0"]
+
+    for T in [Union{}, Missing]
+        labels = (from, to, i; leftclosed, rightclosed) -> (to+from)/2
+        a = @inferred cut(Vector{Union{T, Int}}([1,2,3,4,5,6,7,8]), 0:2:10, labels=labels)
+        @test a == [1.0, 3.0, 3.0, 5.0, 5.0, 7.0, 7.0, 9.0]
+        @test isa(a, CategoricalVector{Union{Float64, T}})
+        @test isordered(a)
+        @test levels(a) == [1.0, 3.0, 5.0, 7.0, 9.0]
+
+        labels = (from, to, i; leftclosed, rightclosed) -> "$((to+from)/2)"
+        a = @inferred cut(Vector{Union{T, Int}}([1,2,3,4,5,6,7,8]), 0:2:10, labels=labels)
+        @test a == string.([1.0, 3.0, 3.0, 5.0, 5.0, 7.0, 7.0, 9.0])
+        @test isa(a, CategoricalVector{Union{String, T}})
+        @test isordered(a)
+        @test levels(a) == string.([1.0, 3.0, 5.0, 7.0, 9.0])
+    end
+
+    @test cut(Float64[0,1,2,3,4,5,6,7,8], 3, labels=[-0.0, 0.0, 1.0]) ==
+        [-0.0, -0.0, -0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
+
+    @test cut(Float64[-0.0, 0.0, 1.0, 2.0, 3.0, 4.0], [-0.0, 0.0, 5.0], labels=[-0.0, 0.0]) ==
+        [-0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
 end
 
 @testset "cut with duplicated breaks" begin
@@ -204,6 +226,12 @@ end
                                    labels=["1", "2", "2", "3"])
     @test_throws ArgumentError cut(1:10, [1, 3, 3, 5, 5, 11], allowempty=true,
                                    labels=["1", "2", "3", "2", "4"])
+
+    @test_throws ArgumentError cut([1,2,3,4,5,6,7,8], 0:2:10, labels=[0,1,1,2,3])
+    @test_throws ArgumentError cut([1,2,3,4,5,6,7,8], [0,2,2,6,8,10], labels=[0,1,1,2,3], allowempty=true)
+
+    fmt = (from, to, i; leftclosed, rightclosed) -> (i%2==0 ? to : 0.0)
+    @test_throws ArgumentError cut([1,2,3,4,5,6,7,8], 0:2:10, labels=fmt)
 end
 
 @testset "cut with extend=true" begin
@@ -220,6 +248,17 @@ end
     @test err.value.msg == "could not extend breaks as all values are missing: please specify at least two breaks manually"
 
     @test cut([missing], [1, 2], extend=true) ≅ [missing]
+
+    @test cut(Float64[-0.0, 0.0, 1.0, 2.0, 3.0, 4.0], [-0.0, 0.0, 3.0], labels=[-0.0, 0.0, 3.0], extend=true) ==
+        [-0.0, 0.0, 0.0, 0.0, 3.0, 3.0]
+end
+
+@testset "cut with extend=missing" begin
+    x = @inferred cut(Float64[-0.0, 0.0, 1.0, 2.0, 3.0, 4.0], [-0.0, 0.0, 3.0], labels=[-0.0, 0.0], extend=missing)
+    @test x ≅ [-0.0, 0.0, 0.0, 0.0, missing, missing]
+    @test x isa CategoricalArray{Union{Missing, Float64},1,UInt32}
+    @test isordered(x)
+    @test levels(x) == [-0.0, 0.0]
 end
 
 end

--- a/test/15_extras.jl
+++ b/test/15_extras.jl
@@ -89,21 +89,21 @@ const ≅ = isequal
     @test levels(x) == ["[-2.134, 3.0)", "[3.0, 12.5)"]
 
     labels = 0:2:8
-    x = @inferred cut(Vector{Union{T, Int}}([1,2,3,4,5,6,7,8]), 0:2:10; labels)
+    x = @inferred cut(Vector{Union{T, Int}}([1,2,3,4,5,6,7,8]), 0:2:10, labels= labels)
     @test x == [0,2,2,4,4,6,6,8]
-    @test isa(x, CategoricalVector{Union{Int64, T}})
+    @test isa(x, CategoricalVector{Union{Int, T}})
     @test isordered(x)
     @test levels(x) == [0,2,4,6,8]
 
     labels = Union{Int64,String}[0,"2",4,"6",8]
-    x = @inferred cut(Vector{Union{T, Int}}([1,2,3,4,5,6,7,8]), 10:-2:0; labels)
+    x = @inferred cut(Vector{Union{T, Int}}([1,2,3,4,5,6,7,8]), 10:-2:0, labels=labels)
     @test x == [0,"2","2",4,4,"6","6",8]
-    @test isa(x, CategoricalVector{Union{Int64, String, T}})
+    @test isa(x, CategoricalVector{Union{Int, String, T}})
     @test isordered(x)
     @test levels(x) == [0,"2",4,"6",8]
 
-    labels = (from, to , i; leftclosed, rightclosed) -> (to+from)/2
-    x = @inferred cut(Vector{Union{T, Int}}([1,2,3,4,5,6,7,8]), 0:2:10; labels)
+    labels = (from, to, i; leftclosed, rightclosed) -> (to+from)/2
+     x = @inferred cut(Vector{Union{T, Int}}([1,2,3,4,5,6,7,8]), 0:2:10, labels=labels)
     @test x == [1.0, 3.0, 3.0, 5.0, 5.0, 7.0, 7.0, 9.0]
     @test isa(x, CategoricalVector{Union{Float64, T}})
     @test isordered(x)

--- a/test/15_extras.jl
+++ b/test/15_extras.jl
@@ -261,6 +261,9 @@ end
     @test x isa CategoricalArray{Union{Missing, Float64},1,UInt32}
     @test isordered(x)
     @test levels(x) == [-0.0, 0.0]
+
+    x = @inferred cut(-1:0.5:1, [0, 1], extend=true)
+    @test x == ["[-1.0, 0.0)", "[-1.0, 0.0)", "[0.0, 1.0]", "[0.0, 1.0]", "[0.0, 1.0]"]
 end
 
 end

--- a/test/15_extras.jl
+++ b/test/15_extras.jl
@@ -87,6 +87,27 @@ const ≅ = isequal
     @test isa(x, CategoricalMatrix{Union{String, T}})
     @test isordered(x)
     @test levels(x) == ["[-2.134, 3.0)", "[3.0, 12.5)"]
+
+    labels = 0:2:8
+    x = @inferred cut(Vector{Union{T, Int}}([1,2,3,4,5,6,7,8]), 0:2:10; labels)
+    @test x == [0,2,2,4,4,6,6,8]
+    @test isa(x, CategoricalVector{Union{Int64, T}})
+    @test isordered(x)
+    @test levels(x) == [0,2,4,6,8]
+
+    labels = Union{Int64,String}[0,"2",4,"6",8]
+    x = @inferred cut(Vector{Union{T, Int}}([1,2,3,4,5,6,7,8]), 10:-2:0; labels)
+    @test x == [0,"2","2",4,4,"6","6",8]
+    @test isa(x, CategoricalVector{Union{Int64, String, T}})
+    @test isordered(x)
+    @test levels(x) == [0,"2",4,"6",8]
+
+    labels = (from, to , i; leftclosed, rightclosed) -> (to+from)/2
+    x = @inferred cut(Vector{Union{T, Int}}([1,2,3,4,5,6,7,8]), 0:2:10; labels)
+    @test x == [1.0, 3.0, 3.0, 5.0, 5.0, 7.0, 7.0, 9.0]
+    @test isa(x, CategoricalVector{Union{Float64, T}})
+    @test isordered(x)
+    @test levels(x) == [1.0, 3.0, 5.0, 7.0, 9.0]
 end
 
 @testset "cut with missing values in input" begin

--- a/test/15_extras.jl
+++ b/test/15_extras.jl
@@ -89,18 +89,18 @@ const ≅ = isequal
     @test levels(x) == ["[-2.134, 3.0)", "[3.0, 12.5)"]
 
     labels = 0:2:8
-    x = @inferred cut(Vector{Union{T, Int}}([1,2,3,4,5,6,7,8]), 0:2:10, labels= labels)
+    x = @inferred cut(Vector{Union{T, Int}}(1:8), 0:2:10, labels=labels)
     @test x == [0,2,2,4,4,6,6,8]
     @test isa(x, CategoricalVector{Union{Int, T}})
     @test isordered(x)
-    @test levels(x) == [0,2,4,6,8]
+    @test levels(x) == [0, 2, 4, 6, 8]
 
-    labels = Union{Int, String}[0,"2",4,"6",8]
-    x = @inferred cut(Vector{Union{T, Int}}([1,2,3,4,5,6,7,8]), 10:-2:0, labels=labels)
-    @test x == [0,"2","2",4,4,"6","6",8]
+    labels = Union{Int, String}[0, "2", 4, "6", 8]
+    x = @inferred cut(Vector{Union{T, Int}}(1:8), 10:-2:0, labels=labels)
+    @test x == [0, "2", "2", 4, 4, "6", "6", 8]
     @test isa(x, CategoricalVector{Union{Int, String, T}})
     @test isordered(x)
-    @test levels(x) == [0,"2",4,"6",8]
+    @test levels(x) == [0, "2", 4, "6", 8]
 
     @test_throws ArgumentError cut([-0.0, 0.0], 2)
     @test_throws ArgumentError cut([-0.0, 0.0], 2, labels=[-0.0, 0.0])
@@ -148,26 +148,26 @@ end
     a = @inferred cut(x, p, labels=my_formatter_2)
     @test a == ["1: 1.0 -- 1.4", "1: 1.0 -- 1.4", "2: 1.4 -- 1.8", "2: 1.4 -- 1.8", "3: 1.8 -- 2.0"]
 
-    for T in [Union{}, Missing]
+    for T in (Union{}, Missing)
         labels = (from, to, i; leftclosed, rightclosed) -> (to+from)/2
-        a = @inferred cut(Vector{Union{T, Int}}([1,2,3,4,5,6,7,8]), 0:2:10, labels=labels)
+        a = @inferred cut(Vector{Union{T, Int}}(1:8), 0:2:10, labels=labels)
         @test a == [1.0, 3.0, 3.0, 5.0, 5.0, 7.0, 7.0, 9.0]
         @test isa(a, CategoricalVector{Union{Float64, T}})
         @test isordered(a)
         @test levels(a) == [1.0, 3.0, 5.0, 7.0, 9.0]
 
         labels = (from, to, i; leftclosed, rightclosed) -> "$((to+from)/2)"
-        a = @inferred cut(Vector{Union{T, Int}}([1,2,3,4,5,6,7,8]), 0:2:10, labels=labels)
+        a = @inferred cut(Vector{Union{T, Int}}(1:8), 0:2:10, labels=labels)
         @test a == string.([1.0, 3.0, 3.0, 5.0, 5.0, 7.0, 7.0, 9.0])
         @test isa(a, CategoricalVector{Union{String, T}})
         @test isordered(a)
         @test levels(a) == string.([1.0, 3.0, 5.0, 7.0, 9.0])
     end
 
-    @test cut(Float64[0,1,2,3,4,5,6,7,8], 3, labels=[-0.0, 0.0, 1.0]) ==
+    @test cut(0.0:8.0, 3, labels=[-0.0, 0.0, 1.0]) ==
         [-0.0, -0.0, -0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
 
-    @test cut(Float64[-0.0, 0.0, 1.0, 2.0, 3.0, 4.0], [-0.0, 0.0, 5.0], labels=[-0.0, 0.0]) ==
+    @test cut([-0.0, 0.0, 1.0, 2.0, 3.0, 4.0], [-0.0, 0.0, 5.0], labels=[-0.0, 0.0]) ==
         [-0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
 end
 
@@ -227,11 +227,11 @@ end
     @test_throws ArgumentError cut(1:10, [1, 3, 3, 5, 5, 11], allowempty=true,
                                    labels=["1", "2", "3", "2", "4"])
 
-    @test_throws ArgumentError cut([1,2,3,4,5,6,7,8], 0:2:10, labels=[0,1,1,2,3])
-    @test_throws ArgumentError cut([1,2,3,4,5,6,7,8], [0,2,2,6,8,10], labels=[0,1,1,2,3], allowempty=true)
+    @test_throws ArgumentError cut(1:8, 0:2:10, labels=[0, 1, 1, 2, 3])
+    @test_throws ArgumentError cut(1:8, [0, 2, 2, 6, 8, 10], labels=[0, 1, 1, 2, 3], allowempty=true)
 
-    fmt = (from, to, i; leftclosed, rightclosed) -> (i%2==0 ? to : 0.0)
-    @test_throws ArgumentError cut([1,2,3,4,5,6,7,8], 0:2:10, labels=fmt)
+    fmt = (from, to, i; leftclosed, rightclosed) -> (i % 2 == 0 ? to : 0.0)
+    @test_throws ArgumentError cut(1:8, 0:2:10, labels=fmt)
 end
 
 @testset "cut with extend=true" begin
@@ -249,12 +249,14 @@ end
 
     @test cut([missing], [1, 2], extend=true) ≅ [missing]
 
-    @test cut(Float64[-0.0, 0.0, 1.0, 2.0, 3.0, 4.0], [-0.0, 0.0, 3.0], labels=[-0.0, 0.0, 3.0], extend=true) ==
+    @test cut([-0.0, 0.0, 1.0, 2.0, 3.0, 4.0], [-0.0, 0.0, 3.0],
+              labels=[-0.0, 0.0, 3.0], extend=true) ==
         [-0.0, 0.0, 0.0, 0.0, 3.0, 3.0]
 end
 
 @testset "cut with extend=missing" begin
-    x = @inferred cut(Float64[-0.0, 0.0, 1.0, 2.0, 3.0, 4.0], [-0.0, 0.0, 3.0], labels=[-0.0, 0.0], extend=missing)
+    x = @inferred cut([-0.0, 0.0, 1.0, 2.0, 3.0, 4.0], [-0.0, 0.0, 3.0],
+                      labels=[-0.0, 0.0], extend=missing)
     @test x ≅ [-0.0, 0.0, 0.0, 0.0, missing, missing]
     @test x isa CategoricalArray{Union{Missing, Float64},1,UInt32}
     @test isordered(x)

--- a/test/15_extras.jl
+++ b/test/15_extras.jl
@@ -95,7 +95,7 @@ const ≅ = isequal
     @test isordered(x)
     @test levels(x) == [0,2,4,6,8]
 
-    labels = Union{Int64,String}[0,"2",4,"6",8]
+    labels = Union{Int, String}[0,"2",4,"6",8]
     x = @inferred cut(Vector{Union{T, Int}}([1,2,3,4,5,6,7,8]), 10:-2:0, labels=labels)
     @test x == [0,"2","2",4,4,"6","6",8]
     @test isa(x, CategoricalVector{Union{Int, String, T}})


### PR DESCRIPTION
Referring to https://discourse.julialang.org/t/creating-data-bins-with-numeric-labels-with-cut/81281/10?u=skleinbo

Inference seems to be fine. Tests pass on `Julia 1.7`. 

Three  things:
1. There is a test error on `1.6`, but that is due to `Base.return_types` not inferring correctly. The actual return type is as expected.  
That's not ideal. Should the test be taken out, somehow altered to pass on older Julia versions (don't know how tbh), or executed conditionally?
2. Technically, mixed labels are possible when passed as a `AbstractVector{<:SupportedTypes}`. E.g. just passing `[1,"2",3]::Vector{Any}` fails, while `Union{Int, String}[1,"2",3]` is fine. Should an effort be made to automatically do a conversion? Given the IMHO obscurity of mixed labels, should this even be mentioned in the docs? I say no on both points.
3. A label formatter must always return the same concrete type. That's a disparity to 2. and one could jump through the same hoops to allow for mixed labels, but is it worth it?
4. The current `cut` implicitly casts labels of any `AbstractString` to `String`. While not promised, someone downstream might rely on that conversion. 

Thanks!

