### PR TITLE
remove JET runtime dispatch error

### DIFF
--- a/src/pool.jl
+++ b/src/pool.jl
@@ -68,7 +68,7 @@ it doesn't do this itself to avoid doing a dict lookup twice
     i = R(n + 1)
     push!(pool.levels, x)
     pool_hash = pool.hash
-    if !isnothing(pool_hash)
+    if pool_hash !== nothing
         pool.hash = hash(x, pool_hash)
     end
     pool.equalto = C_NULL

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -67,8 +67,9 @@ it doesn't do this itself to avoid doing a dict lookup twice
 
     i = R(n + 1)
     push!(pool.levels, x)
-    if pool.hash !== nothing
-        pool.hash = hash(x, pool.hash)
+    pool_hash = pool.hash
+    if !isnothing(pool_hash)
+        pool.hash = hash(x, pool_hash)
     end
     pool.equalto = C_NULL
     pool.subsetof = C_NULL


### PR DESCRIPTION
I am hunting JET errors in my code and I found the following error in CategoricalArrays that's easy to fix with a tiny rewrite.

This is how I found the JET error:
```julia
julia> using JET, CategoricalArrays

julia> @report_opt CategoricalVector{String, UInt8}(String[])
...
│││││││││││┌ push_level!(pool::CategoricalPool{String, UInt8, CategoricalValue{String, UInt8}}, level::String) @ CategoricalArrays C:\Localdata\Repositories\CategoricalArrays.jl\src\pool.jl:71
││││││││││││ runtime dispatch detected: CategoricalArrays.hash(level::String, %33::Union{Nothing, UInt64})::UInt64  
│││││││││││└────────────────────
```

JET thinks a `Nothing` might pass into the code, even though the code checks for a nothing. With my change JET doesn't make that mistake anymore. I understand it's a trivial change, but do hope you'll allow this.
