### PR TITLE
Add `Array` constructors and `convert` methods

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -1,6 +1,7 @@
 ## Code for CategoricalArray
 
-import Base: Array, convert, collect, copy, getindex, setindex!, similar, size,
+import Base: Array, Vector, Matrix, convert, collect, copy, getindex,
+             setindex!, similar, size,
              unique, vcat, in, summary, float, complex, copyto!
 
 # Used for keyword argument default value
@@ -409,6 +410,12 @@ convert(::Type{CategoricalArray{T, N, R}}, A::CategoricalArray{T, N, R}) where {
 convert(::Type{CategoricalArray{T, N}}, A::CategoricalArray{T, N}) where {T, N} = A
 convert(::Type{CategoricalArray{T}}, A::CategoricalArray{T}) where {T} = A
 convert(::Type{CategoricalArray}, A::CategoricalArray) = A
+
+convert(::Type{Array{S, N}}, A::CatArrOrSub{T, N}) where {S, T, N} =
+    collect(S, A)
+convert(::Type{Array}, A::CatArrOrSub) = unwrap.(A)
+convert(::Type{Vector}, A::CatArrOrSub) = unwrap.(A)
+convert(::Type{Matrix}, A::CatArrOrSub) = unwrap.(A)
 
 function Base.:(==)(A::CategoricalArray{S}, B::CategoricalArray{T}) where {S, T}
     if size(A) != size(B)
@@ -1049,8 +1056,10 @@ function in(x::CategoricalValue, y::CategoricalArray{T, N, R}) where {T, N, R}
     end
 end
 
-Array(A::CategoricalArray{T}) where {T} = Array{T}(A)
-collect(A::CategoricalArray) = copy(A)
+Array(A::CatArrOrSub{T}) where {T} = Array{T}(A)
+Vector(A::CatArrOrSub{T}) where {T} = Vector{T}(A)
+Matrix(A::CatArrOrSub{T}) where {T} = Matrix{T}(A)
+collect(A::CatArrOrSub) = copy(A)
 
 # Defined for performance
 collect(x::Base.SkipMissing{<: CatArrOrSub{T}}) where {T} =

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -1328,16 +1328,114 @@ end
     @test levels(x) == [2, 1, 3, 4]
 end
 
-@testset "Array(::CategoricalArray{T}) produces Array{T}" begin
+@testset "Array(::CatArrOrSub{T}) produces Array{T}" begin
     x = [1,1,2,2]
     y = categorical(x)
     z = Array(y)
+    @test typeof(x) == typeof(z)
+    @test z == x
+    z = Array(view(x, 1:4))
     @test typeof(x) == typeof(z)
     @test z == x
 
     x = [1,1,2,missing]
     y = categorical(x)
     z = Array(y)
+    @test typeof(x) == typeof(z)
+    @test z ≅ x
+    z = Array(view(x, 1:4))
+    @test typeof(x) == typeof(z)
+    @test z ≅ x
+
+    x = [1,1,2,2]
+    y = categorical(x)
+    z = Vector(y)
+    @test typeof(x) == typeof(z)
+    @test z == x
+    z = Vector(view(x, 1:4))
+    @test typeof(x) == typeof(z)
+    @test z == x
+
+    x = [1,1,2,missing]
+    y = categorical(x)
+    z = Vector(y)
+    @test typeof(x) == typeof(z)
+    @test z ≅ x
+    z = Vector(view(x, 1:4))
+    @test typeof(x) == typeof(z)
+    @test z ≅ x
+
+    x = [1 1 2 2]
+    y = categorical(x)
+    z = Matrix(y)
+    @test typeof(x) == typeof(z)
+    @test z == x
+    z = Matrix(view(x, :, 1:4))
+    @test typeof(x) == typeof(z)
+    @test z == x
+
+    x = [1 1 2 missing]
+    y = categorical(x)
+    z = Matrix(y)
+    @test typeof(x) == typeof(z)
+    @test z ≅ x
+    z = Matrix(view(x, :, 1:4))
+    @test typeof(x) == typeof(z)
+    @test z ≅ x
+end
+
+@testset "convert(Array, ::CatArrOrSub{T}) produces Array{T}" begin
+    x = [1,1,2,2]
+    y = categorical(x)
+    z = convert(Array, y)
+    @test typeof(x) == typeof(z)
+    @test z == x
+    z = Array(view(x, 1:4))
+    @test typeof(x) == typeof(z)
+    @test z == x
+
+    x = [1,1,2,missing]
+    y = categorical(x)
+    z = convert(Array, y)
+    @test typeof(x) == typeof(z)
+    @test z ≅ x
+    z = Array(view(x, 1:4))
+    @test typeof(x) == typeof(z)
+    @test z ≅ x
+
+    x = [1,1,2,2]
+    y = categorical(x)
+    z = convert(Vector, y)
+    @test typeof(x) == typeof(z)
+    @test z == x
+    z = Vector(view(x, 1:4))
+    @test typeof(x) == typeof(z)
+    @test z == x
+
+    x = [1,1,2,missing]
+    y = categorical(x)
+    z = convert(Vector, y)
+    @test typeof(x) == typeof(z)
+    @test z ≅ x
+    z = Vector(view(x, 1:4))
+    @test typeof(x) == typeof(z)
+    @test z ≅ x
+
+    x = [1 1 2 2]
+    y = categorical(x)
+    z = convert(Matrix, y)
+    @test typeof(x) == typeof(z)
+    @test z == x
+    z = Matrix(view(x, :, 1:4))
+    @test typeof(x) == typeof(z)
+    @test z == x
+
+    x = [1 1 2 missing]
+    y = categorical(x)
+    z = convert(Matrix, y)
+    @test typeof(x) == typeof(z)
+    @test z ≅ x
+    z = Matrix(view(x, :, 1:4))
     @test typeof(x) == typeof(z)
     @test z ≅ x
 end


### PR DESCRIPTION
Consistent with existing `similar` methods and the `Array` constructor, ensure `T(::CategoricalArray{U})` and `convert(T, ::CategoricalArray{U})` return an `Array{U}` for `T` in `Array`, `Vector`, `Matrix`. Same for `SubArray`s of `CategoricalArray`s. This avoids creating `Array{<:CategoricalValue}` objects which are inefficient and unlikely to be what users want.

Apparently we forgot to add these in https://github.com/JuliaData/CategoricalArrays.jl/pull/123.
Fixes #294.