### PR TITLE
Fix allocations by dropping `CategoricalPool` type parameter

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -160,9 +160,8 @@ function CategoricalArray{T, N, R}(::UndefInitializer, dims::NTuple{N,Int};
     U = leveltype(nonmissingtype(T))
     S = T >: Missing ? Union{U, Missing} : U
     check_supported_eltype(S, T)
-    V = CategoricalValue{U, R}
     levs = levels === nothing ? U[] : collect(U, levels)
-    CategoricalArray{S, N}(zeros(R, dims), CategoricalPool{U, R, V}(levs, ordered))
+    CategoricalArray{S, N}(zeros(R, dims), CategoricalPool{U, R}(levs, ordered))
 end
 
 CategoricalArray{T, N}(::UndefInitializer, dims::NTuple{N,Int};

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -2,20 +2,18 @@ const catpool_seed = UInt === UInt32 ? 0xe3cf1386 : 0x356f2c715023f1a5
 
 hashlevels(levs::AbstractVector) = foldl((h, x) -> hash(x, h), levs, init=catpool_seed)
 
-CategoricalPool{T, R, V}(ordered::Bool=false) where {T, R, V} =
-    CategoricalPool{T, R, V}(T[], ordered)
 CategoricalPool{T, R}(ordered::Bool=false) where {T, R} =
     CategoricalPool{T, R}(T[], ordered)
 CategoricalPool{T}(ordered::Bool=false) where {T} =
     CategoricalPool{T, DefaultRefType}(T[], ordered)
 
 CategoricalPool{T, R}(levels::AbstractVector, ordered::Bool=false) where {T, R} =
-    CategoricalPool{T, R, CategoricalValue{T, R}}(convert(Vector{T}, levels), ordered)
+    CategoricalPool{T, R}(convert(Vector{T}, levels), ordered)
 CategoricalPool(levels::AbstractVector{T}, ordered::Bool=false) where {T} =
     CategoricalPool{T, DefaultRefType}(convert(Vector{T}, levels), ordered)
 
 CategoricalPool(invindex::Dict{T, R}, ordered::Bool=false) where {T, R <: Integer} =
-    CategoricalPool{T, R, CategoricalValue{T, R}}(invindex, ordered)
+    CategoricalPool{T, R}(invindex, ordered)
 
 Base.convert(::Type{T}, pool::T) where {T <: CategoricalPool} = pool
 
@@ -29,12 +27,12 @@ function Base.convert(::Type{CategoricalPool{T, R}}, pool::CategoricalPool) wher
 
     levelsT = convert(Vector{T}, pool.levels)
     invindexT = convert(Dict{T, R}, pool.invindex)
-    return CategoricalPool{T, R, CategoricalValue{T, R}}(levelsT, invindexT, pool.ordered)
+    return CategoricalPool{T, R}(levelsT, invindexT, pool.ordered)
 end
 
-Base.copy(pool::CategoricalPool{T, R, V}) where {T, R, V} =
-    CategoricalPool{T, R, V}(copy(pool.levels), copy(pool.invindex),
-                             pool.ordered, pool.hash)
+Base.copy(pool::CategoricalPool{T, R}) where {T, R} =
+    CategoricalPool{T, R}(copy(pool.levels), copy(pool.invindex),
+                          pool.ordered, pool.hash)
 
 function Base.show(io::IO, pool::CategoricalPool{T, R}) where {T, R}
     @static if VERSION >= v"1.6.0"

--- a/test/04_constructors.jl
+++ b/test/04_constructors.jl
@@ -5,22 +5,10 @@ using CategoricalArrays: DefaultRefType
 
 @testset "Type parameter constraints" begin
     # cannot use categorical value as level type
-    @test_throws TypeError CategoricalPool{CategoricalValue{Int,UInt8}, UInt8, CategoricalValue{CategoricalValue{Int,UInt8},UInt8}}(
+    @test_throws TypeError CategoricalPool{CategoricalValue{Int,UInt8}, UInt8}(
             Dict{CategoricalValue{Int,UInt8}, UInt8}(), false)
-    @test_throws TypeError CategoricalPool{CategoricalValue{Int,UInt8}, UInt8, CategoricalValue{CategoricalValue{Int,UInt8},UInt8}}(
+    @test_throws TypeError CategoricalPool{CategoricalValue{Int,UInt8}, UInt8}(
                 CategoricalValue{Int,UInt8}[], false)
-    # cannot use non-categorical value as categorical value type
-    @test_throws ArgumentError CategoricalPool{Int, UInt8, Int}(Int[], false)
-    @test_throws ArgumentError CategoricalPool{Int, UInt8, Int}(Dict{Int, UInt8}(), false)
-    # level type of the pool and categorical value must match
-    @test_throws ArgumentError CategoricalPool{Int, UInt8, CategoricalValue{String, UInt8}}(Int[], false)
-    @test_throws ArgumentError CategoricalPool{Int, UInt8, CategoricalValue{String, UInt8}}(Dict{Int, UInt8}(), false)
-    # reference type of the pool and categorical value must match
-    @test_throws ArgumentError CategoricalPool{Int, UInt8, CategoricalValue{Int, UInt16}}(Int[], false)
-    @test_throws ArgumentError CategoricalPool{Int, UInt8, CategoricalValue{Int, UInt16}}(Dict{Int, UInt8}(), false)
-    # correct types combination
-    @test CategoricalPool{Int, UInt8, CategoricalValue{Int, UInt8}}(Int[], false) isa CategoricalPool
-    @test CategoricalPool{Int, UInt8, CategoricalValue{Int, UInt8}}(Dict{Int, UInt8}(), false) isa CategoricalPool
 end
 
 @testset "empty CategoricalPool{String}" begin
@@ -38,7 +26,7 @@ end
 @testset "empty CategoricalPool{Int}" begin
     pool = CategoricalPool{Int, UInt8}()
 
-    @test isa(pool, CategoricalPool{Int, UInt8, CategoricalValue{Int, UInt8}})
+    @test isa(pool, CategoricalPool{Int, UInt8})
 
     @test isa(pool.levels, Vector{Int})
     @test length(pool.levels) == 0
@@ -50,7 +38,7 @@ end
 @testset "CategoricalPool{String, DefaultRefType}(a b c)" begin
     pool = CategoricalPool(["a", "b", "c"])
 
-    @test isa(pool, CategoricalPool{String, UInt32, CategoricalValue{String, UInt32}})
+    @test isa(pool, CategoricalPool{String, UInt32})
 
     @test isa(pool.levels, Vector{String})
     @test pool.levels == ["a", "b", "c"]
@@ -156,7 +144,7 @@ end
 @testset "CategoricalPool{Float64, UInt8}()" begin
     pool = CategoricalPool{Float64, UInt8}([1.0, 2.0, 3.0])
 
-    @test isa(pool, CategoricalPool{Float64, UInt8, CategoricalValue{Float64, UInt8}})
+    @test isa(pool, CategoricalPool{Float64, UInt8})
     @test CategoricalValue(pool, 1) isa CategoricalValue{Float64, UInt8}
 end
 


### PR DESCRIPTION
Self-referential types generate allocations since Julia 1.11 (JuliaLang/julia#58169). This third parameter seems to have been unnecessary since `NominalValue` and `OrdinalValue` got merged into a single `CategoricalValue` type.

Fixes https://github.com/JuliaData/CategoricalArrays.jl/issues/412.

I'm not sure we should backport this or not, given that it's slightly breaking (in particular it breaks deserializing old objects). I don't see a way to fix this without changing type parameters -- the other option is to add one parameter to `CategoricalValue`.