### PR TITLE
Drop redundant `convert(Union{T, Missing/Nothing}, x)` methods

### DIFF
--- a/src/value.jl
+++ b/src/value.jl
@@ -88,13 +88,9 @@ Base.promote_rule(::Type{C1}, ::Type{C2}) where
 Base.promote_rule(::Type{C1}, ::Type{C2}) where {C1<:CategoricalValue, C2<:CategoricalValue} =
     CategoricalValue{cat_promote_type(leveltype(C1), leveltype(C2))}
 
-# General fallbacks
+# General fallback
 Base.convert(::Type{S}, x::CategoricalValue) where {S <: SupportedTypes} =
     convert(S, unwrap(x))
-Base.convert(::Type{Union{S, Missing}}, x::CategoricalValue) where {S <: SupportedTypes} =
-    convert(Union{S, Missing}, unwrap(x))
-Base.convert(::Type{Union{S, Nothing}}, x::CategoricalValue) where {S <: SupportedTypes} =
-    convert(Union{S, Nothing}, unwrap(x))
 
 (::Type{T})(x::T) where {T <: CategoricalValue} = x
 

--- a/test/05_convert.jl
+++ b/test/05_convert.jl
@@ -49,6 +49,12 @@ using CategoricalArrays: DefaultRefType, refcode, reftype, leveltype
         @test convert(Union{T, U}, v3) === v3
     end
 
+    for T in (Int, Int8, Float64), U in (Missing, Nothing)
+        @test convert(Union{T, U}, v1)::T == v1
+        @test convert(Union{T, U}, v2)::T == v2
+        @test convert(Union{T, U}, v3)::T == v3
+    end
+
     @test unwrap(v1) === get(v1) === 1
     @test unwrap(v2) === get(v2) === 2
     @test unwrap(v3) === get(v3) === 3


### PR DESCRIPTION
The fallback defined in Base calls `convert(T, x)`, giving the same result, and these methods cause invalidations.