### PR TITLE
Make `levels` return a `CategoricalArray`

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -55,11 +55,11 @@ SUITE["many levels"]["CategoricalArray(::Vector{String})"] =
 a = rand([@sprintf("id%010d", k) for k in 1:1000], 10000)
 ca = CategoricalArray(a)
 
-levs = levels(ca)
+levs = unwrap.(levels(ca))
 SUITE["many levels"]["levels! with original levels"] =
     @benchmarkable levels!(ca, levs)
 
-levs = reverse(levels(ca))
+levs = reverse(unwrap.(levels(ca)))
 SUITE["many levels"]["levels! with resorted levels"] =
     @benchmarkable levels!(ca, levs)
 

--- a/docs/src/using.md
+++ b/docs/src/using.md
@@ -20,7 +20,7 @@ By default, the levels are lexically sorted, which is clearly not correct in our
 
 ```jldoctest using
 julia> levels(x)
-3-element Vector{String}:
+3-element CategoricalArray{String,1,UInt32}:
  "Middle"
  "Old"
  "Young"
@@ -68,7 +68,7 @@ To get rid of the `"Old"` group, just call the [`droplevels!`](@ref) function:
 
 ```jldoctest using
 julia> levels(x)
-3-element Vector{String}:
+3-element CategoricalArray{String,1,UInt32}:
  "Young"
  "Middle"
  "Old"
@@ -81,7 +81,7 @@ julia> droplevels!(x)
  "Young"
 
 julia> levels(x)
-2-element Vector{String}:
+2-element CategoricalArray{String,1,UInt32}:
  "Young"
  "Middle"
 
@@ -139,7 +139,7 @@ Levels still need to be reordered manually:
 
 ```jldoctest using
 julia> levels(y)
-3-element Vector{String}:
+3-element CategoricalArray{String,1,UInt32}:
  "Middle"
  "Old"
  "Young"
@@ -263,7 +263,7 @@ true
 Likewise, assigning a `CategoricalValue` from `y` to an entry in `x` expands the levels of `x` with all levels from `y`, *respecting the ordering of levels of both vectors if possible*:
 ```jldoctest using
 julia> levels(x)
-2-element Vector{String}:
+2-element CategoricalArray{String,1,UInt32}:
  "Middle"
  "Old"
 
@@ -271,7 +271,7 @@ julia> x[1] = y[1]
 CategoricalValue{String, UInt32} "Young" (1/2)
 
 julia> levels(x)
-3-element Vector{String}:
+3-element CategoricalArray{String,1,UInt32}:
  "Young"
  "Middle"
  "Old"
@@ -296,7 +296,7 @@ julia> ab = vcat(a, b)
  "c"
 
 julia> levels(ab)
-3-element Vector{String}:
+3-element CategoricalArray{String,1,UInt32}:
  "a"
  "b"
  "c"
@@ -320,7 +320,7 @@ julia> ab2 = vcat(a, b)
  "c"
 
 julia> levels(ab2)
-3-element Vector{String}:
+3-element CategoricalArray{String,1,UInt32}:
  "a"
  "b"
  "c"

--- a/docs/src/using.md
+++ b/docs/src/using.md
@@ -251,7 +251,7 @@ julia> xy = vcat(x, y)
  "Middle"
 
 julia> levels(xy)
-3-element Vector{String}:
+3-element CategoricalArray{String,1,UInt32}:
  "Young"
  "Middle"
  "Old"

--- a/ext/CategoricalArraysArrowExt.jl
+++ b/ext/CategoricalArraysArrowExt.jl
@@ -7,6 +7,8 @@ import Arrow: ArrowTypes
 const CATARRAY_ARROWNAME = Symbol("JuliaLang.CategoricalArrays.CategoricalArray")
 ArrowTypes.arrowname(::Type{<:CategoricalValue}) = CATARRAY_ARROWNAME
 ArrowTypes.arrowmetadata(::Type{CategoricalValue{T, R}}) where {T, R} = string(R)
+ArrowTypes.ArrowType(::Type{<:CategoricalValue{T}}) where {T} = T
+ArrowTypes.toarrow(x::CategoricalValue) = unwrap(x)
 
 ArrowTypes.arrowname(::Type{Union{<:CategoricalValue, Missing}}) = CATARRAY_ARROWNAME
 ArrowTypes.arrowmetadata(::Type{Union{CategoricalValue{T, R}, Missing}}) where {T, R} =

--- a/ext/CategoricalArraysRecipesBaseExt.jl
+++ b/ext/CategoricalArraysRecipesBaseExt.jl
@@ -9,7 +9,7 @@ else
 end
 
 RecipesBase.@recipe function f(::Type{T}, v::T) where T <: CategoricalValue
-    level_strings = [map(string, levels(v)); missing]
+    level_strings = [map(string, CategoricalArrays._levels(v)); missing]
     ticks --> eachindex(level_strings)
     v -> ismissing(v) ? length(level_strings) : Int(CategoricalArrays.refcode(v)),
     i -> level_strings[Int(i)]

--- a/src/recode.jl
+++ b/src/recode.jl
@@ -111,7 +111,7 @@ function _recode!(dest::CategoricalArray{T, <:Any, R}, src::AbstractArray, defau
     levels!(dest.pool, filter!(!ismissing, unique(vals)))
     # In the absence of duplicated recoded values, we do not need to lookup the reference
     # for each pair in the loop, which is more efficient (with loop unswitching)
-    dupvals = length(vals) != length(levels(dest.pool))
+    dupvals = length(vals) != length(_levels(dest.pool))
 
     drefs = dest.refs
     pairmap = [ismissing(v) ? zero(R) : get(dest.pool, v) for v in vals]
@@ -150,7 +150,7 @@ function _recode!(dest::CategoricalArray{T, <:Any, R}, src::AbstractArray, defau
 
     # Put existing levels first, and sort them if possible
     # for consistency with CategoricalArray
-    oldlevels = setdiff(levels(dest), vals)
+    oldlevels = setdiff(_levels(dest), vals)
     filter!(!ismissing, oldlevels)
     L = eltype(oldlevels)
     if Base.OrderStyle(L) isa Base.Ordered
@@ -163,7 +163,7 @@ function _recode!(dest::CategoricalArray{T, <:Any, R}, src::AbstractArray, defau
             e isa MethodError || rethrow(e)
         end
     end
-    levels!(dest, union(oldlevels, levels(dest)))
+    levels!(dest, union(oldlevels, _levels(dest)))
 
     dest
 end
@@ -174,7 +174,7 @@ function _recode!(dest::CategoricalArray{T, N, R}, src::CategoricalArray,
     vals = T[p.second for p in pairs]
              
     if default === nothing
-        srclevels = levels(src)
+        srclevels = _levels(src)
 
         # Remove recoded levels as they won't appear in result
         keptlevels = Vector{T}(undef, 0)
@@ -201,7 +201,7 @@ function _recode!(dest::CategoricalArray{T, N, R}, src::CategoricalArray,
         ordered = false
     end
 
-    srclevels = src.pool === dest.pool ? copy(levels(src.pool)) : levels(src.pool)
+    srclevels = src.pool === dest.pool ? copy(_levels(src.pool)) : _levels(src.pool)
     if length(levs) > length(srclevels) && view(levs, 1:length(srclevels)) == srclevels
         levels!(dest.pool, levs)
     else

--- a/src/typedefs.jl
+++ b/src/typedefs.jl
@@ -8,6 +8,7 @@ const SupportedTypes = Union{AbstractString, AbstractChar, Number}
 # * `R` integer type for referencing category levels
 mutable struct CategoricalPool{T <: SupportedTypes, R <: Integer}
     levels::Vector{T}          # category levels ordered by their reference codes
+    levelsinds::Vector{R}      # set to 1:length(levels), used by `levels(p)`
     invindex::Dict{T, R}       # map from category levels to their reference codes
     ordered::Bool              # whether levels can be compared using <
     hash::Union{UInt, Nothing} # hash of levels
@@ -45,8 +46,8 @@ mutable struct CategoricalPool{T <: SupportedTypes, R <: Integer}
                                    invindex::Dict{T, R},
                                    ordered::Bool,
                                    hash::Union{UInt, Nothing}=nothing) where {T, R}
-        pool = new(levels, invindex, ordered, hash, C_NULL, C_NULL)
-        return pool
+        return new(levels, 1:length(levels), invindex,
+                   ordered, hash, C_NULL, C_NULL)
     end
 end
 

--- a/src/value.jl
+++ b/src/value.jl
@@ -27,6 +27,8 @@ reftype(x::Any) = reftype(typeof(x))
 pool(x::CategoricalValue) = x.pool
 refcode(x::CategoricalValue) = x.ref
 isordered(x::CategoricalValue) = isordered(x.pool)
+DataAPI.levels(x::CategoricalValue) = levels(pool(x))
+_levels(x::CategoricalValue) = _levels(pool(x))
 
 # extract the type of the original value from array eltype `T`
 unwrap_catvaluetype(::Type{T}) where {T} = T
@@ -42,7 +44,7 @@ unwrap_catvaluetype(::Type{T}) where {T <: CategoricalValue} = leveltype(T)
 
 Get the value wrapped by categorical value `x`. If `x` is `Missing` return `missing`.
 """
-DataAPI.unwrap(x::CategoricalValue) = levels(x)[refcode(x)]
+DataAPI.unwrap(x::CategoricalValue) = _levels(x)[refcode(x)]
 
 """
     levelcode(x::CategoricalValue)
@@ -59,10 +61,8 @@ Return `missing`.
 """
 levelcode(x::Missing) = missing
 
-DataAPI.levels(x::CategoricalValue) = levels(pool(x))
-
 function cat_promote_type(::Type{S}, ::Type{T}) where {S, T}
-    U = promote_type(S, T)
+    U = promote_type(unwrap_catvaluetype(S), unwrap_catvaluetype(T))
     U <: Union{SupportedTypes, Missing} ?
         U : typeintersect(Union{SupportedTypes, Missing}, Union{S, T})
 end

--- a/test/01_value.jl
+++ b/test/01_value.jl
@@ -22,6 +22,8 @@ end
     for i in 1:3
         x = CategoricalValue(pool, i)
 
+        @test levels(x) == levels(pool)
+        @test levels(x) isa CategoricalVector{String, UInt32}
         @test leveltype(x) === String
         @test leveltype(typeof(x)) === String
         @test reftype(x) === DefaultRefType
@@ -48,6 +50,8 @@ end
     for i in 1:3
         x = CategoricalValue(pool, i)
 
+        @test levels(x) == levels(pool)
+        @test levels(x) isa CategoricalVector{String, UInt8}
         @test leveltype(x) === String
         @test leveltype(typeof(x)) === String
         @test reftype(x) === UInt8
@@ -68,7 +72,8 @@ end
     for x in (CategoricalValue(pool, 1), arr, view(arr, 2:3))
         for (i, v) in enumerate(levels(pool))
             @test CategoricalValue(v, x) ===
-                CategoricalValue(float(v), x) ===
+                CategoricalValue(unwrap(v), x) ===
+                CategoricalValue(float(unwrap(v)), x) ===
                 CategoricalValue(CategoricalValue(pool, i), x) ===
                 CategoricalValue(pool, i)
         end

--- a/test/11_array.jl
+++ b/test/11_array.jl
@@ -746,7 +746,7 @@ end
     @test y == unique(x)
 
     x = CategoricalArray(String[])
-    @test isa(levels(x), Vector{String}) && isempty(levels(x))
+    @test isa(levels(x), CategoricalVector{String, DefaultRefType}) && isempty(levels(x))
     @test isa(unique(x), typeof(x)) && isempty(unique(x))
     @test levels!(x, ["Young", "Middle", "Old"]) === x
     @test levels(x) == ["Young", "Middle", "Old"]

--- a/test/12_missingarray.jl
+++ b/test/12_missingarray.jl
@@ -1160,7 +1160,7 @@ end
     @test unique(x) ≅ ["Old", "Young", "Middle", missing]
 
     x = CategoricalArray((Union{String, Missing})[missing])
-    @test isa(levels(x), Vector{String}) && isempty(levels(x))
+    @test isa(levels(x), CategoricalVector{String, DefaultRefType}) && isempty(levels(x))
     @test unique(x) ≅ [missing]
     @test levels!(x, ["Young", "Middle", "Old"]) === x
     @test levels(x) == ["Young", "Middle", "Old"]

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -2326,18 +2326,18 @@ end
               view(categorical(Union{String, Missing}[missing, "b", "a"], levels=["b", "c", "a"]), 2:3))
         @test @inferred(levels(x)) == ["b", "c", "a"]
         @test levels(x, skipmissing=true) == ["b", "c", "a"]
-        @test levels(x, skipmissing=true) isa Vector{String}
+        @test levels(x, skipmissing=true) isa CategoricalVector{String}
         @test levels(x, skipmissing=false) == ["b", "c", "a"]
-        @test levels(x, skipmissing=false) isa Vector{Union{String, Missing}}
+        @test levels(x, skipmissing=false) isa CategoricalVector{Union{String, Missing}}
     end
 
     for x in (categorical(Union{String, Missing}["a", "b", missing], levels=["b", "c", "a"]),
               view(categorical(Union{String, Missing}["c", "b", missing], levels=["b", "c", "a"]), 2:3))
         @test @inferred(levels(x)) == ["b", "c", "a"]
         @test levels(x, skipmissing=true) == ["b", "c", "a"]
-        @test levels(x, skipmissing=true) isa Vector{String}
+        @test levels(x, skipmissing=true) isa CategoricalVector{String}
         @test levels(x, skipmissing=false) ≅ ["b", "c", "a", missing]
-        @test levels(x, skipmissing=false) isa Vector{Union{String, Missing}}
+        @test levels(x, skipmissing=false) isa CategoricalVector{Union{String, Missing}}
     end
 end
 

--- a/test/14_view.jl
+++ b/test/14_view.jl
@@ -11,7 +11,8 @@ const ≅ = isequal
 
     x = CategoricalArray{Union{T, eltype(a)}}(a, ordered=order)
     v = view(x, inds)
-    @test levels(v) === levels(x)
+    @test levels(x) isa CategoricalVector{nonmissingtype(eltype(a))}
+    @test levels(v) == levels(x)
     @test unique(v) == (ndims(v) > 0 ? unique(a[inds]) : [a[inds]])
     @test isordered(v) === isordered(x)
 end


### PR DESCRIPTION
Having `levels` preserve the eltype of the input is sometimes useful to write generic code. This is only slightly breaking as the result still compares equal to the previous behvior returning unwrapped values.

Fixes https://github.com/JuliaData/CategoricalArrays.jl/issues/390.