### PR TITLE
make recode! type stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1' # automatically expands to the latest stable 1.x release of Julia
           - 'nightly'
         os:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - '1.0'
           - '1' # automatically expands to the latest stable 1.x release of Julia
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 version = "0.10.8"
 
 [deps]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 Future = "9fa8497b-333b-5362-9e8d-4d0656e87820"
 Missings = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
@@ -24,6 +25,7 @@ CategoricalArraysSentinelArraysExt = "SentinelArrays"
 CategoricalArraysStructTypesExt = "StructTypes"
 
 [compat]
+Compat = "3.37"
 DataAPI = "1.6"
 JSON = "0.15, 0.16, 0.17, 0.18, 0.19, 0.20, 0.21"
 JSON3 = "1.1.2"

--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,7 @@ CategoricalArraysSentinelArraysExt = "SentinelArrays"
 CategoricalArraysStructTypesExt = "StructTypes"
 
 [compat]
-Compat = "3.37"
+Compat = "3.37, 4"
 DataAPI = "1.6"
 JSON = "0.15, 0.16, 0.17, 0.18, 0.19, 0.20, 0.21"
 JSON3 = "1.1.2"

--- a/Project.toml
+++ b/Project.toml
@@ -32,7 +32,7 @@ RecipesBase = "1.1"
 Requires = "1"
 SentinelArrays = "1"
 StructTypes = "1"
-julia = "1"
+julia = "1.6"
 
 [extras]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/Project.toml
+++ b/Project.toml
@@ -32,7 +32,7 @@ RecipesBase = "1.1"
 Requires = "1"
 SentinelArrays = "1"
 StructTypes = "1"
-julia = "1.6"
+julia = "1"
 
 [extras]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/CategoricalArrays.jl
+++ b/src/CategoricalArrays.jl
@@ -14,6 +14,7 @@ module CategoricalArrays
     using DataAPI
     using Missings
     using Printf
+    import Compat
 
     # JuliaLang/julia#36810
     if VERSION < v"1.5.2"

--- a/src/recode.jl
+++ b/src/recode.jl
@@ -59,10 +59,10 @@ function recode!(dest::AbstractArray, src::AbstractArray, default::Any, pairs::P
 
     opt_pairs = optimize_pair.(pairs)
 
-    _recode!(dest, src, default, opt_pairs...)
+    _recode!(dest, src, default, opt_pairs)
 end
 
-function _recode!(dest::AbstractArray{T}, src::AbstractArray, default, pairs...) where {T}
+function _recode!(dest::AbstractArray{T}, src::AbstractArray, default, pairs) where {T}
     recode_to = last.(pairs)
     recode_from = first.(pairs)
     
@@ -100,7 +100,7 @@ function _recode!(dest::AbstractArray{T}, src::AbstractArray, default, pairs...)
     dest
 end
 
-function _recode!(dest::CategoricalArray{T, <:Any, R}, src::AbstractArray, default::Any, pairs...) where {T, R}
+function _recode!(dest::CategoricalArray{T, <:Any, R}, src::AbstractArray, default::Any, pairs) where {T, R}
     recode_to = last.(pairs)
     recode_from = first.(pairs)
 
@@ -168,7 +168,7 @@ function _recode!(dest::CategoricalArray{T, <:Any, R}, src::AbstractArray, defau
 end
 
 function _recode!(dest::CategoricalArray{T, N, R}, src::CategoricalArray,
-                 default::Any, pairs::Pair...) where {T, N, R<:Integer}
+                 default::Any, pairs::Tuple) where {T, N, R<:Integer}
     vals = T[p.second for p in pairs]
     if default === nothing
         srclevels = levels(src)

--- a/src/recode.jl
+++ b/src/recode.jl
@@ -1,3 +1,4 @@
+import Compat
 const ≅ = isequal
 
 """
@@ -49,8 +50,6 @@ A user defined type could override this method to define an appropriate test fun
 @inline recode_in(x, collection::Set) = x in collection
 @inline recode_in(x, collection) = any(x ≅ y for y in collection)
 
-@inline findfirstrecode(x, recode_from) = findfirst(y -> isequal(x, y) || recode_in(x,y), recode_from)
-
 optimize_pair(pair::Pair) = pair
 optimize_pair(pair::Pair{<:AbstractArray}) = Set(pair.first) => pair.second
 
@@ -71,7 +70,7 @@ function _recode!(dest::AbstractArray{T}, src::AbstractArray, default, pairs) wh
     @inbounds for i in eachindex(dest, src)
         x = src[i]
 
-        j = findfirstrecode(x, recode_from)
+        j = Compat.@inline findfirst(y -> isequal(x, y) || recode_in(x,y), recode_from)
         if !isnothing(j)
             dest[i] = recode_to[j]
             @goto nextitem
@@ -121,7 +120,7 @@ function _recode!(dest::CategoricalArray{T, <:Any, R}, src::AbstractArray, defau
     @inbounds for i in eachindex(drefs, src)
         x = src[i]
 
-        j = findfirstrecode(x, recode_from)
+        j = Compat.@inline findfirst(y -> isequal(x, y) || recode_in(x,y), recode_from)
         if !isnothing(j)
             drefs[i] = dupvals ? pairmap[j] : j
             @goto nextitem

--- a/src/recode.jl
+++ b/src/recode.jl
@@ -1,4 +1,3 @@
-import Compat
 const ≅ = isequal
 
 """

--- a/src/recode.jl
+++ b/src/recode.jl
@@ -71,7 +71,7 @@ function _recode!(dest::AbstractArray{T}, src::AbstractArray, default, pairs) wh
         x = src[i]
 
         j = Compat.@inline findfirst(y -> isequal(x, y) || recode_in(x,y), recode_from)
-        if !isnothing(j)
+        if j !== nothing
             dest[i] = recode_to[j]
             @goto nextitem
         end
@@ -121,7 +121,7 @@ function _recode!(dest::CategoricalArray{T, <:Any, R}, src::AbstractArray, defau
         x = src[i]
 
         j = Compat.@inline findfirst(y -> isequal(x, y) || recode_in(x,y), recode_from)
-        if !isnothing(j)
+        if j !== nothing
             drefs[i] = dupvals ? pairmap[j] : j
             @goto nextitem
         end

--- a/src/recode.jl
+++ b/src/recode.jl
@@ -49,6 +49,8 @@ A user defined type could override this method to define an appropriate test fun
 @inline recode_in(x, collection::Set) = x in collection
 @inline recode_in(x, collection) = any(x ≅ y for y in collection)
 
+@inline findfirstrecode(x, recode_from) = findfirst(y -> isequal(x, y) || recode_in(x,y), recode_from)
+
 optimize_pair(pair::Pair) = pair
 optimize_pair(pair::Pair{<:AbstractArray}) = Set(pair.first) => pair.second
 
@@ -69,7 +71,7 @@ function _recode!(dest::AbstractArray{T}, src::AbstractArray, default, pairs) wh
     @inbounds for i in eachindex(dest, src)
         x = src[i]
 
-        j = @inline findfirst(y -> isequal(x, y) || recode_in(x,y), recode_from)
+        j = findfirstrecode(x, recode_from)
         if !isnothing(j)
             dest[i] = recode_to[j]
             @goto nextitem
@@ -119,7 +121,7 @@ function _recode!(dest::CategoricalArray{T, <:Any, R}, src::AbstractArray, defau
     @inbounds for i in eachindex(drefs, src)
         x = src[i]
 
-        j = @inline findfirst(y -> isequal(x, y) || recode_in(x,y), recode_from)
+        j = findfirstrecode(x, recode_from)
         if !isnothing(j)
             drefs[i] = dupvals ? pairmap[j] : j
             @goto nextitem

--- a/src/recode.jl
+++ b/src/recode.jl
@@ -57,13 +57,11 @@ function recode!(dest::AbstractArray{T}, src::AbstractArray, default::Any, pairs
         throw(DimensionMismatch("dest and src must be of the same length (got $(length(dest)) and $(length(src)))"))
     end
 
-    opt_pairs = map(optimize_pair, pairs)
-
     @inbounds for i in eachindex(dest, src)
         x = src[i]
 
-        for j in 1:length(opt_pairs)
-            p = opt_pairs[j]
+        for j in 1:length(pairs)
+            p = optimize_pair(pairs[j])
             # we use isequal and recode_in because we cannot really distinguish scalars from collections
             if x ≅ p.first || recode_in(x, p.first)
                 dest[i] = p.second
@@ -101,9 +99,7 @@ function recode!(dest::CategoricalArray{T}, src::AbstractArray, default::Any, pa
         throw(DimensionMismatch("dest and src must be of the same length (got $(length(dest)) and $(length(src)))"))
     end
 
-    opt_pairs = map(optimize_pair, pairs)
-
-    vals = T[p.second for p in opt_pairs]
+    vals = T[p.second for p in pairs]
     default !== nothing && push!(vals, default)
 
     levels!(dest.pool, filter!(!ismissing, unique(vals)))
@@ -117,8 +113,8 @@ function recode!(dest::CategoricalArray{T}, src::AbstractArray, default::Any, pa
     @inbounds for i in eachindex(drefs, src)
         x = src[i]
 
-        for j in 1:length(opt_pairs)
-            p = opt_pairs[j]
+        for j in 1:length(pairs)
+            p = optimize_pair(pairs[j])
             # we use isequal and recode_in because we cannot really distinguish scalars from collections
             if x ≅ p.first || recode_in(x, p.first)
                 drefs[i] = dupvals ? pairmap[j] : j

--- a/src/recode.jl
+++ b/src/recode.jl
@@ -47,6 +47,8 @@ A user defined type could override this method to define an appropriate test fun
 """
 @inline recode_in(x, collection) = any(x ≅ y for y in collection)
 @inline recode_in(x, ::Missing) = false
+@inline recode_in(::T, ::T) where T = false
+@inline recode_in(::Missing, ::Missing) where T = false
 
 optimize_pair(pair::Pair) = pair
 optimize_pair(pair::Pair{<:AbstractArray}) = Set(pair.first) => pair.second

--- a/src/recode.jl
+++ b/src/recode.jl
@@ -45,11 +45,11 @@ The default method is to test if any element in the `collection` `isequal` to
 `x`. For `Set`s `in` is used as it is faster than the default method and equivalent to it.
 A user defined type could override this method to define an appropriate test function.
 """
-@inline recode_in(x, ::Missing) = false
-@inline recode_in(::Missing, ::Missing) = true
-@inline recode_in(x, collection::Set) = x in collection
-@inline recode_in(x, collection) = x ≅ collection || any(x ≅ y for y in collection)
-@inline recode_in(x::T, y::T) where T = x === y
+recode_in(x, ::Missing) = false
+recode_in(::Missing, ::Missing) = true
+recode_in(x, collection::Set) = x in collection
+recode_in(x, collection) = x ≅ collection || any(x ≅ y for y in collection)
+recode_in(x::T, y::T) where T = x === y
 
 optimize_pair(pair::Pair) = pair
 optimize_pair(pair::Pair{<:AbstractArray}) = Set(pair.first) => pair.second


### PR DESCRIPTION
This PR improves the type-stability of `recode!`, providing a huge performance improvement, in particular when recoding normal (not categorical) arrays.

On this MWE
```julia
A = (rand('a':'c', 100_000))
@profview recode(A, 'b' => 1, 'a' => 2, 'c' => 3)
```
Before:
![billede](https://github.com/user-attachments/assets/6b5573db-1603-422c-b715-cfea28dee829)
After:
![billede](https://github.com/user-attachments/assets/8396276f-f61e-4a36-99eb-1d5714ad4c34)

For a ~200 times speed-up