### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,10 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - 'min'
+          - 'lts'
           - '1' # automatically expands to the latest stable 1.x release of Julia
-          - 'nightly'
+          - 'pre'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ jobs:
           - 'pre'
         os:
           - ubuntu-latest
-          - macOS-latest
-          - windows-latest
         arch:
           - x64
           - x86

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,10 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 'min'
+          # FIXME! Switch from 1.6 to 'min' once we require a higher minimum
+          # We can't switch yet as there is a method ambiguity for a depndency
+          # in version 1.6.0.
+          - '1.6'
           - 'lts'
           - '1' # automatically expands to the latest stable 1.x release of Julia
           - 'pre'

--- a/Project.toml
+++ b/Project.toml
@@ -45,12 +45,12 @@ Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
-Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 PooledArrays = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+RecipesPipeline = "01d81517-befc-4cb6-b9ec-a95719d0359c"
 SentinelArrays = "91c51154-3ec4-41a3-a24f-3f23e20d615c"
 StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Arrow", "Dates", "JSON", "JSON3", "Plots", "PooledArrays", "RecipesBase", "SentinelArrays", "StructTypes", "Test"]
+test = ["Arrow", "Dates", "JSON", "JSON3", "PooledArrays", "RecipesBase", "RecipesPipeline", "SentinelArrays", "StructTypes", "Test"]

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -8,7 +8,7 @@ using PooledArrays
 using JSON3
 using StructTypes
 using RecipesBase
-using Plots
+using RecipesPipeline
 using SentinelArrays
 using Arrow
 using Missings


### PR DESCRIPTION
There are two separate commits here. One that adjust the versions to `min`, `lts`, `1`, and `pre`. The first one is just a convenient way to keep CI i sync with the requirement in the projects file. The latter is in my opinion a better choice for most packages as it avoids tests failures due to unintended breakage on nightly. Instead, we'll detect the regressions only during the testing period of new releases.

The second commit removes the Mac and Windows testing. I generally think there is little value to testing on these targets when the package doesn't have any direct binary dependencies. It will provide faster CI and it will also avoid an unrelated issue with Plots triggering a segfault on Windows.